### PR TITLE
feat: 重构 SetBase 标签页逻辑并修复路由问题

### DIFF
--- a/src/entries/options/views/Settings/SetBackup/RestoreDialog.vue
+++ b/src/entries/options/views/Settings/SetBackup/RestoreDialog.vue
@@ -4,6 +4,7 @@ import { ref, shallowRef } from "vue";
 import { isEmpty } from "es-toolkit/compat";
 import { jsZipBlobToBackupData } from "@ptd/backupServer/utils.ts";
 import type { IBackupData } from "@ptd/backupServer";
+import { useRouter } from "vue-router";
 
 import { useConfigStore } from "@/options/stores/config.ts";
 import { useRuntimeStore } from "@/options/stores/runtime.ts";
@@ -12,6 +13,7 @@ import { BackupFields, type TBackupFields, type IRestoreOptions } from "@/shared
 
 const showDialog = defineModel<boolean>();
 const { t } = useI18n();
+const router = useRouter();
 
 type TRestoreMetaData = { type: "file" } | { type: "remote"; server: string; path: string };
 
@@ -193,6 +195,11 @@ function resetDialog() {
     loadRemoteBackupFile();
   }
 }
+
+function goToPtppImport() {
+  router.push({ name: "SetBaseBackup" });
+  showDialog.value = false;
+}
 </script>
 
 <template>
@@ -205,6 +212,14 @@ function resetDialog() {
       </v-card-title>
       <v-divider />
       <v-card-text>
+        <v-alert class="mb-3" type="info" variant="tonal">
+          <div class="d-flex align-center justify-space-between">
+            <span>需要导入 PT-Plugin-Plus 备份？</span>
+            <v-btn color="primary" size="small" variant="outlined" prepend-icon="mdi-import" @click="goToPtppImport">
+              PT-Plugin-Plus 备份导入
+            </v-btn>
+          </div>
+        </v-alert>
         <v-window v-model="currentStep">
           <v-window-item value="file" eager>
             <v-file-input

--- a/src/entries/options/views/Settings/SetBase/Index.vue
+++ b/src/entries/options/views/Settings/SetBase/Index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { computed, ref, useTemplateRef } from "vue";
+import { computed, useTemplateRef } from "vue";
 import { useI18n } from "vue-i18n";
-import { useRoute, useRouter, type RouteRecordRaw } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 
 import { setBaseChildren } from "@/options/plugins/router.ts";
 import { useConfigStore } from "@/options/stores/config.ts";

--- a/src/entries/options/views/Settings/SetBase/Index.vue
+++ b/src/entries/options/views/Settings/SetBase/Index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { ref, useTemplateRef } from "vue";
+import { computed, ref, useTemplateRef } from "vue";
 import { useI18n } from "vue-i18n";
-import { useRouter } from "vue-router";
+import { useRoute, useRouter, type RouteRecordRaw } from "vue-router";
 
 import { setBaseChildren } from "@/options/plugins/router.ts";
 import { useConfigStore } from "@/options/stores/config.ts";
@@ -9,6 +9,7 @@ import { useRuntimeStore } from "@/options/stores/runtime.ts";
 
 const { t } = useI18n();
 const router = useRouter();
+const route = useRoute();
 const configStore = useConfigStore();
 const runtimeStore = useRuntimeStore();
 
@@ -18,12 +19,16 @@ const setBaseTabs = setBaseChildren.map((x) => ({
   icon: x.meta!.icon,
 }));
 
-const setTab = ref<string>("");
 const setTabRef = useTemplateRef<{ beforeSave?: () => Promise<void>; afterSave?: () => Promise<void> }>("setTabRef");
 
-function enterTab(routeName: string) {
-  router.push({ name: routeName });
-}
+const activeTab = computed({
+  get() {
+    return route.name;
+  },
+  set(newRouteName) {
+    router.push({ name: newRouteName });
+  },
+});
 
 async function save() {
   await setTabRef.value?.beforeSave?.(); // 如果对应的 tab 有 afterSave 方法，则调用
@@ -35,35 +40,29 @@ async function save() {
 
 <template>
   <v-card>
-    <v-tabs
-      v-model="setTab"
-      align-tabs="center"
-      bg-color="primary"
-      show-arrows
-      stacked
-      @update:model-value="(v) => enterTab(v as string)"
-    >
+    <v-tabs v-model="activeTab" align-tabs="center" bg-color="primary" show-arrows stacked>
       <v-tab v-for="tab in setBaseTabs" :key="tab.key as string" :value="tab.route">
         <v-icon :icon="tab.icon as string" />
         {{ t(`SetBase.tab.${tab.key}`) }}
       </v-tab>
     </v-tabs>
-
-    <v-card>
-      <v-card-text>
-        <router-view v-slot="{ Component }">
-          <component :is="Component" ref="setTabRef" />
-        </router-view>
-      </v-card-text>
-      <v-divider />
-      <v-card-actions>
-        <v-row class="ml-2 my-1">
-          <v-btn color="green" prepend-icon="mdi-check-circle-outline" variant="elevated" @click="save">
-            {{ t("common.save") }}
-          </v-btn>
-        </v-row>
-      </v-card-actions>
-    </v-card>
+    <v-window v-model="activeTab">
+      <v-card>
+        <v-card-text>
+          <router-view v-slot="{ Component }">
+            <component :is="Component" ref="setTabRef" />
+          </router-view>
+        </v-card-text>
+        <v-divider />
+        <v-card-actions>
+          <v-row class="ml-2 my-1">
+            <v-btn color="green" prepend-icon="mdi-check-circle-outline" variant="elevated" @click="save">
+              {{ t("common.save") }}
+            </v-btn>
+          </v-row>
+        </v-card-actions>
+      </v-card>
+    </v-window>
   </v-card>
 </template>
 


### PR DESCRIPTION
重构 SetBase/Index.vue，使用计算属性 activeTab 来处理标签页导航，简化了代码逻辑，并确保在直接导航时能正确激活标签页。
在 RestoreDialog.vue 中添加了到 PT-Plugin-Plus 备份导入页面的链接，并修复了相关的路由跳转逻辑。

<img width="1393" height="670" alt="image" src="https://github.com/user-attachments/assets/767d081b-20b1-4278-b415-631cc753105f" />
