### PR TITLE
Fix(hhanclub): Update bonusPerHour selector

### DIFF
--- a/src/packages/site/definitions/hhanclub.ts
+++ b/src/packages/site/definitions/hhanclub.ts
@@ -238,6 +238,10 @@ export const siteMetadata: ISiteMetadata = {
           },
         ],
       },
+      bonusPerHour: {
+        selector: [".grid .row-span-4"],
+        filters: [{ name: "parseNumber" }],
+      },
     },
   },
 


### PR DESCRIPTION
The selector for bonusPerHour has been changed to `.grid .row-span-4` for the hhanclub site to correctly parse the bonus points information.