### PR TITLE
fix(audiences): handle negative progress values

### DIFF
--- a/src/packages/site/definitions/audiences.ts
+++ b/src/packages/site/definitions/audiences.ts
@@ -99,17 +99,22 @@ export const siteMetadata: ISiteMetadata = {
         selector: ['div[class^="torrents-progress"][style*="width"]:first'],
         elementProcess: (element: HTMLElement) => {
           const elementStyle = element.getAttribute("style") || "";
-          const widthMatch = elementStyle.match(/width:([ \d.]+)%/);
-          return widthMatch && widthMatch.length >= 2 ? parseFloat(widthMatch[1]) : 0;
+          const widthMatch = elementStyle.match(/width:([ \d.-]+)%/);
+          const progress = widthMatch && widthMatch.length >= 2 ? parseFloat(widthMatch[1]) : 0;
+          return progress < 0 ? 0 : progress;
         },
       },
       status: {
         selector: ['div[class^="torrents-progress"][style*="width"]:first'],
         elementProcess: (element: HTMLElement) => {
           if (element.classList.contains("torrents-progress2")) {
-            const widthMatch = (element.getAttribute("style") || "").match(/width:([ \d.]+)%/);
+            const widthMatch = (element.getAttribute("style") || "").match(/width:([ \d.-]+)%/);
             const progress = widthMatch && widthMatch.length >= 2 ? parseFloat(widthMatch[1]) : 0;
-            return progress >= 100 ? ETorrentStatus.completed : ETorrentStatus.inactive;
+            return progress < 0
+              ? ETorrentStatus.unknown
+              : progress >= 100
+                ? ETorrentStatus.completed
+                : ETorrentStatus.inactive;
           } else if (element.classList.contains("torrents-progress")) {
             const widthMatch = (element.getAttribute("style") || "").match(/width:([ \d.]+)%/);
             const progress = widthMatch && widthMatch.length >= 2 ? parseFloat(widthMatch[1]) : 0;


### PR DESCRIPTION
- Return 0 for negative progress values instead of negative numbers
- Return ETorrentStatus.unknown for negative progress in torrents-progress2
- Update regex to support negative values parsing for both progress and status selectors