### PR TITLE
Fix: Update springsunday bonusPerHour selector

### DIFF
--- a/src/packages/site/definitions/springsunday.ts
+++ b/src/packages/site/definitions/springsunday.ts
@@ -312,7 +312,7 @@ export const siteMetadata: ISiteMetadata = {
         ],
       },
       bonusPerHour: {
-        selector: ["tbody:contains('我的数据') > tr:first > td:last"],
+        selector: ["tbody tr.nowrap:first td:last"],
         filters: [{ name: "parseNumber" }],
       },
       messageCount: {


### PR DESCRIPTION
Ensure the selector for bonusPerHour in springsunday site definition is `tbody tr.nowrap:first td:last`.