### PR TITLE
extract i18n fields from vue code

### DIFF
--- a/src/entries/options/views/Overview/DownloadHistory/Index.vue
+++ b/src/entries/options/views/Overview/DownloadHistory/Index.vue
@@ -29,12 +29,12 @@ const { tableFilterRef, tableWaitFilterRef, tableFilterFn } = tableCustomFilter;
 
 const tableHeader = [
   { title: "№", key: "id", align: "center", width: 50 },
-  { title: "站点", key: "siteId", align: "center", width: 90 },
-  { title: "种子", key: "title", align: "start", minWidth: 600, maxWidth: "32vw" },
-  { title: "下载服务器", key: "downloaderId", minWidth: 200, align: "start" },
-  { title: "下载时间", key: "downloadAt", align: "center" },
-  { title: "下载状态", key: "downloadStatus" },
-  { title: "操作", key: "action", align: "center", width: 90, minWidth: 90, sortable: false },
+  { title: t("DownloadHistory.table.site"), key: "siteId", align: "center", width: 90 },
+  { title: t("DownloadHistory.table.title"), key: "title", align: "start", minWidth: 600, maxWidth: "32vw" },
+  { title: t("DownloadHistory.table.downloader"), key: "downloaderId", minWidth: 200, align: "start" },
+  { title: t("DownloadHistory.table.downloadAt"), key: "downloadAt", align: "center" },
+  { title: t("DownloadHistory.table.status"), key: "downloadStatus" },
+  { title: t("common.action"), key: "action", align: "center", width: 90, minWidth: 90, sortable: false },
 ] as DataTableHeader[];
 const tableSelected = ref<TTorrentDownloadKey[]>([]);
 
