### PR TITLE
fix(pkg/site): 修复opencd详情页无content-script完整功能

### DIFF
--- a/src/packages/site/definitions/opencd.ts
+++ b/src/packages/site/definitions/opencd.ts
@@ -253,7 +253,6 @@ export const siteMetadata: ISiteMetadata = {
     urlPattern: ["/plugin_details.php"],
       
     selectors: {
-      ...SchemaMetadata.detail!.selectors!,
       id: {
         selector: ":self",
         elementProcess: (element: Document) => {

--- a/src/packages/site/definitions/opencd.ts
+++ b/src/packages/site/definitions/opencd.ts
@@ -1,5 +1,10 @@
-import { ETorrentStatus, type IElementQuery, type ISiteMetadata } from "../types";
-import { CategoryInclbookmarked, CategoryIncldead, CategorySpstate, SchemaMetadata } from "../schemas/NexusPHP.ts";
+import { ETorrentStatus, type IElementQuery, type ITorrent, type ISiteMetadata } from "../types";
+import NexusPHP, {
+  CategoryInclbookmarked,
+  CategoryIncldead,
+  CategorySpstate,
+  SchemaMetadata,
+} from "../schemas/NexusPHP.ts";
 
 // OpenCD 中的部分选择器和处理方法被其他站公用
 export const selectorSearchProgress: IElementQuery = {
@@ -30,6 +35,7 @@ export const siteMetadata: ISiteMetadata = {
   version: 1,
   id: "opencd",
   name: "OpenCD",
+  aka: ["皇后"],
   description: "皇后，专一的音乐类PT站，是目前国内最大的无损音乐PT",
   tags: ["音乐"],
 
@@ -242,6 +248,36 @@ export const siteMetadata: ISiteMetadata = {
     },
   },
 
+  detail: {
+    // 该站详情页为 /plugin_details.php?id=数字
+    urlPattern: ["/plugin_details.php"],
+      
+    selectors: {
+      ...SchemaMetadata.detail!.selectors!,
+      id: {
+        selector: ":self",
+        elementProcess: (element: Document) => {
+          // 从 URL 中获取 ID，例如 /plugin_details.php?id=179082
+          const url = element.URL;
+          const idMatch = url.match(/id=(\d+)/);
+          if (idMatch && idMatch.length >= 2) {
+            return idMatch[1];
+          }
+          return undefined;
+        },
+      },
+      title: {
+        // 音乐站title不适合作为搜索词
+        selector: 'td.rowtitle:contains("專輯名稱：") + td',
+        attr: "title",
+      },
+      link: {
+        selector: ['a[href*="download.php?id="][href*="&passkey="]'],
+        attr: "href"
+      },
+    },
+  },
+
   levelRequirements: [
     {
       id: 1,
@@ -315,10 +351,25 @@ export const siteMetadata: ISiteMetadata = {
       alternative: [{ downloaded: "3TB" }, { uploads: 600 }],
       privilege: "得到十个邀请名额。",
     },
-    {
-      id: 100,
-      name: "貴賓(VIP)",
-      groupType: "vip",
-    },
+    { id: 100, name: "貴賓(VIP)", groupType: "vip" },
+    { id: 101, name: "養老族", groupType: "vip" },
+    { id: 201, name: "保種員", groupType: "manager" },
+    { id: 202, name: "發布員", groupType: "manager" },
+    { id: 203, name: "工作人員", groupType: "manager" },
+    { id: 204, name: "管理员", groupType: "manager" },
+    { id: 205, name: "論壇版主", groupType: "manager" },
+    { id: 206, name: "總版主", groupType: "manager" },
+    { id: 207, name: "維護開发員", groupType: "manager" },
   ],
 };
+
+export default class OpenCD extends NexusPHP {
+  public override async getTorrentDownloadLink(torrent: ITorrent): Promise<string> {
+    // 对 OpenCD 站点，种子详情页为 /plugin_details.php?id=123 的形式
+    if (torrent.link && torrent.link.includes("/plugin_details.php")) {
+      return torrent.link.replace(/plugin_details\.php\?id=(\d+)/, "download.php?id=$1").replace(/&hit=1/, ""); // hit=1 是为了统计下载次数
+    }
+
+    return super.getTorrentDownloadLink(torrent);
+  }
+}

--- a/src/packages/site/definitions/ultrahd.ts
+++ b/src/packages/site/definitions/ultrahd.ts
@@ -14,7 +14,7 @@ export const siteMetadata: ISiteMetadata = {
   version: 1,
   id: "ultrahd",
   name: "UltraHD",
-  description: "纯韩影韩剧韩音综的韩语综合站",
+  description: "专注韩语语种内容，包含韩影、韩剧、韩综、动漫以及纪录片",
   tags: ["电影", "电视剧", "综艺", "纪录片", "动漫"],
   timezoneOffset: "+0800",
 

--- a/src/packages/site/definitions/ultrahd.ts
+++ b/src/packages/site/definitions/ultrahd.ts
@@ -1,5 +1,12 @@
-import { type ISiteMetadata } from "../types";
-import { CategoryInclbookmarked, CategoryIncldead, CategorySpstate, SchemaMetadata } from "../schemas/NexusPHP";
+import {
+  type ISiteMetadata
+} from "../types";
+import {
+  CategoryInclbookmarked,
+  CategoryIncldead,
+  CategorySpstate,
+  SchemaMetadata,
+} from "../schemas/NexusPHP.ts";
 
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,
@@ -7,7 +14,7 @@ export const siteMetadata: ISiteMetadata = {
   version: 1,
   id: "ultrahd",
   name: "UltraHD",
-  description: "韩剧",
+  description: "纯韩影韩剧韩音综的韩语综合站",
   tags: ["电影", "电视剧", "综艺", "纪录片", "动漫"],
   timezoneOffset: "+0800",
 
@@ -194,22 +201,5 @@ export const siteMetadata: ISiteMetadata = {
       seedingBonus: 1500000,
       privilege: "得到两个邀请名额",
     },
-    {
-      id: 100,
-      name: "贵宾(VIP)",
-      groupType: "vip",
-      privilege: "和Nexus Master拥有相同权限并被认为是精英成员。免除自动降级",
-    },
-    {
-      id: 200,
-      name: "养老族",
-      groupType: "manager",
-      privilege: "退休后的管理组成员",
-    },
-    { id: 201, name: "发布员", groupType: "manager" },
-    { id: 202, name: "总版主", groupType: "manager" },
-    { id: 203, name: "管理员", groupType: "manager" },
-    { id: 204, name: "维护开发员", groupType: "manager" },
-    { id: 205, name: "主管", groupType: "manager" },
   ],
 };


### PR DESCRIPTION
同时发现一个问题 可能是站点nphp版本较老的缘故 种子列表页(torrents.php)的下载按钮是不完整的 即`download.php?id=12345` 不带passkey的下载链接导致导出链接和批量功能不可用于下载器 也会影响到插件搜索结果的链接

目前想到方案：
1.  _userInputSettingsMeta_ 有感输入
2.  _[中间层提供实例缓存运行配置等功能](https://github.com/pt-plugins/PT-depiler/commit/d81bb01a98b618e029d776de3d37d03f8b2ecb11)_ 无感获取