### PR TITLE
fix(憨憨): 修复Free标签选择器

### DIFF
--- a/src/packages/site/definitions/hhanclub.ts
+++ b/src/packages/site/definitions/hhanclub.ts
@@ -175,6 +175,7 @@ export const siteMetadata: ISiteMetadata = {
       },
       tags: [
         ...SchemaMetadata.search!.selectors!.tags!,
+        { name: "Free", selector: "span.promotion-tag-free", color: "blue" },
         { name: "官方", selector: "a[href*='tag_id3=1']", color: "#0000ff" },
         { name: "完结", selector: "a[href*='tag_id17=1']", color: "#4682B4" },
         { name: "原创", selector: "a[href*='tag_id8=1']", color: "#ff3300" },


### PR DESCRIPTION
- 将Free标签选择器从默认的 img.pro_free 改为 span.promotion-tag-free
- 针对HhanClub站点的实际DOM结构进行适配
- 确保Free促销标签能够正确识别和显示