### PR TITLE
Fix: Cannot find name 'IAdvancedSearchRequestConfig' in okpt.ts

### DIFF
--- a/src/packages/site/definitions/okpt.ts
+++ b/src/packages/site/definitions/okpt.ts
@@ -1,4 +1,4 @@
-import { type ISiteMetadata } from "../types";
+import { type ISiteMetadata, type IAdvancedSearchRequestConfig } from "../types";
 import { CategoryInclbookmarked, CategoryIncldead, CategorySpstate, SchemaMetadata } from "../schemas/NexusPHP.ts";
 
 export const siteMetadata: ISiteMetadata = {


### PR DESCRIPTION
Imports IAdvancedSearchRequestConfig from ../types to resolve the TypeScript error.