@@ -81,7 +81,7 @@ onMounted(() => {
         <NavButton
           color="green"
           icon="mdi-cached"
-          text="刷新下载记录列表"
+          :text="t('DownloadHistory.refresh')"
           @click="() => throttleLoadDownloadHistory()"
         />
 
@@ -91,7 +91,7 @@ onMounted(() => {
           :disabled="tableSelected.length === 0"
           color="primary"
           icon="mdi-tray-arrow-down"
-          text="重新下载"
+          :text="t('DownloadHistory.reDownload')"
           @click="() => reDownloadTorrent(tableSelected)"
         />
 
@@ -112,7 +112,7 @@ onMounted(() => {
           clearable
           density="compact"
           hide-details
-          label="过滤下载记录"
+          :label="t('DownloadHistory.filterPlaceholder')"
           max-width="500"
           prepend-inner-icon="mdi-filter"
           single-line

--- a/src/entries/options/views/Overview/MediaServerEntity/Index.vue
+++ b/src/entries/options/views/Overview/MediaServerEntity/Index.vue
@@ -70,7 +70,7 @@ onMounted(async () => {
           density="compact"
           hide-details
           max-width="500"
-          placeholder="搜索词"
+          :placeholder="t('MediaServerEntity.searchPlaceholder')"
           @keyup.enter="() => doSearch({ searchKey: search })"
           @click:append="() => doSearch({ searchKey: search })"
         >
@@ -84,7 +84,7 @@ onMounted(async () => {
                   <v-checkbox
                     hide-details
                     indeterminate
-                    label="全选"
+                    :label="t('common.checkbox.all')"
                     @click.stop
                     @update:model-value="
                       (v: unknown) => {
@@ -182,7 +182,9 @@ onMounted(async () => {
                 <v-img v-bind="props" :src="item.poster" :title="item.name" />
               </template>
 
-              <v-btn append-icon="mdi-information-outline" block @click="() => showItemInformation(item)">详情</v-btn>
+              <v-btn append-icon="mdi-information-outline" block @click="() => showItemInformation(item)">
+                {{ t("MediaServerEntity.detail") }}
+              </v-btn>
               <v-btn
                 :href="item.url"
                 append-icon="mdi-arrow-top-right-bold-box-outline"
@@ -190,7 +192,7 @@ onMounted(async () => {
                 rel="noopener noreferrer nofollow"
                 target="_blank"
               >
-                访问
+                {{ t("common.visit") }}
               </v-btn>
             </v-menu>
           </div>

--- a/src/entries/options/views/Overview/MyData/Index.vue
+++ b/src/entries/options/views/Overview/MyData/Index.vue
@@ -203,20 +203,25 @@ function viewStatistic() {
           :disabled="tableSelected.length === 0"
           color="indigo"
           icon="mdi-open-in-new"
-          text="批量打开"
+          :text="t('MyData.index.multiOpen')"
           @click="multiOpen"
         />
 
         <v-divider class="mx-2" vertical />
 
-        <NavButton color="green" icon="mdi-chart-timeline-variant" text="时间轴" @click="viewTimeline" />
-        <NavButton color="green" icon="mdi-equalizer" text="数据图表" @click="viewStatistic" />
+        <NavButton
+          color="green"
+          icon="mdi-chart-timeline-variant"
+          :text="t('MyData.index.viewTimeline')"
+          @click="viewTimeline"
+        />
+        <NavButton color="green" icon="mdi-equalizer" :text="t('MyData.index.viewStatistic')" @click="viewStatistic" />
 
         <v-divider class="mx-2" vertical />
 
         <v-menu :close-on-content-clicks="false">
           <template v-slot:activator="{ props }">
-            <NavButton color="blue" icon="mdi-cog" text="设置" class="mr-1" v-bind="props" />
+            <NavButton color="blue" icon="mdi-cog" :text="t('MyData.index.setting')" class="mr-1" v-bind="props" />
           </template>
           <v-list>
             <!-- 表格字体大小控制 -->
@@ -335,10 +340,12 @@ function viewStatistic() {
                 <v-icon v-bind="props" icon="mdi-filter" variant="plain" />
               </template>
               <v-list class="pa-0">
-                <v-list-item-subtitle class="ma-2">站点状态</v-list-item-subtitle>
+                <v-list-item-subtitle class="ma-2">
+                  {{ t("MyData.index.siteStatus") }}
+                </v-list-item-subtitle>
 
                 <v-list-item
-                  title="今日未更新"
+                  :title="t('MyData.index.filter.todayNotUpdated')"
                   @click.stop="
                     () => {
                       advanceFilterDictRef.updateAt.value = ['', formatDate(new Date(), 'yyyyMMdd')];
@@ -348,7 +355,7 @@ function viewStatistic() {
                 />
 
                 <v-list-item
-                  title="最后更新状态异常"
+                  :title="t('MyData.index.filter.lastUpdateError')"
                   @click.stop="
                     () => {
                       advanceFilterDictRef.status.required = [
@@ -362,7 +369,7 @@ function viewStatistic() {
                 />
 
                 <v-list-item
-                  title="未读信息"
+                  :title="t('MyData.index.filter.unreadMessage')"
                   @click.stop="
                     () => {
                       advanceFilterDictRef.messageCount.value = [1, ' '];
@@ -371,7 +378,9 @@ function viewStatistic() {
                   "
                 />
 
-                <v-list-item-subtitle class="ma-2">站点分类</v-list-item-subtitle>
+                <v-list-item-subtitle class="ma-2">
+                  {{ t("MyData.index.siteCategory") }}
+                </v-list-item-subtitle>
 
                 <v-list-item
                   v-for="(item, index) in metadataStore.getSitesGroupData"

--- a/src/entries/options/views/Overview/SearchEntity/Index.vue
+++ b/src/entries/options/views/Overview/SearchEntity/Index.vue
@@ -33,17 +33,24 @@ const showSearchStatusDialog = ref<boolean>(false);
 const showSaveSnapshotDialog = ref<boolean>(false);
 
 const fullTableHeader = [
-  { title: "站点", key: "site", align: "center", width: 90, props: { disabled: true } },
-  { title: "标题", key: "title", align: "start", minWidth: 600, maxWidth: "32vw", props: { disabled: true } },
-  { title: "分类", key: "category", align: "center", width: 90 },
-  { title: "大小", key: "size", align: "end" },
-  { title: "上传", key: "seeders", align: "end", width: 90, minWidth: 90 },
-  { title: "下载", key: "leechers", align: "end", width: 90, minWidth: 90 },
-  { title: "完成", key: "completed", align: "end", width: 90, minWidth: 90 },
-  { title: "评论", key: "comments", align: "end", width: 90, minWidth: 90 },
-  { title: "发布于(≈)", key: "time", align: "center" },
+  { title: t("SearchEntity.index.table.site"), key: "site", align: "center", width: 90, props: { disabled: true } },
   {
-    title: "操作",
+    title: t("SearchEntity.index.table.title"),
+    key: "title",
+    align: "start",
+    minWidth: 600,
+    maxWidth: "32vw",
+    props: { disabled: true },
+  },
+  { title: t("SearchEntity.index.table.category"), key: "category", align: "center", width: 90 },
+  { title: t("SearchEntity.index.table.size"), key: "size", align: "end" },
+  { title: t("SearchEntity.index.table.seeders"), key: "seeders", align: "end", width: 90, minWidth: 90 },
+  { title: t("SearchEntity.index.table.leechers"), key: "leechers", align: "end", width: 90, minWidth: 90 },
+  { title: t("SearchEntity.index.table.completed"), key: "completed", align: "end", width: 90, minWidth: 90 },
+  { title: t("SearchEntity.index.table.comments"), key: "comments", align: "end", width: 90, minWidth: 90 },
+  { title: t("SearchEntity.index.table.time"), key: "time", align: "center" },
+  {
+    title: t("common.action"),
     key: "action",
     align: "center",
     width: 125,
@@ -116,22 +123,34 @@ function cancelSearchQueue() {
 <template>
   <v-alert type="info">
     <v-alert-title>
-      <template v-if="runtimeStore.search.startAt === 0">请输入搜索关键词开始搜索</template>
+      <template v-if="runtimeStore.search.startAt === 0">
+        {{ t("SearchEntity.index.alert.enterKeyword") }}
+      </template>
       <template v-else>
-        <v-btn class="mr-2" color="primary" size="small" @click="showSearchStatusDialog = true">搜索情况</v-btn>
+        <v-btn class="mr-2" color="primary" size="small" @click="showSearchStatusDialog = true">
+          {{ t("SearchEntity.index.alert.statusButton") }}
+        </v-btn>
         <template v-if="runtimeStore.search.isSearching">
-          <template v-if="isSearchingParsed">搜索暂停中...</template>
-          <template v-else>搜索中...</template>
+          <template v-if="isSearchingParsed">
+            {{ t("SearchEntity.index.alert.paused") }}
+          </template>
+          <template v-else>
+            {{ t("SearchEntity.index.alert.searching") }}
+          </template>
         </template>
         <template v-else>
           <template v-if="runtimeStore.search.snapshot">
-            搜索快照 [{{ metadataStore.snapshots[runtimeStore.search.snapshot].name }}] ，
+            {{ t("SearchEntity.index.alert.snapshot") }}
+            [{{ metadataStore.snapshots[runtimeStore.search.snapshot].name }}]，
           </template>
           <template v-else>
-            搜索方案 [{{ metadataStore.getSearchSolutionName(runtimeStore.search.searchPlanKey) }}] ，
+            {{ t("SearchEntity.index.alert.plan") }}
+            [{{ metadataStore.getSearchSolutionName(runtimeStore.search.searchPlanKey) }}]，
           </template>
-          关键词 [{{ runtimeStore.search.searchKey }}]， 共 {{ runtimeStore.search.searchResult.length }} 条结果，
-          耗时： {{ runtimeStore.searchCostTime / 1000 }} 秒。
+          {{ t("SearchEntity.index.alert.keyword") }}
+          [{{ runtimeStore.search.searchKey }}]，
+          {{ t("SearchEntity.index.alert.results", [runtimeStore.search.searchResult.length]) }}
+          {{ t("SearchEntity.index.alert.duration", [(runtimeStore.searchCostTime / 1000).toFixed(1)]) }}
         </template>
       </template>
     </v-alert-title>
@@ -144,14 +163,14 @@ function cancelSearchQueue() {
             v-show="isSearchingParsed"
             color="success"
             icon="mdi-play"
-            title="开始搜索队列"
+            :title="t('SearchEntity.index.action.start')"
             @click="() => startSearchQueue()"
           ></v-btn>
           <v-btn
             v-show="!isSearchingParsed"
             color="success"
             icon="mdi-pause"
-            title="暂停搜索队列"
+            :title="t('SearchEntity.index.action.pause')"
             @click="() => pauseSearchQueue()"
           ></v-btn>
 
@@ -159,7 +178,7 @@ function cancelSearchQueue() {
             v-show="runtimeStore.search.isSearching"
             color="red"
             icon="mdi-cancel"
-            title="取消当前等待的搜索"
+            :title="t('SearchEntity.index.action.cancel')"
             @click="cancelSearchQueue"
           ></v-btn>
           <v-btn
@@ -167,7 +186,7 @@ function cancelSearchQueue() {
             :disabled="isSearchingParsed"
             color="red"
             icon="mdi-cached"
-            title="重新搜索"
+            :title="t('SearchEntity.index.action.retry')"
             @click="() => doSearch(null as unknown as string, null as unknown as string, true)"
           ></v-btn>
 
@@ -243,7 +262,7 @@ function cancelSearchQueue() {
           clearable
           density="compact"
           hide-details
-          label="过滤搜索结果"
+          :label="t('SearchEntity.index.filterLabel')"
           max-width="500"
           prepend-inner-icon="mdi-filter"
           single-line

--- a/src/entries/options/views/Overview/SearchResultSnapshot/Index.vue
+++ b/src/entries/options/views/Overview/SearchResultSnapshot/Index.vue
@@ -23,10 +23,24 @@ const showEditNameDialog = ref<boolean>(false);
 const showDeleteDialog = ref<boolean>(false);
 
 const tableHeader = [
-  { title: "快照名称", key: "name", align: "start" },
-  { title: "种子数", key: "recordCount", align: "end", width: 100 },
-  { title: "创建时间", key: "createdAt", align: "center", width: 150, minWidth: 150 },
-  { title: "操作", key: "action", align: "center", width: 125, minWidth: 125, sortable: false, alwaysShow: true },
+  { title: t("SearchResultSnapshot.table.header.name"), key: "name", align: "start" },
+  { title: t("SearchResultSnapshot.table.header.recordCount"), key: "recordCount", align: "end", width: 100 },
+  {
+    title: t("SearchResultSnapshot.table.header.createdAt"),
+    key: "createdAt",
+    align: "center",
+    width: 150,
+    minWidth: 150,
+  },
+  {
+    title: t("common.action"),
+    key: "action",
+    align: "center",
+    width: 125,
+    minWidth: 125,
+    sortable: false,
+    alwaysShow: true,
+  },
 ] as DataTableHeader[];
 const tableSelected = ref<TSearchSnapshotKey[]>([]);
 const tableWaitFilter = ref("");
@@ -78,7 +92,7 @@ async function confirmDeleteSearchSnapshot(searchSnapshotId: TSearchSnapshotKey)
           clearable
           density="compact"
           hide-details
-          label="快照名称过滤"
+          :label="t('SearchResultSnapshot.table.filterLabel')"
           max-width="500"
           single-line
         />
@@ -109,14 +123,14 @@ async function confirmDeleteSearchSnapshot(searchSnapshotId: TSearchSnapshotKey)
             color="green"
             icon="mdi-archive-search"
             size="small"
-            title="查看"
+            :title="t('SearchResultSnapshot.table.action.view')"
             @click="() => viewSnapshot(item.id)"
           ></v-btn>
           <v-btn
             color="blue"
             icon="mdi-archive-edit"
             size="small"
-            title="编辑标题"
+            :title="t('SearchResultSnapshot.table.action.editTitle')"
             @click="() => editSnapshotName(item.id)"
           ></v-btn>
           <v-btn

--- a/src/entries/options/views/Settings/SetBackup/Index.vue
+++ b/src/entries/options/views/Settings/SetBackup/Index.vue
@@ -30,11 +30,11 @@ const showRestoreDialog = ref<boolean>(false);
 const showDeleteDialog = ref<boolean>(false);
 
 const fullTableHeader = [
-  { title: t("SetDownloader.common.type"), key: "type", align: "center" },
-  { title: t("SetDownloader.common.name"), key: "name", align: "start" },
-  { title: "备份内容", key: "backupFields", align: "start", sortable: false },
-  { title: "最近一次备份时间", key: "lastBackupAt", align: "end" },
-  { title: t("SetDownloader.index.table.enabled"), key: "enabled", align: "center" },
+  { title: t("SetBackup.table.type"), key: "type", align: "center" },
+  { title: t("SetBackup.table.name"), key: "name", align: "start" },
+  { title: t("SetBackup.table.backupFields"), key: "backupFields", align: "start", sortable: false },
+  { title: t("SetBackup.table.lastBackupAt"), key: "lastBackupAt", align: "end" },
+  { title: t("SetBackup.index.table.enabled"), key: "enabled", align: "center" },
   { title: t("common.action"), key: "action", sortable: false },
 ] as DataTableHeader[];
 const tableSelected = ref<TBackupServerKey[]>([]);
@@ -48,9 +48,9 @@ async function doBackup(backupServerId: TBackupServerKey | symbol) {
     const backupFields = metadataStore.backupServers[backupServerId].backupFields ?? [...BackupFields];
     const backupStatus = await sendMessage("exportBackupData", { backupFields, backupServerId });
     if (backupStatus) {
-      runtimeStore.showSnakebar("备份成功", { color: "success" });
+      runtimeStore.showSnakebar(t("SetBackup.snackbar.success"), { color: "success" });
     } else {
-      runtimeStore.showSnakebar("备份失败", { color: "error" });
+      runtimeStore.showSnakebar(t("SetBackup.snackbar.failure"), { color: "error" });
     }
   } else if (backupServerId == localBackup) {
     showLocalExportConfirmDialog.value = true;
@@ -104,10 +104,15 @@ async function confirmDeleteBackupServer(id: TBackupServerKey) {
           :loading="doBackupStatus[localBackup]"
           color="success"
           icon="mdi-database-export"
-          text="本地导出"
+          :text="t('SetBackup.localExport')"
           @click="doBackup(localBackup)"
         />
-        <NavButton text="本地导入" color="blue" icon="mdi-database-import" @click="() => (showRestoreDialog = true)" />
+        <NavButton
+          color="blue"
+          icon="mdi-database-import"
+          :text="t('SetBackup.localImport')"
+          @click="() => (showRestoreDialog = true)"
+        />
 
         <v-spacer />
 

--- a/src/entries/options/views/Settings/SetBase/BackupWindow.vue
+++ b/src/entries/options/views/Settings/SetBase/BackupWindow.vue
@@ -3,6 +3,7 @@ import JSZip from "jszip";
 import { nanoid } from "nanoid";
 import { ref, shallowRef, watch } from "vue";
 import { useThrottledRefHistory } from "@vueuse/core";
+import { useI18n } from "vue-i18n";
 
 import { useConfigStore } from "@/options/stores/config.ts";
 import type { IPtppDumpUserInfo } from "@/shared/types.ts";
@@ -11,6 +12,7 @@ import RestorePtppUserDataDialog from "./RestorePtppUserDataDialog.vue";
 
 import { REPO_NAME } from "~/helper.ts";
 
+const { t } = useI18n();
 const configStore = useConfigStore();
 
 const showEncryptionKey = ref<boolean>(false);
@@ -43,7 +45,7 @@ async function loadPTPPBackupFile() {
       console.log(parsedPtppUserData.value);
       showRestorePtppUserDataDialog.value = true;
     } catch (e) {
-      alert("文件格式错误，请检查是否按正确步骤（关闭备份加密功能）导出备份。");
+      alert(t("ptppSettings.invalidFileFormat"));
     } finally {
       ptppUserDataFile.value = undefined; // 清空 File
     }
@@ -58,14 +60,14 @@ function randomEncryptionKey() {
 <template>
   <v-row>
     <v-col md="6">
-      <v-label class="my-2">基本配置</v-label>
+      <v-label class="my-2">{{ t("ptppSettings.basicConfig") }}</v-label>
       <v-alert class="mb-2" type="info" variant="tonal">
-        注意：密钥仅保存在当前浏览器，不会备份，请妥善保存；加密后如密钥丢失将无法恢复数据。留空表示不做加密。
+        {{ t("ptppSettings.saveKeyNotice") }}
       </v-alert>
       <v-text-field
         v-model="encryptionKey"
         :append-inner-icon="showEncryptionKey ? 'mdi-eye' : 'mdi-eye-off'"
-        :label="`备份文件加密、解密密钥`"
+        :label="t('ptppSettings.encryptionKeyLabel')"
         :type="showEncryptionKey ? 'text' : 'password'"
         hide-details
         @click:append-inner="showEncryptionKey = !showEncryptionKey"
@@ -76,7 +78,7 @@ function randomEncryptionKey() {
             color="green"
             variant="text"
             icon
-            title="恢复上一个密钥"
+            :title="t('ptppSettings.undoKeyTitle')"
             @click="undoEncryptionKey"
           >
             <v-badge v-if="history.length > 1" :content="history.length - 1" :max="9" floating>
@@ -84,7 +86,13 @@ function randomEncryptionKey() {
             </v-badge>
             <v-icon v-else icon="mdi-arrow-left" />
           </v-btn>
-          <v-btn color="warning" icon="mdi-key" variant="text" title="随机生成" @click="randomEncryptionKey" />
+          <v-btn
+            color="warning"
+            icon="mdi-key"
+            variant="text"
+            :title="t('ptppSettings.randomGenTitle')"
+            @click="randomEncryptionKey"
+          />
         </template>
       </v-text-field>
     </v-col>
@@ -92,23 +100,22 @@ function randomEncryptionKey() {
 
   <v-row>
     <v-col md="6">
-      <v-label class="my-2">PT-Plugin-Plus 配置导入</v-label>
+      <v-label class="my-2">{{ t("ptppSettings.importConfigTitle") }}</v-label>
       <v-alert class="mb-2" type="warning" variant="tonal">
         <span class="font-weight-bold">
-          {{ REPO_NAME }} 只能导入原 PT-Plugin-Plus 的用户历史数据信息，其他配置文件不支持导入。<br />
-          在导入之前，请做好以下准备：<br />
+          {{ t("ptppSettings.importConfigInfoLine1", { repoName: REPO_NAME }) }}<br />
+          {{ t("ptppSettings.importConfigInfoPrep") }}<br />
         </span>
-        1. 请先备份好当前 {{ REPO_NAME }} 的配置文件。 <br />
-        2. 在 {{ REPO_NAME }} 的站点设置中添加需要恢复的站点。（如果没有添加站点，对应的用户历史数据会被忽略）<br />
-        3. 在 PT-Plugin-Plus 中，<span class="font-weight-bold">关闭备份加密功能</span>，并导出本地备份文件。
-        其应该是一个名为 <code>PT-Plugin-Plus-Backup-yyyy-MM-DD_hh-mm-ss.zip</code> 的 zip 压缩文件。 <br />
-        4. 将压缩包 或者 从压缩包中解压出的 <code>userdatas.json</code> 文件，上传到下面的输入框中。 <br />
+        1. {{ t("ptppSettings.importStep1", { repoName: REPO_NAME }) }}<br />
+        2. {{ t("ptppSettings.importStep2", { repoName: REPO_NAME }) }}<br />
+        3. <span class="font-weight-bold" v-html="t('ptppSettings.importStep3')"></span><br />
+        4. {{ t("ptppSettings.importStep4") }}<br />
       </v-alert>
       <v-file-input
         v-model="ptppUserDataFile"
         accept="application/zip, application/json"
         show-size
-        label="选择 PTPP 备份文件"
+        :label="t('ptppSettings.selectBackupFile')"
         @update:model-value="loadPTPPBackupFile"
       />
     </v-col>

--- a/src/entries/options/views/Settings/SetBase/DownloadWindow.vue
+++ b/src/entries/options/views/Settings/SetBase/DownloadWindow.vue
@@ -24,17 +24,17 @@ async function clearLastDownloader(v: boolean) {
         color="success"
         false-icon="mdi-alert-octagon"
         hide-details
-        label="是否保存下载历史（如非必要请勿关闭此功能）"
+        :label="t('SetBase.download.saveDownloadHistory')"
       />
     </v-col>
   </v-row>
 
   <v-row>
     <v-col md="6">
-      <v-label>本地下载</v-label>
+      <v-label>{{ t("SetBase.download.localDownloadTitle") }}</v-label>
       <v-select
         v-model="configStore.download.localDownloadMethod"
-        label="本地下载方式"
+        :label="t('SetBase.download.localDownloadMethod')"
         :items="
           LocalDownloadMethod.map((item) => ({
             title: t(`SetBase.download.localDownloadMethod.${item}`),
@@ -48,26 +48,26 @@ async function clearLastDownloader(v: boolean) {
         v-model="configStore.download.ignoreSiteDownloadIntervalWhenLocalDownload"
         color="success"
         hide-details
-        label="本地下载时忽略站点下载间隔限制"
+        :label="t('SetBase.download.localDownloadIgnoreInterval')"
       />
     </v-col>
   </v-row>
 
   <v-row>
     <v-col md="6">
-      <v-label>下载服务器推送</v-label>
+      <v-label>{{ t("SetBase.download.pushDownloadServerTitle") }}</v-label>
       <v-switch
         v-model="configStore.download.saveLastDownloader"
         color="success"
         hide-details
-        label="保存上一次使用的下载服务器设置"
+        :label="t('SetBase.download.saveLastDownloader')"
         @update:model-value="(v) => clearLastDownloader(v as unknown as boolean)"
       />
       <v-switch
         v-model="configStore.download.allowDirectSendToClient"
         color="warning"
         hide-details
-        label="是否允许直接将链接（而不是种子文件）发送到下载服务器（如非必要请勿启用）"
+        :label="t('SetBase.download.allowDirectSendToClient')"
       />
     </v-col>
   </v-row>

--- a/src/entries/options/views/Settings/SetBase/SearchEntityWindow.vue
+++ b/src/entries/options/views/Settings/SetBase/SearchEntityWindow.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { useConfigStore } from "@/options/stores/config.ts";
 import { useMetadataStore } from "@/options/stores/metadata.ts";
+import { useI18n } from "vue-i18n";
 
+const { t } = useI18n();
 const configStore = useConfigStore();
 const metadataStore = useMetadataStore();
 
@@ -15,20 +17,20 @@ async function clearLastFilter(v: boolean) {
 <template>
   <v-row>
     <v-col md="6">
-      <v-label>站点搜索配置</v-label>
+      <v-label>{{ t("route.Settings.SearchConfig.siteSearchConfig") }}</v-label>
       <v-number-input
         v-model="configStore.searchEntity.queueConcurrency"
         :max="100"
         :min="1"
         controlVariant="default"
         hide-details
-        label="请求队列长度"
+        :label="t('route.Settings.SearchConfig.siteQueueConcurrency')"
       />
       <v-switch
         v-model="configStore.searchEntity.saveLastFilter"
         color="success"
         hide-details
-        label="保存上一次使用的搜索筛选词"
+        :label="t('route.Settings.SearchConfig.saveLastSearchFilter')"
         @update:model-value="(v) => clearLastFilter(v as boolean)"
       />
     </v-col>
@@ -36,13 +38,13 @@ async function clearLastFilter(v: boolean) {
 
   <v-row>
     <v-col md="6">
-      <v-label>媒体服务器搜索配置</v-label>
+      <v-label>{{ t("route.Settings.SearchConfig.mediaServerSearchConfig") }}</v-label>
       <v-number-input
         v-model="configStore.mediaServerEntity.queueConcurrency"
         :max="100"
         :min="1"
         controlVariant="default"
-        label="请求队列长度"
+        :label="t('route.Settings.SearchConfig.mediaQueueConcurrency')"
       />
       <v-number-input
         v-model="configStore.mediaServerEntity.searchLimit"
@@ -50,20 +52,20 @@ async function clearLastFilter(v: boolean) {
         :min="1"
         :step="configStore.mediaServerEntity.searchLimit >= 100 ? 10 : 1"
         controlVariant="default"
-        label="单次搜索结果数量"
-        messages="请不要一次性加载过多的搜索结果，未作 virtual-scroll 优化，可能会导致浏览器卡死，同时也会影响媒体服务器的性能"
+        :label="t('route.Settings.SearchConfig.mediaSearchLimit')"
+        :messages="t('route.Settings.SearchConfig.mediaSearchLimitMessage')"
       />
       <v-switch
         v-model="configStore.mediaServerEntity.autoSearchWhenMount"
         color="success"
         hide-details
-        label="自动加载首屏媒体墙"
+        :label="t('route.Settings.SearchConfig.autoLoadInitialMediaWall')"
       />
       <v-switch
         v-model="configStore.mediaServerEntity.autoSearchMoreWhenScroll"
         color="success"
         hide-details
-        label="当滚动到页面底部时，自动加载新的媒体墙"
+        :label="t('route.Settings.SearchConfig.autoLoadMoreMediaOnScroll')"
       />
     </v-col>
   </v-row>

--- a/src/entries/options/views/Settings/SetBase/SocialInformationWindow.vue
+++ b/src/entries/options/views/Settings/SetBase/SocialInformationWindow.vue
@@ -3,29 +3,36 @@ import { buildInPtGenApi } from "@ptd/social";
 
 import { useConfigStore } from "@/options/stores/config.ts";
 
+import { useI18n } from "vue-i18n";
+
+const { t } = useI18n();
 const configStore = useConfigStore();
 </script>
 
 <template>
   <v-row>
     <v-col md="6">
-      <v-label>基本配置</v-label>
+      <v-label>{{ t("socialConfig.basicConfig") }}</v-label>
       <v-number-input
         v-model="configStore.socialSiteInformation.cacheDay"
-        :label="`缓存有效期（天）`"
+        :label="t('socialConfig.cacheValidityDays')"
         :min="3"
-        messages="缓存时间过短会导致频繁请求，过长会导致数据不及时"
+        :messages="t('socialConfig.cacheShortWarning')"
       />
-      <v-number-input v-model="configStore.socialSiteInformation.timeout" :label="`请求超时时间 (毫秒)`" hide-details />
+      <v-number-input
+        v-model="configStore.socialSiteInformation.timeout"
+        :label="t('socialConfig.requestTimeoutMs')"
+        hide-details
+      />
     </v-col>
   </v-row>
 
   <v-row>
     <v-col md="6">
-      <v-label>PtGen 配置</v-label>
+      <v-label>{{ t("socialConfig.ptgenConfig") }}</v-label>
       <v-switch
         v-model="configStore.socialSiteInformation.preferPtGen"
-        :label="`优先使用 PtGen 提供的数据`"
+        :label="t('socialConfig.preferPtgenLabel')"
         color="success"
         hide-details
       />
@@ -36,20 +43,20 @@ const configStore = useConfigStore();
         :return-object="false"
         item-title="provider"
         item-value="url"
-        label="PtGen API 地址"
-        messages="选择内置地址或输入类似 https://example.com/ptgen?site=<site>&sid=<sid> 的地址"
+        :label="t('socialConfig.ptgenApiAddress')"
+        :messages="t('socialConfig.ptgenApiMessages')"
       />
     </v-col>
   </v-row>
 
   <v-row>
     <v-col md="6">
-      <v-label>各媒体评分站点配置</v-label>
+      <v-label>{{ t("socialConfig.mediaRatingConfig") }}</v-label>
       <v-text-field
         v-model="configStore.socialSiteInformation.socialSite!.anidb.client"
-        :label="`AniDB Client ID`"
+        :label="t('socialConfig.anidbClientId')"
         clearable
-        messages="请在 https://anidb.net/perl-bin/animedb.pl?show=client 中申请 Client ID， 并按照 `Name/Version` 的格式填写"
+        :messages="t('socialConfig.anidbClientMessages')"
       >
         <template #prepend>
           <v-avatar image="/icons/social/anidb.png" />
@@ -58,9 +65,9 @@ const configStore = useConfigStore();
 
       <v-text-field
         v-model="configStore.socialSiteInformation.socialSite!.bangumi.apikey"
-        :label="`Bangumi API Key`"
+        :label="t('socialConfig.bangumiApiKey')"
         clearable
-        messages="你可以在 https://next.bgm.tv/demo/access-token 生成一个 Access Token"
+        :messages="t('socialConfig.bangumiApiMessages')"
       >
         <template #prepend>
           <v-avatar image="/icons/social/bangumi.png" />

--- a/src/entries/options/views/Settings/SetBase/UserInfoWindow.vue
+++ b/src/entries/options/views/Settings/SetBase/UserInfoWindow.vue
@@ -6,7 +6,9 @@ import { EJobType } from "@/background/utils/alarms.ts";
 import { useConfigStore } from "@/options/stores/config.ts";
 import { useMetadataStore } from "@/options/stores/metadata.ts";
 import { formatDate } from "@/options/utils.ts";
+import { useI18n } from "vue-i18n";
 
+const { t } = useI18n();
 const configStore = useConfigStore();
 const metadataStore = useMetadataStore();
 
@@ -45,20 +47,20 @@ onMounted(async () => {
         v-model="configStore.userInfo.queueConcurrency"
         :max="100"
         :min="1"
-        label="请求队列长度"
+        :label="t('userInfo.queueConcurrency')"
       ></v-number-input>
 
       <!-- 自动刷新 -->
       <v-switch
         v-model="configStore.userInfo.autoReflush.enabled"
-        :label="`是否启用后台定时刷新？`"
+        :label="t('userInfo.enableAutoRefresh')"
         color="success"
         hide-details
       />
       <v-row v-if="configStore.userInfo.autoReflush.enabled" class="mt-1 ml-2 mb-2">
         <v-alert type="info" variant="outlined">
           <div class="d-inline-flex align-center text-no-wrap">
-            每隔
+            {{ t("userInfo.autoRefresh.every") }}
             <v-select
               v-model="configStore.userInfo.autoReflush.interval"
               :items="range(1, 24)"
@@ -68,12 +70,12 @@ onMounted(async () => {
               density="compact"
               hide-details
             />
-            小时，自动刷新一次当天
-            <p class="font-weight-bold">未刷新过</p>
-            的站点
+            {{ t("userInfo.autoRefresh.hoursLabel") }}
+            <p class="font-weight-bold">{{ $t("userInfo.autoRefresh.unrefreshedSite") }}</p>
+            {{ t("userInfo.autoRefresh.ofSites") }}
           </div>
           <div class="d-inline-flex align-center text-no-wrap">
-            如果刷新失败，则重试
+            {{ t("userInfo.autoRefresh.retryOnFail") }}
             <v-select
               v-model="configStore.userInfo.autoReflush.retry.max"
               :items="range(0, 6)"
@@ -81,7 +83,7 @@ onMounted(async () => {
               density="compact"
               hide-details
             />
-            次，每次间隔
+            {{ t("userInfo.autoRefresh.times") }}
             <v-select
               v-model="configStore.userInfo.autoReflush.retry.interval"
               :items="range(1, 11)"
@@ -89,10 +91,11 @@ onMounted(async () => {
               density="compact"
               hide-details
             />
-            分钟。
+            {{ t("userInfo.autoRefresh.minutes") }}
           </div>
           <div class="d-flex align-center justify-end mt-1">
-            最近一次刷新时间: {{ formatDate(metadataStore.lastUserInfoAutoFlushAt) }} &nbsp; 下一次刷新时间:
+            {{ t("userInfo.autoRefresh.lastFlushTime") }} {{ formatDate(metadataStore.lastUserInfoAutoFlushAt) }} &nbsp;
+            {{ t("userInfo.autoRefresh.nextFlushTime") }}
             {{ nextFlushUserInfoAt != 0 ? formatDate(nextFlushUserInfoAt) : "-" }}
             <v-btn
               class="ml-1"
@@ -108,13 +111,13 @@ onMounted(async () => {
 
       <v-switch
         v-model="configStore.userInfo.showDeadSiteInOverview"
-        :label="`在概览中展示已被标记为死亡 （isDead） 的站点`"
+        :label="t('userInfo.showDeadSite')"
         color="success"
         hide-details
       />
       <v-switch
         v-model="configStore.userInfo.showPassedSiteInOverview"
-        :label="`在概览中展示已被标记为离线 （isOffline） 或不允许查询用户信息的站点`"
+        :label="t('userInfo.showPassedSite')"
         color="success"
         hide-details
       />

--- a/src/entries/options/views/Settings/SetSearchSolution/Index.vue
+++ b/src/entries/options/views/Settings/SetSearchSolution/Index.vue
@@ -157,12 +157,17 @@ function setDefaultSearchSolution(toDefault: boolean, solutionId: TSolutionKey) 
           @change="importSearchSolution"
         />
 
-        <NavButton color="info" icon="mdi-import" text="导入" @click="() => importFileInputRef?.click()" />
+        <NavButton
+          color="info"
+          icon="mdi-import"
+          :text="t('SetSearchSolution.import')"
+          @click="() => importFileInputRef?.click()"
+        />
         <NavButton
           :disabled="tableSelected.length === 0"
           color="info"
           icon="mdi-export"
-          text="导出"
+          :text="t('SetSearchSolution.export')"
           @click="() => exportSearchSolutions(tableSelected)"
         />
 

--- a/src/entries/options/views/Settings/SetSite/Index.vue
+++ b/src/entries/options/views/Settings/SetSite/Index.vue
@@ -35,7 +35,7 @@ const tableHeader = [
   // site favicon
   { title: "", key: "userConfig.sortIndex", align: "center", width: 48 },
   { title: t("SetSite.common.name"), key: "name", align: "left", width: 120, sortable: false },
-  { title: "站点分类", key: "groups", align: "left", minWidth: 120, sortable: false },
+  { title: t("SetSite.common.groups"), key: "groups", align: "left", minWidth: 120, sortable: false },
   { title: t("SetSite.common.url"), key: "url", align: "start", sortable: false },
   { title: t("SetSite.common.isOffline"), key: "userConfig.isOffline", align: "center", width: 180 },
   { title: t("SetSite.common.allowSearch"), key: "userConfig.allowSearch", align: "center", width: 180 },
@@ -111,7 +111,7 @@ async function flushSiteFavicon(siteId: TSiteID | TSiteID[]) {
         <NavButton
           color="info"
           icon="mdi-crosshairs-gps"
-          text="一键导入站点"
+          :text="t('SetSite.index.oneClickImport')"
           @click="() => (showOneClickImportDialog = true)"
         />
 
@@ -159,7 +159,7 @@ async function flushSiteFavicon(siteId: TSiteID | TSiteID[]) {
 
                 <v-divider />
 
-                <v-list-item-subtitle class="ma-2">站点分类</v-list-item-subtitle>
+                <v-list-item-subtitle class="ma-2">{{ t("SetSite.common.groups") }}</v-list-item-subtitle>
                 <v-list-item
                   v-for="(item, index) in metadataStore.getSitesGroupData"
                   :key="index"

--- a/src/entries/options/views/Settings/SetSite/OneClickImportDialog.vue
+++ b/src/entries/options/views/Settings/SetSite/OneClickImportDialog.vue
@@ -54,23 +54,23 @@ const statusIconPropComputed = (site: TSiteID) =>
     if (canAddSites.value[site].userInputSettingMeta) {
       progressIcon = "progress-close"; // 需要手动添加
       progressColor = "purple";
-      progressTitle = "该站点需要手动添加";
+      progressTitle = t("SetSite.oneClickImportDialog.status.manual");
     } else if (importStatus.value.working === site) {
       progressIcon = "progress-wrench"; // 正在尝试中
       progressColor = "blue";
-      progressTitle = "正在尝试中";
+      progressTitle = t("SetSite.oneClickImportDialog.status.trying");
     } else if (importStatus.value.success.includes(site)) {
       progressIcon = "progress-check"; // 已添加成功
       progressColor = "green";
-      progressTitle = "已添加成功";
+      progressTitle = t("SetSite.oneClickImportDialog.status.success");
     } else if (importStatus.value.failed.includes(site)) {
       progressIcon = "progress-alert"; // 添加失败
       progressColor = "red";
-      progressTitle = "添加失败";
+      progressTitle = t("SetSite.oneClickImportDialog.status.failed");
     } else if (importStatus.value.toWork.includes(site)) {
       progressIcon = "progress-pencil"; // 已选择
       progressColor = "";
-      progressTitle = "已选择";
+      progressTitle = t("SetSite.oneClickImportDialog.status.selected");
     }
 
     return {
@@ -142,7 +142,7 @@ async function dialogEnter() {
     <v-card>
       <v-card-title class="pa-0">
         <v-toolbar color="blue-grey-darken-2">
-          <v-toolbar-title>一键导入站点</v-toolbar-title>
+          <v-toolbar-title>{{ t("SetSite.oneClickImportDialog.title") }}</v-toolbar-title>
           <template #append>
             <v-btn icon="mdi-close" @click="showDialog = false" :disabled="importStatus.isWorking" />
           </template>
@@ -150,21 +150,20 @@ async function dialogEnter() {
       </v-card-title>
       <v-divider />
       <v-card-text>
-        <v-alert
-          class="mb-2"
-          title="此操作会尝试以默认配置导入你选择的站点，请确保该站点已在浏览器上登录过。导入过程不能中断，请耐心等待。"
-          type="warning"
-          variant="tonal"
-        >
+        <v-alert class="mb-2" :title="t('SetSite.oneClickImportDialog.alert1')" type="warning" variant="tonal">
         </v-alert>
 
-        <v-alert class="mb-1 py-2" title="未添加的站点列表">
+        <v-alert class="mb-1 py-2" :title="t('SetSite.oneClickImportDialog.alert2')">
           <template #text>
-            <span>已选择 {{ importStatus.toWork.length }} 个站点，</span>
-            <span class="text-green">已添加 {{ importStatus.success.length }} 个站点，</span>
-            <span class="text-red">添加失败 {{ importStatus.failed.length }} 个站点。</span>
+            {{
+              t("SetSite.oneClickImportDialog.stats", {
+                count: importStatus.toWork.length,
+                success: importStatus.success.length,
+                failed: importStatus.failed.length,
+              })
+            }}
             <span v-if="importStatus.isWorking">
-              正在尝试导入站点 [{{ canAddSites[importStatus.working].name }}] ...
+              {{ t("SetSite.oneClickImportDialog.trying", { name: canAddSites[importStatus.working].name }) }}
             </span>
           </template>
           <template #append>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -57,7 +57,8 @@
       "searchTip": "Input keyword, IMDb numbers to search",
       "wiki": "Wiki",
       "wrongPixelRatioNotice": "Your page display may be affected by zooming. It is recommended to zoom at 100% to ensure your browsing experience~"
-    }
+    },
+    "init": "Please wait patiently for the page to load....."
   },
   "manifest": {
     "extDesc": "PT Depiler",
@@ -96,7 +97,18 @@
       "SetDownloader": "Download Server",
       "SetMediaServer": "Media Server",
       "SetSearchSolution": "Search Solution",
-      "SetSite": "Sites"
+      "SetSite": "Sites",
+      "SearchConfig": {
+        "siteSearchConfig": "Site Search Configuration",
+        "siteQueueConcurrency": "Request Queue Concurrency",
+        "saveLastSearchFilter": "Save last used search filter",
+        "mediaServerSearchConfig": "Media Server Search Configuration",
+        "mediaQueueConcurrency": "Request Queue Concurrency",
+        "mediaSearchLimit": "Number of search results per request",
+        "mediaSearchLimitMessage": "Please do not load too many search results at once. It's not optimized with virtual-scroll, which may cause the browser to freeze and affect the performance of the media server.",
+        "autoLoadInitialMediaWall": "Automatically load the initial media wall",
+        "autoLoadMoreMediaOnScroll": "Automatically load more media when scrolling to the bottom of the page"
+      }
     }
   },
   "checkSwitch": {
@@ -165,6 +177,22 @@
     },
     "thankNote": "The birth of 'PT Plugin Plus' is established on the base of these projects. Thanks all the participants of the project, thanks for your contribution!"
   },
+  "DownloadHistory": {
+    "refresh": "Refresh download history list",
+    "reDownload": "Re-download",
+    "filterPlaceholder": "Filter download history",
+    "table": {
+      "site": "Site",
+      "title": "Torrent",
+      "downloader": "Downloader",
+      "downloadAt": "Download Time",
+      "status": "Download Status"
+    }
+  },
+  "MediaServerEntity": {
+    "searchPlaceholder": "Search term",
+    "detail": "Details"
+  },
   "MyData": {
     "index": {
       "flushSelectSite": "Flush selected",
@@ -186,7 +214,18 @@
       "showNextLevelInDialog": "Show next level requirements in Level Requirement Dialog",
       "showHnR": "Show H&R",
       "showSeedingBonus": "Show Seeding Bonus",
-      "updateAtFormatAsAlive": "Display update At as Relative Time"
+      "updateAtFormatAsAlive": "Display update At as Relative Time",
+      "multiOpen": "Open in batch",
+      "viewTimeline": "Timeline",
+      "viewStatistic": "Data Chart",
+      "setting": "Settings",
+      "siteStatus": "Site Status",
+      "siteCategory": "Site Category",
+      "filter": {
+        "todayNotUpdated": "Not updated today",
+        "lastUpdateError": "Last update error",
+        "unreadMessage": "Unread messages"
+      }
     },
     "table": {
       "site": "Site",
@@ -226,7 +265,8 @@
     },
     "dateRange": {
       "custom": "Custom",
-      "all": "All"
+      "all": "All",
+      "day": "Last {0} days"
     }
   },
   "UserDataTimeline": {
@@ -248,6 +288,35 @@
   },
   "SearchEntity": {
     "index": {
+      "table": {
+        "site": "Site",
+        "title": "Title",
+        "category": "Category",
+        "size": "Size",
+        "seeders": "Seeders",
+        "leechers": "Leechers",
+        "completed": "Completed",
+        "comments": "Comments",
+        "time": "Published(≈)"
+      },
+      "alert": {
+        "enterKeyword": "Please enter keywords to start searching",
+        "statusButton": "Search Status",
+        "paused": "Search paused...",
+        "searching": "Searching...",
+        "snapshot": "Search Snapshot",
+        "plan": "Search Plan",
+        "keyword": "Keyword",
+        "results": "Total {0} results, ",
+        "duration": "Duration: {0} seconds."
+      },
+      "action": {
+        "start": "Start search queue",
+        "pause": "Pause search queue",
+        "cancel": "Cancel current waiting search",
+        "retry": "Retry Search"
+      },
+      "filterLabel": "Filter search results",
       "showSiteName": "Show Site Name",
       "showTorrentTag": "Show Torrent Tags",
       "showTorrentSubtitle": "Show Torrent Subtitle",
@@ -263,6 +332,20 @@
         "quarter": "Quarter",
         "year": "Year",
         "custom": "Custom"
+      }
+    }
+  },
+  "SearchResultSnapshot": {
+    "table": {
+      "header": {
+        "name": "Snapshot Name",
+        "recordCount": "Torrent Count",
+        "createdAt": "Created At"
+      },
+      "filterLabel": "Filter by snapshot name",
+      "action": {
+        "view": "View",
+        "editTitle": "Edit Title"
       }
     }
   },
@@ -292,7 +375,13 @@
         "browserTip": "(RECOMMEND) Use the browser's download method provided by the extension to download directly",
         "extension": "Extension Proxy",
         "extensionTip": "The extension downloads the torrent in the background and proxies it to @:SetBase.download.localDownloadMethod.browser for downloading"
-      }
+      },
+      "saveDownloadHistory": "Save download history (Please do not disable this function unless necessary)",
+      "localDownloadTitle": "Local Download",
+      "localDownloadIgnoreInterval": "Ignore site download interval limit for local downloads",
+      "pushDownloadServerTitle": "Push to Download Server",
+      "saveLastDownloader": "Save the last used download server settings",
+      "allowDirectSendToClient": "Allow sending links directly (instead of torrent files) to the download server (Do not enable unless necessary)"
     }
   },
   "SetDownloader": {
@@ -383,6 +472,8 @@
   },
   "SetSearchSolution": {
     "solution": "Search Solution",
+    "import": "Import",
+    "export": "Export",
     "table": {
       "enable": "Enabled ?",
       "default": "Default ?"
@@ -411,7 +502,8 @@
       "showMessageCount": "Show Notice",
       "tags": "Tags",
       "type": "Type",
-      "url": "URL"
+      "url": "URL",
+      "groups": "Site Groups"
     },
     "delete": {
       "text": "Are you sure to delete these {0} Site?"
@@ -424,6 +516,7 @@
       "customUrlPlaceholder": "Custom site url",
       "description": "Site description",
       "sortIndexTip": "Can be used for search sorting",
+      "tagTip": "Press Enter to add a tag after typing. (Only the first 4 will be displayed on the list page)",
       "timezone": "Timezone",
       "uploadSpeedLimit": "Upload Speed",
       "uploadSpeedLimitHint": "Set upload speed limit (MB/s) when pushing torrents to downloader, 0 or empty means unlimited"
@@ -436,13 +529,91 @@
       "settingNote": [
         "Only the configured site will display the plugin icon and the corresponding function;",
         "the offline site will no longer participate in the search and information acquisition;"
-      ]
+      ],
+      "oneClickImport": "One-Click Import Sites"
     },
     "spDialog": {
       "noDefNotice": "This site does not define any search categories, please go to help!",
       "notice": "It is not recommended to set it here, and it is recommended to configure your user CP in site or use search solution",
       "selectAllNotice": "(Notice: In most cases, you don't need to select all search terms! )",
       "title": "Set default search params for Site {name}"
+    },
+    "oneClickImportDialog": {
+      "title": "One-Click Import Sites",
+      "alert1": "This operation will attempt to import the sites you select with default configurations. Please ensure you have logged into these sites in your browser. The import process cannot be interrupted, please wait patiently.",
+      "alert2": "List of unadded sites",
+      "stats": "Selected {count} sites, added {success} sites, failed to add {failed} sites.",
+      "trying": "Trying to import site [{name}] ...",
+      "status": {
+        "manual": "This site needs to be added manually",
+        "trying": "Trying",
+        "success": "Added successfully",
+        "failed": "Failed to add",
+        "selected": "Selected"
+      }
     }
+  },
+  "SetBackup": {
+    "table": {
+      "type": "Type",
+      "name": "Name",
+      "backupFields": "Backup Content",
+      "lastBackupAt": "Last Backup Time",
+      "notBackup": "Not Backed Up"
+    },
+    "localExport": "Local Export",
+    "localImport": "Local Import",
+    "snackbar": {
+      "success": "Backup successful",
+      "failure": "Backup failed"
+    }
+  },
+  "userInfo": {
+    "queueConcurrency": "Request Queue Concurrency",
+    "enableAutoRefresh": "Enable background auto-refresh?",
+    "autoRefresh": {
+      "every": "Every",
+      "hoursLabel": "hours, auto-refresh today's",
+      "unrefreshedSite": "unrefreshed",
+      "ofSites": "sites",
+      "retryOnFail": "If refresh fails, retry",
+      "times": "times, with an interval of",
+      "minutes": "minutes.",
+      "lastFlushTime": "Last refresh time:",
+      "nextFlushTime": "Next refresh time:"
+    },
+    "showDeadSite": "Show sites marked as dead (isDead) in the overview",
+    "showPassedSite": "Show sites marked as offline (isOffline) or not allowing user info query in the overview"
+  },
+  "ptppSettings": {
+    "basicConfig": "Basic Configuration",
+    "saveKeyNotice": "Note: The key is only saved in the current browser and will not be backed up, please keep it safe; data cannot be recovered if the key is lost after encryption. Leave blank for no encryption.",
+    "encryptionKeyLabel": "Backup file encryption/decryption key",
+    "undoKeyTitle": "Restore previous key",
+    "randomGenTitle": "Generate Randomly",
+    "invalidFileFormat": "Invalid file format, please check if the backup was exported correctly (with the backup encryption feature turned off).",
+    "importConfigTitle": "PT-Plugin-Plus Configuration Import",
+    "importConfigInfoLine1": "{repoName} can only import user history data from the original PT-Plugin-Plus. Other configuration files are not supported.",
+    "importConfigInfoPrep": "Before importing, please make the following preparations:",
+    "importStep1": "First, please back up the current configuration file of {repoName}.",
+    "importStep2": "In the site settings of {repoName}, add the sites that need to be restored. (If a site is not added, its corresponding user history data will be ignored).",
+    "importStep3": "In PT-Plugin-Plus, disable the backup encryption feature and export the local backup file. It should be a zip file named <code>PT-Plugin-Plus-Backup-yyyy-MM-DD_hh-mm-ss.zip</code>.",
+    "importStep4": "Upload the zip package or the extracted <code>userdatas.json</code> file to the input box below.",
+    "selectBackupFile": "Select PTPP Backup File"
+  },
+  "socialConfig": {
+    "basicConfig": "Basic Configuration",
+    "cacheValidityDays": "Cache Validity (days)",
+    "cacheShortWarning": "A cache time that is too short will lead to frequent requests, while one that is too long will result in outdated data.",
+    "requestTimeoutMs": "Request Timeout (milliseconds)",
+    "ptgenConfig": "PtGen Configuration",
+    "preferPtgenLabel": "Prefer data provided by PtGen",
+    "ptgenApiAddress": "PtGen API Address",
+    "ptgenApiMessages": "Select a built-in address or enter an address like https://example.com/ptgen?site=<site>&sid=<sid>",
+    "mediaRatingConfig": "Media Rating Site Configuration",
+    "anidbClientId": "AniDB Client ID",
+    "anidbClientMessages": "Please apply for a Client ID at https://anidb.net/perl-bin/animedb.pl?show=client and fill it in the format `Name/Version`.",
+    "bangumiApiKey": "Bangumi API Key",
+    "bangumiApiMessages": "You can generate an Access Token at https://next.bgm.tv/demo/access-token"
   }
 }

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -97,7 +97,18 @@
       "SetDownloader": "下载器设置",
       "SetMediaServer": "媒体服务器设置",
       "SetSearchSolution": "搜索方案定义",
-      "SetSite": "站点设置"
+      "SetSite": "站点设置",
+      "SearchConfig": {
+        "siteSearchConfig": "站点搜索配置",
+        "siteQueueConcurrency": "请求队列长度",
+        "saveLastSearchFilter": "保存上一次使用的搜索筛选词",
+        "mediaServerSearchConfig": "媒体服务器搜索配置",
+        "mediaQueueConcurrency": "请求队列长度",
+        "mediaSearchLimit": "单次搜索结果数量",
+        "mediaSearchLimitMessage": "请不要一次性加载过多的搜索结果，未作 virtual‑scroll 优化，可能会导致浏览器卡死，同时也会影响媒体服务器的性能",
+        "autoLoadInitialMediaWall": "自动加载首屏媒体墙",
+        "autoLoadMoreMediaOnScroll": "当滚动到页面底部时，自动加载新的媒体墙"
+      }
     }
   },
   "checkSwitch": {
@@ -166,6 +177,22 @@
     },
     "thankNote": "PT 助手的诞生是建立在这些项目基础之上，在此感谢所有项目的参与人员，感谢他们的付出！"
   },
+  "DownloadHistory": {
+    "refresh": "刷新下载记录列表",
+    "reDownload": "重新下载",
+    "filterPlaceholder": "过滤下载记录",
+    "table": {
+      "site": "站点",
+      "title": "种子",
+      "downloader": "下载服务器",
+      "downloadAt": "下载时间",
+      "status": "下载状态"
+    }
+  },
+  "MediaServerEntity": {
+    "searchPlaceholder": "搜索词",
+    "detail": "详情"
+  },
   "MyData": {
     "index": {
       "flushSelectSite": "刷新数据",
@@ -187,7 +214,18 @@
       "showNextLevelInDialog": "在站点等级列表中显示下一级别要求",
       "showHnR": "显示 H&R",
       "showSeedingBonus": "显示做种积分",
-      "updateAtFormatAsAlive": "更新时间显示为相对时间"
+      "updateAtFormatAsAlive": "更新时间显示为相对时间",
+      "multiOpen": "批量打开",
+      "viewTimeline": "时间轴",
+      "viewStatistic": "数据图表",
+      "setting": "设置",
+      "siteStatus": "站点状态",
+      "siteCategory": "站点分类",
+      "filter": {
+        "todayNotUpdated": "今日未更新",
+        "lastUpdateError": "最后更新状态异常",
+        "unreadMessage": "未读信息"
+      }
     },
     "table": {
       "site": "站点",
@@ -250,6 +288,35 @@
   },
   "SearchEntity": {
     "index": {
+      "table": {
+        "site": "站点",
+        "title": "标题",
+        "category": "分类",
+        "size": "大小",
+        "seeders": "上传",
+        "leechers": "下载",
+        "completed": "完成",
+        "comments": "评论",
+        "time": "发布于(≈)"
+      },
+      "alert": {
+        "enterKeyword": "请输入搜索关键词开始搜索",
+        "statusButton": "搜索情况",
+        "paused": "搜索暂停中…",
+        "searching": "搜索中…",
+        "snapshot": "搜索快照",
+        "plan": "搜索方案",
+        "keyword": "关键词",
+        "results": "共 {0} 条结果，",
+        "duration": "耗时： {0} 秒。"
+      },
+      "action": {
+        "start": "开始搜索队列",
+        "pause": "暂停搜索队列",
+        "cancel": "取消当前等待的搜索",
+        "retry": "重新搜索"
+      },
+      "filterLabel": "过滤搜索结果",
       "showSiteName": "显示站点名称",
       "showTorrentTag": "显示种子标签",
       "showTorrentSubtitle": "显示种子副标题",
@@ -265,6 +332,20 @@
         "quarter": "本季度",
         "year": "本年",
         "custom": "自定义"
+      }
+    }
+  },
+  "SearchResultSnapshot": {
+    "table": {
+      "header": {
+        "name": "快照名称",
+        "recordCount": "种子数",
+        "createdAt": "创建时间"
+      },
+      "filterLabel": "快照名称过滤",
+      "action": {
+        "view": "查看",
+        "editTitle": "编辑标题"
       }
     }
   },
@@ -294,7 +375,13 @@
         "browserTip": "（推荐）调用浏览器为插件提供的下载方法直接下载",
         "extension": "插件中转",
         "extensionTip": "插件后台下载种子，并中转到 @:SetBase.download.localDownloadMethod.browser 进行下载"
-      }
+      },
+      "saveDownloadHistory": "是否保存下载历史（如非必要请勿关闭此功能）",
+      "localDownloadTitle": "本地下载",
+      "localDownloadIgnoreInterval": "本地下载时忽略站点下载间隔限制",
+      "pushDownloadServerTitle": "下载服务器推送",
+      "saveLastDownloader": "保存上一次使用的下载服务器设置",
+      "allowDirectSendToClient": "是否允许直接将链接（而不是种子文件）发送到下载服务器（如非必要请勿启用）"
     }
   },
   "SetDownloader": {
@@ -385,6 +472,8 @@
   },
   "SetSearchSolution": {
     "solution": "搜索方案",
+    "import": "导入",
+    "export": "导出",
     "table": {
       "enable": "启用？",
       "default": "默认？"
@@ -413,7 +502,8 @@
       "showMessageCount": "信息提醒",
       "tags": "标签",
       "type": "类型",
-      "url": "网站链接"
+      "url": "网站链接",
+      "groups": "站点分类"
     },
     "delete": {
       "text": "确认删除这 {0} 个站点吗？"
@@ -436,13 +526,91 @@
       "table": {
         "flushFavicon": "刷新站点图标"
       },
-      "settingNote": ["只有配置过的站点才会显示插件图标及相应的功能；", "已离线的站点不再参与搜索和信息获取；"]
+      "settingNote": ["只有配置过的站点才会显示插件图标及相应的功能；", "已离线的站点不再参与搜索和信息获取；"],
+      "oneClickImport": "一键导入站点"
     },
     "spDialog": {
       "noDefNotice": "该站点未定义搜索模块，请到项目仓库提供帮助！",
       "notice": "不推荐在此处进行设置，更建议在对应站点的个人设置中配置或使用插件提供的搜索方案功能！",
       "selectAllNotice": "（注意：在大多数情况下，你并不需要全选所有搜索项！）",
       "title": "配置站点默认搜索模式 - {name}"
+    },
+    "oneClickImportDialog": {
+      "title": "一键导入站点",
+      "alert1": "此操作会尝试以默认配置导入你选择的站点，请确保该站点已在浏览器上登录过。导入过程不能中断，请耐心等待。",
+      "alert2": "未添加的站点列表",
+      "stats": "已选择 {count} 个站点，已添加 {success} 个站点，添加失败 {failed} 个站点。",
+      "trying": "正在尝试导入站点 [{name}] ...",
+      "status": {
+        "manual": "该站点需要手动添加",
+        "trying": "正在尝试中",
+        "success": "已添加成功",
+        "failed": "添加失败",
+        "selected": "已选择"
+      }
     }
+  },
+  "SetBackup": {
+    "table": {
+      "type": "类型",
+      "name": "名称",
+      "backupFields": "备份内容",
+      "lastBackupAt": "最近一次备份时间",
+      "notBackup": "未备份"
+    },
+    "localExport": "本地导出",
+    "localImport": "本地导入",
+    "snackbar": {
+      "success": "备份成功",
+      "failure": "备份失败"
+    }
+  },
+  "userInfo": {
+    "queueConcurrency": "请求队列长度",
+    "enableAutoRefresh": "是否启用后台定时刷新？",
+    "autoRefresh": {
+      "every": "每隔",
+      "hoursLabel": "小时，自动刷新一次当天",
+      "unrefreshedSite": "未刷新过",
+      "ofSites": "的站点",
+      "retryOnFail": "如果刷新失败，则重试",
+      "times": "次，每次间隔",
+      "minutes": "分钟。",
+      "lastFlushTime": "最近一次刷新时间:",
+      "nextFlushTime": "下一次刷新时间:"
+    },
+    "showDeadSite": "在概览中展示已被标记为死亡 （isDead） 的站点",
+    "showPassedSite": "在概览中展示已被标记为离线 （isOffline） 或不允许查询用户信息的站点"
+  },
+  "ptppSettings": {
+    "basicConfig": "基本配置",
+    "saveKeyNotice": "注意：密钥仅保存在当前浏览器，不会备份，请妥善保存；加密后如密钥丢失将无法恢复数据。留空表示不做加密。",
+    "encryptionKeyLabel": "备份文件加密、解密密钥",
+    "undoKeyTitle": "恢复上一个密钥",
+    "randomGenTitle": "随机生成",
+    "invalidFileFormat": "文件格式错误，请检查是否按正确步骤（关闭备份加密功能）导出备份。",
+    "importConfigTitle": "PT-Plugin-Plus 配置导入",
+    "importConfigInfoLine1": "{repoName} 只能导入原 PT-Plugin-Plus 的用户历史数据信息，其他配置文件不支持导入。",
+    "importConfigInfoPrep": "在导入之前，请做好以下准备：",
+    "importStep1": "请先备份好当前 {repoName} 的配置文件。",
+    "importStep2": "在 {repoName} 的站点设置中添加需要恢复的站点。（如果没有添加站点，对应的用户历史数据会被忽略）",
+    "importStep3": "在 PT-Plugin-Plus 中，关闭备份加密功能，并导出本地备份文件。其应该是一个名为 <code>PT-Plugin-Plus-Backup-yyyy-MM-DD_hh-mm-ss.zip</code> 的 zip 压缩文件。",
+    "importStep4": "将压缩包或者从压缩包中解压出的 <code>userdatas.json</code> 文件，上传到下面的输入框中。",
+    "selectBackupFile": "选择 PTPP 备份文件"
+  },
+  "socialConfig": {
+    "basicConfig": "基本配置",
+    "cacheValidityDays": "缓存有效期（天）",
+    "cacheShortWarning": "缓存时间过短会导致频繁请求，过长会导致数据不及时",
+    "requestTimeoutMs": "请求超时时间 (毫秒)",
+    "ptgenConfig": "PtGen 配置",
+    "preferPtgenLabel": "优先使用 PtGen 提供的数据",
+    "ptgenApiAddress": "PtGen API 地址",
+    "ptgenApiMessages": "选择内置地址或输入类似 https://example.com/ptgen?site=<site>&sid=<sid> 的地址",
+    "mediaRatingConfig": "各媒体评分站点配置",
+    "anidbClientId": "AniDB Client ID",
+    "anidbClientMessages": "请在 https://anidb.net/perl-bin/animedb.pl?show=client 中申请 Client ID， 并按照 `Name/Version` 的格式填写",
+    "bangumiApiKey": "Bangumi API Key",
+    "bangumiApiMessages": "你可以在 https://next.bgm.tv/demo/access-token 生成一个 Access Token"
   }
 }


### PR DESCRIPTION
- 没有完整覆盖所有的代码

- 可能还需要优化i18n文件结构？

---

建议：

1. https://github.com/pt-plugins/PT-depiler/blob/fba9162b1cd4d861d7f48e01c37e93d9650775cf/src/entries/options/plugins/i18n.ts#L34
   因为目前中文的翻译覆盖最全，建议fallback到中文

2. 也许可以申请一下 [Hosted Weblate](https://hosted.weblate.org) 来管理i18n翻译