### PR TITLE
Remove bonusPerHour from springsunday site definition

### DIFF
--- a/src/packages/site/definitions/springsunday.ts
+++ b/src/packages/site/definitions/springsunday.ts
@@ -387,10 +387,6 @@ export default class SpringSunday extends NexusPHP {
         selector: "b:eq(1)",
         filters: [{ name: "parseSize" }],
       });
-      flushUserInfo.bonusPerHour = this.getFieldData(userSeedingDocument, {
-        selector: "b:eq(4)",
-        filters: [{ name: "parseNumber" }],
-      });
     } else {
       return super.parseUserInfoForSeedingStatus(flushUserInfo); // 回落到默认的处理
     }


### PR DESCRIPTION
This commit removes the `bonusPerHour` field from the `parseUserInfoForSeedingStatus` method in the `springsunday.ts` site definition file as requested by the user.