### PR TITLE
fix(UserDateTimeline): 数据排行榜中排除 Infinity 值

### DIFF
--- a/src/entries/options/views/Overview/MyData/UserDataTimeline/utils.ts
+++ b/src/entries/options/views/Overview/MyData/UserDataTimeline/utils.ts
@@ -140,6 +140,8 @@ export const timelineDataRef = useResetableRef<ITimelineData>(() => {
             value = parseFloat(userInfo[userInfoKey]);
           } catch (e) {}
 
+          if (!isFinite(value)) continue; // 如果不是有限数字，则跳过
+
           result.totalInfo[userInfoKey] += value; // 更新总量
 
           // 更新最大值和次大值


### PR DESCRIPTION
Ratioless 站点的分享率为 inf，会占据排行版的 rk 1 和 rk 2，实际意义不大。