### PR TITLE
fix(search): 修复搜索耗时计算逻辑，确保时间准确性

### DIFF
--- a/src/entries/options/stores/runtime.ts
+++ b/src/entries/options/stores/runtime.ts
@@ -42,15 +42,20 @@ export const useRuntimeStore = defineStore("runtime", {
 
   getters: {
     searchCostTime(state) {
-      if (!state.search.startAt) {
+      const plans = Object.values(state.search.searchPlan).filter((plan) => plan.startAt);
+
+      if (plans.length === 0) {
         return 0;
       }
 
-      // 如果搜索正在进行，则使用当前时间作为结束时间；否则使用记录的结束时间
-      const endTime = state.search.isSearching ? Date.now() : state.search.endAt;
+      const now = Date.now();
+      const startTimes = plans.map((plan) => plan.startAt!);
+      const endTimes = plans.map((plan) => plan.endAt || (plan.costTime ? plan.startAt! + plan.costTime : now));
 
-      // 如果 endTime 无效（例如搜索刚结束但 endAt 未写入），则使用 startAt 作为备用，使返回值为0
-      return (endTime || state.search.startAt) - state.search.startAt;
+      const earliestStart = Math.min(...startTimes);
+      const latestEnd = Math.max(...endTimes);
+
+      return latestEnd - earliestStart;
     },
 
     isUserInfoFlush(state) {

--- a/src/entries/options/stores/runtime.ts
+++ b/src/entries/options/stores/runtime.ts
@@ -11,6 +11,7 @@ import type { IRuntimePiniaStorageSchema, ISearchData, SnackbarMessageOptions } 
 const initialSearchData: () => ISearchData = () => ({
   isSearching: false,
   startAt: 0,
+  endAt: 0,
   searchKey: "",
   searchPlanKey: "default",
   searchPlan: {},
@@ -41,7 +42,15 @@ export const useRuntimeStore = defineStore("runtime", {
 
   getters: {
     searchCostTime(state) {
-      return Object.values(state.search.searchPlan).reduce((acc, cur) => acc + (cur.costTime ?? 0), 0);
+      if (!state.search.startAt) {
+        return 0;
+      }
+
+      // 如果搜索正在进行，则使用当前时间作为结束时间；否则使用记录的结束时间
+      const endTime = state.search.isSearching ? Date.now() : state.search.endAt;
+
+      // 如果 endTime 无效（例如搜索刚结束但 endAt 未写入），则使用 startAt 作为备用，使返回值为0
+      return (endTime || state.search.startAt) - state.search.startAt;
     },
 
     isUserInfoFlush(state) {

--- a/src/entries/options/views/Overview/SearchEntity/utils.ts
+++ b/src/entries/options/views/Overview/SearchEntity/utils.ts
@@ -114,7 +114,9 @@ export async function doSearchEntity(
       runtimeStore.search.searchPlan[solutionKey].count = runtimeStore.search.searchResult.filter(
         (item) => item.solutionKey == solutionKey,
       ).length;
-      runtimeStore.search.searchPlan[solutionKey].costTime = Date.now() - startAt;
+      const endAt = Date.now();
+      runtimeStore.search.searchPlan[solutionKey].endAt = endAt;
+      runtimeStore.search.searchPlan[solutionKey].costTime = endAt - startAt;
     },
     { priority: queuePriority, id: solutionKey },
   );

--- a/src/entries/options/views/Overview/SearchEntity/utils.ts
+++ b/src/entries/options/views/Overview/SearchEntity/utils.ts
@@ -50,6 +50,7 @@ searchQueue.on("active", () => {
 
 searchQueue.on("idle", () => {
   runtimeStore.search.isSearching = false;
+  runtimeStore.search.endAt = Date.now();
 });
 
 export async function raiseSearchPriority(solutionKey: TSearchSolutionKey) {
@@ -85,12 +86,12 @@ export async function doSearchEntity(
 
   // Search site by plan in queue
   console.log(`Add search ${solutionKey} to queue.`);
-  runtimeStore.search.searchPlan[solutionKey].queueAt = +new Date();
+  runtimeStore.search.searchPlan[solutionKey].queueAt = Date.now();
 
   // noinspection ES6MissingAwait
   searchQueue.add(
     async () => {
-      const startAt = (runtimeStore.search.searchPlan[solutionKey].startAt = +new Date());
+      const startAt = (runtimeStore.search.searchPlan[solutionKey].startAt = Date.now());
       console.log(`search ${solutionKey} start at ${startAt}`);
       runtimeStore.search.searchPlan[solutionKey].status = EResultParseStatus.working;
       const { status: searchStatus, data: searchResult } = await sendMessage("getSiteSearchResult", {
@@ -113,7 +114,7 @@ export async function doSearchEntity(
       runtimeStore.search.searchPlan[solutionKey].count = runtimeStore.search.searchResult.filter(
         (item) => item.solutionKey == solutionKey,
       ).length;
-      runtimeStore.search.searchPlan[solutionKey].costTime = +new Date() - startAt;
+      runtimeStore.search.searchPlan[solutionKey].costTime = Date.now() - startAt;
     },
     { priority: queuePriority, id: solutionKey },
   );
@@ -149,7 +150,7 @@ export async function doSearch(search: string, plan?: string, flush: boolean = t
     return;
   }
 
-  runtimeStore.search.startAt = +Date.now();
+  runtimeStore.search.startAt = Date.now();
   runtimeStore.search.isSearching = true;
 
   for (const { siteId, searchEntries } of searchSolution.solutions) {

--- a/src/entries/shared/types/storages/runtime.ts
+++ b/src/entries/shared/types/storages/runtime.ts
@@ -30,6 +30,7 @@ export interface ISearchData {
   isSearching: boolean; // 是否正在搜索
   // 该搜索相关时间情况
   startAt: number;
+  endAt?: number; // 搜索结束时间
 
   // 该搜索相关的搜索条件
   searchKey: string;

--- a/src/entries/shared/types/storages/runtime.ts
+++ b/src/entries/shared/types/storages/runtime.ts
@@ -21,6 +21,7 @@ export interface ISearchPlanStatus {
   queueAt?: number;
   queuePriority?: number;
   startAt?: number;
+  endAt?: number;
   costTime?: number;
   count?: number;
 }


### PR DESCRIPTION
- 新增 endAt 字段，精确记录搜索结束时间点。
- 重构 searchCostTime getter，根据搜索状态（进行中/已结束）动态计算耗时，取代原有的累加方式。
- 统一时间戳生成方式为 Date.now()，提升代码一致性。