### PR TITLE
Update 13city.ts

### DIFF
--- a/src/packages/site/definitions/13city.ts
+++ b/src/packages/site/definitions/13city.ts
@@ -15,6 +15,16 @@ export const siteMetadata: ISiteMetadata = {
   schema: "NexusPHP",
   urls: ["https://13city.org/"],
   formerHosts: ["13city.online"],
+  userInfo: {
+    ...SchemaMetadata.userInfo!,
+    selectors: {
+      ...SchemaMetadata.userInfo!.selectors!,
+      bonus: {
+        selector: ["td.rowhead:contains('啤酒瓶') + td, td.rowhead:contains('Karma Points') + td"],
+        filters: [{ name: "parseNumber" }],
+      },
+    },
+  },
   category: [
     {
       name: "分类",


### PR DESCRIPTION
修复站点魔力值改为啤酒瓶后PT-depiler魔力值不显示问题