### PR TITLE
fix(u3d): #138 free tags

### DIFF
--- a/src/packages/site/schemas/Unit3D.ts
+++ b/src/packages/site/schemas/Unit3D.ts
@@ -134,7 +134,7 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
         {
           name: "75%",
           selector: "i[title*='75% Free'], span[title*='75% Free']",
-          color: "indigo"
+          color: "lime-darken-3"
         },
         {
           name: "50%",

--- a/src/packages/site/schemas/Unit3D.ts
+++ b/src/packages/site/schemas/Unit3D.ts
@@ -121,8 +121,31 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
         },
       },
       tags: [
-        { name: "Free", selector: "i.fa-star.text-gold, i.fa-globe.text-blue", color: "blue" },
-        { name: "2xUp", selector: "i.fa-gem.text-green", color: "lime" },
+        {
+          name: "Free",
+          selector: "i.fa-star.text-gold, i.fa-globe.text-blue, i[title*='100% Free'], i[title*='Featured'], span[title*='100% Free'], i[data-original-title*='Featured']",
+          color: "blue"
+        },
+        {
+          name: "2xUp",
+          selector: "i.fa-gem.text-green, i[title*='Double Upload'], i[title*='Featured'], i[data-original-title*='Featured']",
+          color: "lime"
+        },
+        {
+          name: "75%",
+          selector: "i[title*='75% Free'], span[title*='75% Free']",
+          color: "indigo"
+        },
+        {
+          name: "50%",
+          selector: "i[title*='50% Free'], span[title*='50% Free']",
+          color: "deep-orange-darken-1"
+        },
+        {
+          name: "25%",
+          selector: "i[title*='25% Free'], span[title*='25% Free']",
+          color: "blue"
+        }
       ],
     },
   },


### PR DESCRIPTION
- I updated the tags array in `src/packages/site/schemas/Unit3D.ts`.
- The new tags include 'Free', '2xUp', '75%', '50%', and '25%'.
- I updated the selectors according to your specifications.
- I referenced the colors from `NexusPHP.ts`, using defaults for any unmatched tags.