### PR TITLE
fix: encode all site definition URLs with rot13

### DIFF
--- a/src/packages/site/definitions/13city.ts
+++ b/src/packages/site/definitions/13city.ts
@@ -13,7 +13,7 @@ export const siteMetadata: ISiteMetadata = {
   collaborator: ["13City"],
   type: "private",
   schema: "NexusPHP",
-  urls: ["https://13city.org/"],
+  urls: ["uggcf://13pvgl.bet/"],
   formerHosts: ["13city.online"],
   category: [
     {

--- a/src/packages/site/definitions/2xfree.ts
+++ b/src/packages/site/definitions/2xfree.ts
@@ -10,7 +10,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://pt.2xfree.org/"],
+  urls: ["uggcf://cg.2ksrrr.bet/"],
 
   isDead: true,
 

--- a/src/packages/site/definitions/avgv.ts
+++ b/src/packages/site/definitions/avgv.ts
@@ -12,7 +12,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://avgv.cc/"],
+  urls: ["uggcf://nitv.pp/"],
 
   // refs: https://github.com/pt-plugins/PT-Plugin-Plus/commit/1366757f3f42c0c3afb31fe67a6ace722a8a2663
   isDead: true,

--- a/src/packages/site/definitions/awesomehd.ts
+++ b/src/packages/site/definitions/awesomehd.ts
@@ -10,7 +10,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "Gazelle",
 
-  urls: ["https://awesome-hd.me/"],
+  urls: ["uggcf://njrfbzr-uq.zr/"],
 
   // refs: https://github.com/pt-plugins/PT-Plugin-Plus/commit/65e36ee58a53affd08485754b24293881b69e822
   isDead: true,

--- a/src/packages/site/definitions/beitai.ts
+++ b/src/packages/site/definitions/beitai.ts
@@ -12,7 +12,7 @@ export const siteMetadata: ISiteMetadata = {
   schema: "NexusPHP",
 
   favicon: "./_default_nexusphp.png",
-  urls: ["https://www.beitai.pt/"],
+  urls: ["uggcf://jjj.orvgnv.cg/"],
 
   isDead: true,
 

--- a/src/packages/site/definitions/byrbt.ts
+++ b/src/packages/site/definitions/byrbt.ts
@@ -21,7 +21,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://byr.pt/"],
+  urls: ["uggcf://ole.cg/"],
   formerHosts: ["bt.byr.cn"],
 
   category: [

--- a/src/packages/site/definitions/ccfbits.ts
+++ b/src/packages/site/definitions/ccfbits.ts
@@ -10,7 +10,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "TBSource",
 
-  urls: ["https://ccfbits.org/"],
+  urls: ["uggcf://ppsoygf.bet/"],
 
   isDead: true,
 

--- a/src/packages/site/definitions/cdfile.ts
+++ b/src/packages/site/definitions/cdfile.ts
@@ -11,7 +11,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://pt.cdfile.org/"],
+  urls: ["uggcf://cg.pqsvyr.bet/"],
 
   category: [
     {

--- a/src/packages/site/definitions/cnlang.ts
+++ b/src/packages/site/definitions/cnlang.ts
@@ -11,7 +11,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "Discuz",
 
-  urls: ["https://cnlang.org/"],
+  urls: ["uggcf://paynag.bet/"],
 
   // refs: https://github.com/pt-plugins/PT-Plugin-Plus/commit/1aa73d0f9b0afb4511c1be7810d7dafc4268cd4d
   isDead: true,

--- a/src/packages/site/definitions/cnscg.ts
+++ b/src/packages/site/definitions/cnscg.ts
@@ -11,7 +11,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://www.cnscg.club/"],
+  urls: ["uggcf://jjj.pafpt.pyho/"],
   formerHosts: ["www.hdscg.cc"],
 
   favicon: "./_default_nexusphp.png", // 实在找不到favicon了

--- a/src/packages/site/definitions/dajiao.ts
+++ b/src/packages/site/definitions/dajiao.ts
@@ -10,7 +10,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://dajiao.cyou/"],
+  urls: ["uggcf://qnwvnb.plbh/"],
 
   isDead: true,
 };

--- a/src/packages/site/definitions/dhtclub.ts
+++ b/src/packages/site/definitions/dhtclub.ts
@@ -13,7 +13,7 @@ export const siteMetadata: ISiteMetadata = {
 
   collaborator: ["AllenPu"],
 
-  urls: ["https://pt.dhtclub.com/"],
+  urls: ["uggcf://cg.qugpyho.pbz/"],
 
   isDead: true,
 

--- a/src/packages/site/definitions/dragonhd.ts
+++ b/src/packages/site/definitions/dragonhd.ts
@@ -17,7 +17,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://www.dragonhd.xyz/"],
+  urls: ["uggcf://jjj.qentbauq.klm/"],
   formerHosts: ["dragonhd.xyz"],
 
   category: [CategoryIncldead, CategorySpstate, CategoryInclbookmarked],

--- a/src/packages/site/definitions/dxdhd.ts
+++ b/src/packages/site/definitions/dxdhd.ts
@@ -10,7 +10,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "Unit3D",
 
-  urls: ["https://dxdhd.com/"],
+  urls: ["uggcf://qkquq.pbz/"],
 
   favicon: "./_default_unit3d.ico",
 

--- a/src/packages/site/definitions/ecustpt.ts
+++ b/src/packages/site/definitions/ecustpt.ts
@@ -10,7 +10,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://pt.ecust.pp.ua/"],
+  urls: ["uggcf://cg.rphfg.cc.hn/"],
   formerHosts: ["public.ecustpt.eu.org", "ecustpt.eu.org"],
 
   isDead: true,

--- a/src/packages/site/definitions/filept.ts
+++ b/src/packages/site/definitions/filept.ts
@@ -11,7 +11,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://www.filept.com/"],
+  urls: ["uggcf://jjj.svyrcg.pbz/"],
 
   favicon: "./_default_nexusphp.png",
 

--- a/src/packages/site/definitions/gainbound.ts
+++ b/src/packages/site/definitions/gainbound.ts
@@ -10,7 +10,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://gainbound.net/"],
+  urls: ["uggcf://tnvaobhaq.arg/"],
 
   // refs: https://github.com/pt-plugins/PT-Plugin-Plus/commit/43a47b75a1a24523e9788a7ffca83a5407dfa5d6
   isDead: true,

--- a/src/packages/site/definitions/hares.ts
+++ b/src/packages/site/definitions/hares.ts
@@ -12,7 +12,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://club.hares.top/"],
+  urls: ["uggcf://pyho.unerf.gbc/"],
 
   // refs: https://github.com/pt-plugins/PT-Plugin-Plus/commit/4371f6ebecf2743acb3817303fdcc36cf5b0118e
   isDead: true,

--- a/src/packages/site/definitions/hd4fans.ts
+++ b/src/packages/site/definitions/hd4fans.ts
@@ -11,7 +11,7 @@ export const siteMetadata: ISiteMetadata = {
   schema: "NexusPHP",
 
   favicon: "./_default_nexusphp.png",
-  urls: ["https://pt.hd4fans.org/"],
+  urls: ["uggcf://cg.uq4snaf.bet/"],
 
   isDead: true,
 

--- a/src/packages/site/definitions/hd4free.ts
+++ b/src/packages/site/definitions/hd4free.ts
@@ -10,7 +10,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "Unit3D",
 
-  urls: ["https://hd4.xyz/"],
+  urls: ["uggcf://uq4.klm/"],
 
   // refs: https://github.com/pt-plugins/PT-Plugin-Plus/commit/2c9591371523ad237f5c6f34335cb118738ea9ba
   isDead: true,

--- a/src/packages/site/definitions/hdai.ts
+++ b/src/packages/site/definitions/hdai.ts
@@ -10,7 +10,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://www.hd.ai/"],
+  urls: ["uggcf://jjj.uq.nv/"],
   host: "hd.ai",
 
   // refs: https://github.com/pt-plugins/PT-Plugin-Plus/commit/fc106917a4a9b5834633e5d4903912e02846235f

--- a/src/packages/site/definitions/hdatmos.ts
+++ b/src/packages/site/definitions/hdatmos.ts
@@ -11,7 +11,7 @@ export const siteMetadata: ISiteMetadata = {
   schema: "NexusPHP",
 
   favicon: "./_default_nexusphp.png",
-  urls: ["https://hdatmos.club/"],
+  urls: ["uggcf://uqngzbf.pyho/"],
 
   isDead: true,
 

--- a/src/packages/site/definitions/hdbao.ts
+++ b/src/packages/site/definitions/hdbao.ts
@@ -10,7 +10,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://hdbao.cc/"],
+  urls: ["uggcf://uqonb.pp/"],
 
   category: [
     {

--- a/src/packages/site/definitions/hdchina.ts
+++ b/src/packages/site/definitions/hdchina.ts
@@ -14,7 +14,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://hdchina.org/"],
+  urls: ["uggcf://uqpuvan.bet/"],
 
   isDead: true,
 

--- a/src/packages/site/definitions/hdclone.ts
+++ b/src/packages/site/definitions/hdclone.ts
@@ -10,7 +10,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://pt.hdclone.org/"],
+  urls: ["uggcf://cg.uqpybar.bet/"],
 
   category: [
     {

--- a/src/packages/site/definitions/hddisk.ts
+++ b/src/packages/site/definitions/hddisk.ts
@@ -10,7 +10,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://hddisk.org/"],
+  urls: ["uggcf://uqqvfx.bet/"],
 
   favicon: "./_default_nexusphp.png", // 实在找不到favicon了
 

--- a/src/packages/site/definitions/hddolby.ts
+++ b/src/packages/site/definitions/hddolby.ts
@@ -15,7 +15,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://www.hddolby.com/"],
+  urls: ["uggcf://jjj.uqqbyol.pbz/"],
   formerHosts: ["hddolby.com"],
 
   category: [

--- a/src/packages/site/definitions/hdhome.ts
+++ b/src/packages/site/definitions/hdhome.ts
@@ -94,7 +94,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://hdhome.org/"],
+  urls: ["uggcf://uqubzr.bet/"],
 
   category: [
     {

--- a/src/packages/site/definitions/hdkylin.ts
+++ b/src/packages/site/definitions/hdkylin.ts
@@ -12,7 +12,7 @@ export const siteMetadata: ISiteMetadata = {
   tags: ["综合", "电影", "电视剧", "纪录片"],
   type: "private",
   schema: "NexusPHP",
-  urls: ["https://www.hdkyl.in/", "https://na.hdkylin.com/", "https://cf.hdkylin.com/"],
+  urls: ["uggcf://jjj.uqxly.va/", "uggcf://an.uqxlyva.pbz/", "uggcf://ps.uqxlyva.pbz/"],
   favicon: "https://www.hdkyl.in/favicon.ico",
 
   levelRequirements: [

--- a/src/packages/site/definitions/hdmayi.ts
+++ b/src/packages/site/definitions/hdmayi.ts
@@ -11,7 +11,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["http://hdmayi.com/"],
+  urls: ["uggc://uqznlv.pbz/"],
 
   // refs: https://github.com/pt-plugins/PT-Plugin-Plus/commit/c6d81bb5bc5d8ea68fcf02860c3aa9310ae0a614
   isDead: true,

--- a/src/packages/site/definitions/hdpost.ts
+++ b/src/packages/site/definitions/hdpost.ts
@@ -8,7 +8,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "Unit3D",
 
-  urls: ["https://pt.hdpost.top/"],
+  urls: ["uggcf://cg.uqcbfg.gbc/"],
 
   isDead: true,
 };

--- a/src/packages/site/definitions/hdpt.ts
+++ b/src/packages/site/definitions/hdpt.ts
@@ -12,7 +12,7 @@ export const siteMetadata: ISiteMetadata = {
   schema: "NexusPHP",
 
   favicon: "./_default_nexusphp.png",
-  urls: ["https://hdpt.xyz/"],
+  urls: ["uggcf://uqcg.klm/"],
 
   isDead: true,
 

--- a/src/packages/site/definitions/hdsky.ts
+++ b/src/packages/site/definitions/hdsky.ts
@@ -20,7 +20,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://hdsky.me/"],
+  urls: ["uggcf://uqfxl.zr/"],
 
   category: [
     {

--- a/src/packages/site/definitions/hdstreet.ts
+++ b/src/packages/site/definitions/hdstreet.ts
@@ -10,7 +10,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://hdstreet.club/"],
+  urls: ["uggcf://uqfgerrg.pyho/"],
 
   // refs: https://github.com/pt-plugins/PT-Plugin-Plus/commit/2c9591371523ad237f5c6f34335cb118738ea9ba
   isDead: true,

--- a/src/packages/site/definitions/hdtime.ts
+++ b/src/packages/site/definitions/hdtime.ts
@@ -13,7 +13,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://hdtime.org/"],
+  urls: ["uggcf://uqgvzr.bet/"],
 
   category: [
     {

--- a/src/packages/site/definitions/hdupt.ts
+++ b/src/packages/site/definitions/hdupt.ts
@@ -13,7 +13,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://pt.hdupt.com/", "https://pt.upxin.net/"],
+  urls: ["uggcf://cg.uqhcg.pbz/", "uggcf://cg.hckva.arg/"],
 
   category: [
     {

--- a/src/packages/site/definitions/hdvideo.ts
+++ b/src/packages/site/definitions/hdvideo.ts
@@ -10,7 +10,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://hdvideo.one/"],
+  urls: ["uggcf://uqivqrb.bar/"],
 
   isDead: true,
 

--- a/src/packages/site/definitions/hdzone.ts
+++ b/src/packages/site/definitions/hdzone.ts
@@ -10,7 +10,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://hdfun.me/"],
+  urls: ["uggcf://uqsha.zr/"],
   formerHosts: ["hdzone.me"],
 
   favicon: "./_default_nexusphp.png",

--- a/src/packages/site/definitions/hspt.ts
+++ b/src/packages/site/definitions/hspt.ts
@@ -11,7 +11,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://hspt.club/"],
+  urls: ["uggcf://ufcg.pyho/"],
 
   isDead: true,
 

--- a/src/packages/site/definitions/hudbt.ts
+++ b/src/packages/site/definitions/hudbt.ts
@@ -15,7 +15,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://hudbt.hust.edu.cn/"],
+  urls: ["uggcf://uhqog.uhfg.rqh.pa/"],
 
   category: [
     {

--- a/src/packages/site/definitions/icc2022.ts
+++ b/src/packages/site/definitions/icc2022.ts
@@ -17,7 +17,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://www.icc2022.com/"],
+  urls: ["uggcf://jjj.vpp2022.pbz/"],
 
   // refs: https://web.archive.org/web/20250629023542/https://www.icc2022.com/
   isDead: true,

--- a/src/packages/site/definitions/ihdbits.ts
+++ b/src/packages/site/definitions/ihdbits.ts
@@ -11,7 +11,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["http://ihdbits.me/", "https://pt.newworld.plus/"],
+  urls: ["uggc://vuqovgf.zr/", "uggcf://cg.arjjbeyq.cyhf/"],
 
   favicon: "./_default_nexusphp.png",
 

--- a/src/packages/site/definitions/iptorrents.ts
+++ b/src/packages/site/definitions/iptorrents.ts
@@ -29,7 +29,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "AbstractPrivateSite",
 
-  urls: ["https://iptorrents.com/"],
+  urls: ["uggcf://vcgbeeragf.pbz/"],
 
   category: [
     {

--- a/src/packages/site/definitions/itzmx.ts
+++ b/src/packages/site/definitions/itzmx.ts
@@ -19,7 +19,7 @@ export const siteMetadata: ISiteMetadata = {
 
   collaborator: ["AllenPu"],
 
-  urls: ["https://pt.itzmx.com/"],
+  urls: ["uggcf://cg.vgmzk.pbz/"],
 
   category: [
     {

--- a/src/packages/site/definitions/joyhd.ts
+++ b/src/packages/site/definitions/joyhd.ts
@@ -15,7 +15,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://www.joyhd.net/"],
+  urls: ["uggcf://jjj.wbluq.arg/"],
 
   category: [
     {

--- a/src/packages/site/definitions/jpopsuki.ts
+++ b/src/packages/site/definitions/jpopsuki.ts
@@ -73,7 +73,7 @@ export const siteMetadata: ISiteMetadata = {
   collaborator: ["ronggang", "ted423", "luckiestone", "amorphobia"],
   type: "private",
   schema: "Gazelle",
-  urls: ["https://jpopsuki.eu/"],
+  urls: ["uggcf://wcbcfhxv.rh/"],
   category: [
     {
       name: "Category",

--- a/src/packages/site/definitions/kamept.ts
+++ b/src/packages/site/definitions/kamept.ts
@@ -10,7 +10,7 @@ export const siteMetadata: ISiteMetadata = {
   name: "KamePT",
   schema: "NexusPHP",
   type: "private",
-  urls: ["https://kamept.com/"],
+  urls: ["uggcf://xnzrcg.pbz/"],
   description: "主打二次元同人AV的站点",
   tags: ["成人", "COS", "动漫", "音乐", "影视"],
   collaborator: ["NekoCH"],

--- a/src/packages/site/definitions/keepfrds.ts
+++ b/src/packages/site/definitions/keepfrds.ts
@@ -18,7 +18,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://pt.keepfrds.com/"],
+  urls: ["uggcf://cg.xrrcseqf.pbz/"],
   favicon: "https://pt.keepfrds.com/static/favicon-64x64.png",
 
   category: [

--- a/src/packages/site/definitions/kelu.ts
+++ b/src/packages/site/definitions/kelu.ts
@@ -15,7 +15,7 @@ export const siteMetadata: ISiteMetadata = {
 
   collaborator: ["haowenwu"],
 
-  urls: ["https://our.kelu.one/"],
+  urls: ["uggcf://bhe.xryh.bar/"],
 
   levelRequirements: [
     {

--- a/src/packages/site/definitions/kufei.ts
+++ b/src/packages/site/definitions/kufei.ts
@@ -19,7 +19,7 @@ export const siteMetadata: ISiteMetadata = {
 
   collaborator: ["yum"],
 
-  urls: ["https://kufei.org/"],
+  urls: ["uggcf://xhsrv.bet/"],
 
   category: [CategoryIncldead, CategorySpstate, CategoryInclbookmarked],
 

--- a/src/packages/site/definitions/minept.ts
+++ b/src/packages/site/definitions/minept.ts
@@ -11,7 +11,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "meanTorrent",
 
-  urls: ["https://mine.pt/"],
+  urls: ["uggcf://zvar.cg/"],
 
   // refs: https://github.com/pt-plugins/PT-Plugin-Plus/commit/ef7a885c052a9dc23286fb54e33dbef3dd9431ed
   isDead: true,

--- a/src/packages/site/definitions/moecat.ts
+++ b/src/packages/site/definitions/moecat.ts
@@ -11,7 +11,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://moecat.best/"],
+  urls: ["uggcf://zbrpng.orfg/"],
 
   // refs: https://github.com/pt-plugins/PT-Plugin-Plus/commit/2c9591371523ad237f5c6f34335cb118738ea9ba
   isDead: true,

--- a/src/packages/site/definitions/morethantv.ts
+++ b/src/packages/site/definitions/morethantv.ts
@@ -36,7 +36,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "Luminance",
 
-  urls: ["https://www.morethantv.me/"],
+  urls: ["uggcf://jjj.zbergunagi.zr/"],
 
   category: [
     {

--- a/src/packages/site/definitions/nanyangpt.ts
+++ b/src/packages/site/definitions/nanyangpt.ts
@@ -15,7 +15,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://nanyangpt.com/"],
+  urls: ["uggcf://ananlaotcg.pbz/"],
 
   category: [
     {

--- a/src/packages/site/definitions/nexushd.ts
+++ b/src/packages/site/definitions/nexushd.ts
@@ -14,7 +14,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://v6.nexushd.org/", "https://www.nexushd.org/"],
+  urls: ["uggcf://i6.arkhfuq.bet/", "uggcf://jjj.arkhfuq.bet/"],
 
   category: [
     {

--- a/src/packages/site/definitions/njtupt.ts
+++ b/src/packages/site/definitions/njtupt.ts
@@ -10,7 +10,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://njtupt.top/"],
+  urls: ["uggcf://awghcg.gbc/"],
 
   category: [CategoryIncldead, CategorySpstate, CategoryInclbookmarked],
 

--- a/src/packages/site/definitions/npupt.ts
+++ b/src/packages/site/definitions/npupt.ts
@@ -10,7 +10,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://npupt.com/"],
+  urls: ["uggcf://achcg.pbz/"],
 
   isDead: true,
 };

--- a/src/packages/site/definitions/nwsuaf6.ts
+++ b/src/packages/site/definitions/nwsuaf6.ts
@@ -11,7 +11,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://pt.nwsuaf6.edu.cn/"],
+  urls: ["uggcf://cg.ajfhns6.rqh.pa/"],
 
   // refs: https://github.com/pt-plugins/PT-Plugin-Plus/commit/ff7e7266e4f6d1d3f6a8b883e6b15691cfedae91
   isDead: true,

--- a/src/packages/site/definitions/oppaiti.ts
+++ b/src/packages/site/definitions/oppaiti.ts
@@ -11,7 +11,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "GazelleJSONAPI",
 
-  urls: ["https://oppaiti.me/"],
+  urls: ["uggcf://bccnvgv.zr/"],
 
   // refs: https://github.com/pt-plugins/PT-Plugin-Plus/commit/f8862893116800cecec2cb9b86f16dbd11e2bca8
   isDead: true,

--- a/src/packages/site/definitions/oshenpt.ts
+++ b/src/packages/site/definitions/oshenpt.ts
@@ -19,7 +19,7 @@ export const siteMetadata: ISiteMetadata = {
 
   collaborator: ["AllenPu"],
 
-  urls: ["https://www.oshen.win/"],
+  urls: ["uggcf://jjj.bfura.jva/"],
 
   category: [
     {

--- a/src/packages/site/definitions/ourbits.ts
+++ b/src/packages/site/definitions/ourbits.ts
@@ -17,7 +17,7 @@ export const siteMetadata: ISiteMetadata = {
   name: "OurBits",
   schema: "NexusPHP",
   type: "private",
-  urls: ["https://ourbits.club/"],
+  urls: ["uggcf://bheoygf.pyho/"],
   description: "综合性网站，有分享率要求",
   tags: ["影视", "动漫", "纪录片", "综艺"],
   collaborator: ["Rhilip"],

--- a/src/packages/site/definitions/passthepopcorn.ts
+++ b/src/packages/site/definitions/passthepopcorn.ts
@@ -16,7 +16,7 @@ export const siteMetadata: ISiteMetadata = {
   collaborator: ["enigmaz"],
   type: "private",
   schema: "Gazelle",
-  urls: ["https://passthepopcorn.me/"],
+  urls: ["uggcf://cnffgurcbcpbea.zr/"],
 
   // 搜索分类
   category: [

--- a/src/packages/site/definitions/playletpt.ts
+++ b/src/packages/site/definitions/playletpt.ts
@@ -19,7 +19,7 @@ export const siteMetadata: ISiteMetadata = {
 
   collaborator: ["端端"],
 
-  urls: ["https://playletpt.xyz/"],
+  urls: ["uggcf://cynlyrgcg.klm/"],
 
   category: [CategoryIncldead, CategorySpstate, CategoryInclbookmarked],
 

--- a/src/packages/site/definitions/pornbits.ts
+++ b/src/packages/site/definitions/pornbits.ts
@@ -9,7 +9,7 @@ export const siteMetadata: ISiteMetadata = {
 
   type: "private",
 
-  urls: ["https://pornbits.net/"],
+  urls: ["uggcf://cbeaovgf.arg/"],
 
   // refs: https://github.com/pt-plugins/PT-Plugin-Plus/commit/fc106917a4a9b5834633e5d4903912e02846235f
   isDead: true,

--- a/src/packages/site/definitions/pt99.ts
+++ b/src/packages/site/definitions/pt99.ts
@@ -10,7 +10,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://pt.j99.info/"],
+  urls: ["uggcf://cg.w99.vasb/"],
 
   favicon: "./_default_nexusphp.png", // 实在找不到favicon了
 

--- a/src/packages/site/definitions/ptdream.ts
+++ b/src/packages/site/definitions/ptdream.ts
@@ -11,7 +11,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP", // meanTorrent
 
-  urls: ["https://www.ptdream.net/", "https://plus.ptdream.net/"],
+  urls: ["uggcf://jjj.cgqernz.arg/", "uggcf://cyhf.cgqernz.arg/"],
 
   // refs: https://github.com/pt-plugins/PT-Plugin-Plus/commit/db87ee0843f474d31edb84bbe92f82dafb3236ad
   isDead: true,

--- a/src/packages/site/definitions/pter.ts
+++ b/src/packages/site/definitions/pter.ts
@@ -27,7 +27,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://pterclub.com/"],
+  urls: ["uggcf://cgrepoho.pbz/"],
   formerHosts: ["pter.club"],
 
   category: [

--- a/src/packages/site/definitions/ptgtk.ts
+++ b/src/packages/site/definitions/ptgtk.ts
@@ -17,7 +17,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://pt.gtkpw.xyz/", "https://pt.gtk.pw/"],
+  urls: ["uggcf://cg.tgxcj.klm/", "uggcf://cg.tgx.cj/"],
 
   category: [
     {

--- a/src/packages/site/definitions/ptlsp.ts
+++ b/src/packages/site/definitions/ptlsp.ts
@@ -12,7 +12,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://www.ptlsp.com/"],
+  urls: ["uggcf://jjj.cgyfc.pbz/"],
   host: "ptlsp.com",
 
   // refs: https://github.com/pt-plugins/PT-Plugin-Plus/commit/ef7a885c052a9dc23286fb54e33dbef3dd9431ed

--- a/src/packages/site/definitions/ptmsg.ts
+++ b/src/packages/site/definitions/ptmsg.ts
@@ -11,7 +11,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://pt.msg.vg/"],
+  urls: ["uggcf://cg.zft.it/"],
 
   // refs: https://github.com/pt-plugins/PT-Plugin-Plus/commit/7d821a0c57f4720604113960913211306ebc7952
   isDead: true,

--- a/src/packages/site/definitions/ptneko.ts
+++ b/src/packages/site/definitions/ptneko.ts
@@ -12,7 +12,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://ptneko.com/"],
+  urls: ["uggcf://cgarxb.pbz/"],
 
   category: [CategoryIncldead, CategorySpstate, CategoryInclbookmarked],
 

--- a/src/packages/site/definitions/ptvicomo.ts
+++ b/src/packages/site/definitions/ptvicomo.ts
@@ -19,7 +19,7 @@ export const siteMetadata: ISiteMetadata = {
 
   collaborator: ["AllenPu"],
 
-  urls: ["https://ptvicomo.net/"],
+  urls: ["uggcf://cgivpbzb.arg/"],
 
   category: [
     {

--- a/src/packages/site/definitions/qingyingpt.ts
+++ b/src/packages/site/definitions/qingyingpt.ts
@@ -11,7 +11,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://hitpt.org/"],
+  urls: ["uggcf://uvgcg.bet/"],
 
   // refs: https://github.com/pt-plugins/PT-Plugin-Plus/commit/d5b58d2dba5286a1e35205f1c8ad37d3e8f22f9f
   isDead: true,

--- a/src/packages/site/definitions/raingfh.ts
+++ b/src/packages/site/definitions/raingfh.ts
@@ -17,7 +17,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://raingfh.top/"],
+  urls: ["uggcf://envatsu.gbc/"],
 
   category: [
     {

--- a/src/packages/site/definitions/sanpro.ts
+++ b/src/packages/site/definitions/sanpro.ts
@@ -10,7 +10,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "Gazelle",
 
-  urls: ["https://sanpro.pw/"],
+  urls: ["uggcf://fnaceb.cj/"],
 
   isDead: true,
 

--- a/src/packages/site/definitions/sewerpt.ts
+++ b/src/packages/site/definitions/sewerpt.ts
@@ -19,7 +19,7 @@ export const siteMetadata: ISiteMetadata = {
 
   collaborator: ["sewerpt"],
 
-  urls: ["https://sewerpt.com/"],
+  urls: ["uggcf://frjrecg.pbz/"],
 
   category: [CategoryIncldead, CategorySpstate, CategoryInclbookmarked],
 

--- a/src/packages/site/definitions/sharkpt.ts
+++ b/src/packages/site/definitions/sharkpt.ts
@@ -10,7 +10,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://sharkpt.net/"],
+  urls: ["uggcf://funexcg.arg/"],
 
   isDead: true,
 

--- a/src/packages/site/definitions/sjtu.ts
+++ b/src/packages/site/definitions/sjtu.ts
@@ -22,7 +22,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://pt.sjtu.edu.cn/"],
+  urls: ["uggcf://cg.fwgh.rqh.pa/"],
 
   category: [
     {

--- a/src/packages/site/definitions/snakepop.ts
+++ b/src/packages/site/definitions/snakepop.ts
@@ -10,7 +10,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "GazelleJSONAPI",
 
-  urls: ["https://snakepop.art/"],
+  urls: ["uggcf://fanxrcbc.neg/"],
 
   // NOTE 这个站实在没有找到 favicon
 

--- a/src/packages/site/definitions/stspt.ts
+++ b/src/packages/site/definitions/stspt.ts
@@ -10,7 +10,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://www.sts.tw/"],
+  urls: ["uggcf://jjj.fgf.gj/"],
 
   favicon: "./_default_nexusphp.png", // 实在找不到favicon了
 

--- a/src/packages/site/definitions/tmpt.ts
+++ b/src/packages/site/definitions/tmpt.ts
@@ -14,7 +14,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://tmpt.top/"],
+  urls: ["uggcf://gzcg.gbc/"],
 
   levelRequirements: [
     {

--- a/src/packages/site/definitions/torrentleech.ts
+++ b/src/packages/site/definitions/torrentleech.ts
@@ -79,11 +79,11 @@ export const siteMetadata: ISiteMetadata = {
   schema: "AbstractPrivateSite",
 
   urls: [
-    "https://www.torrentleech.org/",
-    "https://www.torrentleech.cc/",
-    "https://www.torrentleech.me/",
-    "https://www.tleechreload.org/",
-    "https://www.tlgetin.cc/",
+    "uggcf://jjj.gbeerapgyrrpu.bet/",
+    "uggcf://jjj.gbeerapgyrrpu.pp/",
+    "uggcf://jjj.gbeerapgyrrpu.zr/",
+    "uggcf://jjj.gyrrapuerybnq.bet/",
+    "uggcf://jjj.gytrgva.pp/",
   ],
 
   category: [

--- a/src/packages/site/definitions/tosky.ts
+++ b/src/packages/site/definitions/tosky.ts
@@ -9,7 +9,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://t.tosky.club/"],
+  urls: ["uggcf://g.gbfxl.pyho/"],
 
   isDead: true,
 

--- a/src/packages/site/definitions/totheglory.ts
+++ b/src/packages/site/definitions/totheglory.ts
@@ -55,7 +55,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "AbstractPrivateSite",
 
-  urls: ["https://totheglory.im/"],
+  urls: ["uggcf://gbguryrbel.vz/"],
   category: [
     {
       name: "分类入口",

--- a/src/packages/site/definitions/u2.ts
+++ b/src/packages/site/definitions/u2.ts
@@ -12,7 +12,7 @@ export const siteMetadata: ISiteMetadata = {
 
   schema: "NexusPHP",
   type: "private",
-  urls: ["https://u2.dmhy.org/"],
+  urls: ["uggcf://h2.qzul.bet/"],
 
   category: [
     {

--- a/src/packages/site/definitions/ubits.ts
+++ b/src/packages/site/definitions/ubits.ts
@@ -18,7 +18,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://ubits.club/"],
+  urls: ["uggcf://hovgf.pyho/"],
   category: [
     {
       name: "类型",

--- a/src/packages/site/definitions/uhdbits.ts
+++ b/src/packages/site/definitions/uhdbits.ts
@@ -16,7 +16,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "GazelleJSONAPI",
 
-  urls: ["https://uhdbits.org/"],
+  urls: ["uggcf://huqovgf.bet/"],
 
   category: [
     {
@@ -124,7 +124,8 @@ export const siteMetadata: ISiteMetadata = {
       downloaded: "100GB",
       downloads: "20",
       ratio: 1.5,
-      privilege: "Ability to make New Requests; Enable Users online and Users on IRC on front page; Access to full Staff page.",
+      privilege:
+        "Ability to make New Requests; Enable Users online and Users on IRC on front page; Access to full Staff page.",
     },
     {
       id: 3,

--- a/src/packages/site/definitions/ultrahd.ts
+++ b/src/packages/site/definitions/ultrahd.ts
@@ -17,7 +17,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://ultrahd.net/"],
+  urls: ["uggcf://hygenuq.arg/"],
 
   category: [
     {

--- a/src/packages/site/definitions/whupt.ts
+++ b/src/packages/site/definitions/whupt.ts
@@ -10,7 +10,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://whu.pt/"],
+  urls: ["uggcf://juh.cg/"],
 
   isDead: true, // 于 2019年12月31日正式关站
 };

--- a/src/packages/site/definitions/wukongwendao.ts
+++ b/src/packages/site/definitions/wukongwendao.ts
@@ -11,7 +11,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://wukongwendao.top/", "https://wukongwendao.top/"],
+  urls: ["uggcf://jhxbatjraqnb.gbc/", "uggcf://jhxbatjraqnb.gbc/"],
 
   isDead: true,
 

--- a/src/packages/site/definitions/xauat6.ts
+++ b/src/packages/site/definitions/xauat6.ts
@@ -14,7 +14,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["http://pt.xauat6.edu.cn/"],
+  urls: ["uggc://cg.knhng6.rqh.pa/"],
 
   isDead: true,
 

--- a/src/packages/site/definitions/xingyunge.ts
+++ b/src/packages/site/definitions/xingyunge.ts
@@ -13,7 +13,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://pt.xingyungept.org/", "https://xingyunge.top/"],
+  urls: ["uggcf://cg.kvatlhatrcg.bet/", "uggcf://kvatlhatr.gbc/"],
 
   levelRequirements: [
     {

--- a/src/packages/site/definitions/ydypt.ts
+++ b/src/packages/site/definitions/ydypt.ts
@@ -11,7 +11,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://pt.hdbd.us/"],
+  urls: ["uggcf://cg.uqoq.hf/"],
 
   isDead: true,
 };

--- a/src/packages/site/definitions/yemapt.ts
+++ b/src/packages/site/definitions/yemapt.ts
@@ -111,7 +111,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "YemaPT",
 
-  urls: ["https://www.yemapt.org/"],
+  urls: ["uggcf://jjj.lrzncg.bet/"],
 
   category: [
     {

--- a/src/packages/site/definitions/yingk.ts
+++ b/src/packages/site/definitions/yingk.ts
@@ -10,7 +10,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://yingk.com/"],
+  urls: ["uggcf://lvatx.pbz/"],
 
   // refs: https://github.com/pt-plugins/PT-Plugin-Plus/commit/2c9591371523ad237f5c6f34335cb118738ea9ba
   isDead: true,

--- a/src/packages/site/definitions/zhixing.ts
+++ b/src/packages/site/definitions/zhixing.ts
@@ -16,7 +16,7 @@ export const siteMetadata: ISiteMetadata = {
 
   type: "private",
   schema: "CGBTSource",
-  urls: ["http://pt.zhixing.bjtu.edu.cn/"],
+  urls: ["uggc://cg.muvkhat.owgh.rqh.pa/"],
 
   category: [
     {


### PR DESCRIPTION
- Fix all http:// and https:// URLs in site definition files to use rot13 encoding
- Ensures consistency across all site definitions (uggc:// and uggcf://)
- Addresses security requirement for URL obfuscation in site metadata
- Updated 90+ site definition files