### PR TITLE
fix: 修复SetBackup页面enabled列翻译问题

### DIFF
--- a/src/entries/options/views/Settings/SetBackup/Index.vue
+++ b/src/entries/options/views/Settings/SetBackup/Index.vue
@@ -34,7 +34,7 @@ const fullTableHeader = [
   { title: t("SetBackup.table.name"), key: "name", align: "start" },
   { title: t("SetBackup.table.backupFields"), key: "backupFields", align: "start", sortable: false },
   { title: t("SetBackup.table.lastBackupAt"), key: "lastBackupAt", align: "end" },
-  { title: t("SetBackup.index.table.enabled"), key: "enabled", align: "center" },
+  { title: t("SetBackup.table.enabled"), key: "enabled", align: "center" },
   { title: t("common.action"), key: "action", sortable: false },
 ] as DataTableHeader[];
 const tableSelected = ref<TBackupServerKey[]>([]);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -562,7 +562,8 @@
       "name": "Name",
       "backupFields": "Backup Content",
       "lastBackupAt": "Last Backup Time",
-      "notBackup": "Not Backed Up"
+      "notBackup": "Not Backed Up",
+      "enabled": "Enabled"
     },
     "localExport": "Local Export",
     "localImport": "Local Import",

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -559,7 +559,8 @@
       "name": "名称",
       "backupFields": "备份内容",
       "lastBackupAt": "最近一次备份时间",
-      "notBackup": "未备份"
+      "notBackup": "未备份",
+      "enabled": "启用"
     },
     "localExport": "本地导出",
     "localImport": "本地导入",


### PR DESCRIPTION
- 将翻译键从 SetBackup.index.table.enabled 简化为 SetBackup.table.enabled
- 在英文和中文翻译文件中添加对应的翻译