### PR TITLE
feat: Display data labels on bar charts

### DIFF
--- a/src/entries/options/views/Overview/MyData/UserDataStatistic/Index.vue
+++ b/src/entries/options/views/Overview/MyData/UserDataStatistic/Index.vue
@@ -189,6 +189,13 @@ const createPerSiteChartOptionsFn = (
         emphasis: {
           focus: "series",
         },
+        label: {
+          show: true,
+          position: "top",
+          formatter: (params: any) => {
+            return formatDict[format](params.value);
+          },
+        },
         stack: "site",
         tooltip: {
           formatter: (params: any) => {


### PR DESCRIPTION
This change modifies the ECharts configuration for bar charts in the User Data Statistic view to display data labels on top of each bar.

The `createPerSiteChartOptionsFn` function was updated to include the `label` series option:
- `label.show` is set to `true`.
- `label.position` is set to `'top'`.
- `label.formatter` is configured to display the formatted value of the bar.