### PR TITLE
Fix/hhanclub-free-selector

### DIFF
--- a/src/entries/options/stores/config.ts
+++ b/src/entries/options/stores/config.ts
@@ -163,6 +163,7 @@ export const useConfigStore = defineStore("config", {
       },
       showDeadSiteInOverview: false,
       showPassedSiteInOverview: false,
+      autoExtendCookie: false,
     },
 
     download: {

--- a/src/entries/options/views/Settings/SetBase/UserInfoWindow.vue
+++ b/src/entries/options/views/Settings/SetBase/UserInfoWindow.vue
@@ -121,6 +121,12 @@ onMounted(async () => {
         color="success"
         hide-details
       />
+      <v-switch
+        v-model="configStore.userInfo.autoExtendCookie"
+        :label="t('userInfo.autoExtendCookie')"
+        color="success"
+        hide-details
+      />
     </v-col>
   </v-row>
 </template>

--- a/src/entries/shared/types/storages/config.ts
+++ b/src/entries/shared/types/storages/config.ts
@@ -152,6 +152,8 @@ export interface IConfigPiniaStorageSchema {
     showDeadSiteInOverview: boolean;
     // 是否在概览中展示已被标记为离线 （isOffline） 或不允许查询用户信息 （ allowQueryUserInfo === false ） 的站点
     showPassedSiteInOverview: boolean;
+    // 是否自动延长即将过期的cookie
+    autoExtendCookie: boolean;
   };
 
   download: {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -586,7 +586,8 @@
       "nextFlushTime": "Next refresh time:"
     },
     "showDeadSite": "Show sites marked as dead (isDead) in the overview",
-    "showPassedSite": "Show sites marked as offline (isOffline) or not allowing user info query in the overview"
+    "showPassedSite": "Show sites marked as offline (isOffline) or not allowing user info query in the overview",
+    "autoExtendCookie": "Auto-extend expiring site cookies (extend to 90 days when less than 7 days remain, applies to selected sites only)"
   },
   "ptppSettings": {
     "basicConfig": "Basic Configuration",

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -583,7 +583,8 @@
       "nextFlushTime": "下一次刷新时间:"
     },
     "showDeadSite": "在概览中展示已被标记为死亡 （isDead） 的站点",
-    "showPassedSite": "在概览中展示已被标记为离线 （isOffline） 或不允许查询用户信息的站点"
+    "showPassedSite": "在概览中展示已被标记为离线 （isOffline） 或不允许查询用户信息的站点",
+    "autoExtendCookie": "自动延长即将过期的站点Cookie（少于7天时延长至90天，功能只对部分站点有效）"
   },
   "ptppSettings": {
     "basicConfig": "基本配置",

--- a/src/packages/site/definitions/hhanclub.ts
+++ b/src/packages/site/definitions/hhanclub.ts
@@ -175,6 +175,7 @@ export const siteMetadata: ISiteMetadata = {
       },
       tags: [
         ...SchemaMetadata.search!.selectors!.tags!,
+        { name: "Free", selector: "span.promotion-tag-free", color: "blue" },
         { name: "官方", selector: "a[href*='tag_id3=1']", color: "#0000ff" },
         { name: "完结", selector: "a[href*='tag_id17=1']", color: "#4682B4" },
         { name: "原创", selector: "a[href*='tag_id8=1']", color: "#ff3300" },


### PR DESCRIPTION
- 将 Free 标签选择器从默认的 img.pro_free 更改为 span.promotion-tag-free
- 适配憨憨站点的实际 DOM 结构
- 保持蓝色配色与默认配置一致