### PR TITLE
feat(i18n): 完善媒体库与下载相关页面多语言，修正部分 key 路径

### DIFF
--- a/src/entries/options/views/Overview/MediaServerEntity/Index.vue
+++ b/src/entries/options/views/Overview/MediaServerEntity/Index.vue
@@ -215,7 +215,7 @@ onMounted(async () => {
       </div>
     </div>
     <v-row v-else>
-      <v-col class="d-flex justify-center text-body-1"> No Items, use Search Input or Load More Button to Load </v-col>
+      <v-col class="d-flex justify-center text-body-1">{{ t("MediaServerEntity.noItems") }}</v-col>
     </v-row>
 
     <!-- TODO 点击加载更多 -->
@@ -227,7 +227,7 @@ onMounted(async () => {
             :loading="runtimeStore.mediaServerSearch.isSearching"
             @click="() => doSearch({ searchKey: search, loadMore: true })"
           >
-            Load More
+            {{ t("MediaServerEntity.loadMore") }}
           </v-btn>
         </v-col>
       </v-row>

--- a/src/entries/options/views/Overview/MyData/Index.vue
+++ b/src/entries/options/views/Overview/MyData/Index.vue
@@ -521,11 +521,17 @@ function viewStatistic() {
 
       <!-- 做种数， H&R 情况  -->
       <template #item.seeding="{ item }">
-        <v-container>
+        <v-container
+          v-if="
+            configStore.myDataTableControl.showHnR &&
+            ((typeof item.hnrPreWarning !== 'undefined' && item.hnrPreWarning > 0) ||
+              (typeof item.hnrUnsatisfied !== 'undefined' && item.hnrUnsatisfied > 0))
+          "
+        >
           <v-row align="center" class="flex-nowrap" justify="end">
             <span class="text-no-wrap">{{ item.seeding ?? "-" }}</span>
           </v-row>
-          <v-row v-if="configStore.myDataTableControl.showHnR" align="center" class="flex-nowrap" justify="end">
+          <v-row align="center" class="flex-nowrap" justify="end">
             <span
               v-if="typeof item.hnrPreWarning !== 'undefined' && item.hnrPreWarning > 0"
               class="d-inline-flex align-center ml-2"
@@ -556,6 +562,7 @@ function viewStatistic() {
             </span>
           </v-row>
         </v-container>
+        <span v-else class="text-no-wrap">{{ item.seeding ?? "-" }}</span>
       </template>
 
       <!-- 做种量 -->
@@ -567,25 +574,22 @@ function viewStatistic() {
 
       <!-- 魔力/积分 -->
       <template #item.bonus="{ item }">
-        <v-container>
+        <v-container
+          v-if="
+            configStore.myDataTableControl.showSeedingBonus &&
+            item.seedingBonus !== '' &&
+            !isUndefined(item.seedingBonus)
+          "
+        >
           <v-row align="center" class="flex-nowrap" justify="end">
-            <v-icon :title="t('levelRequirement.bonus')" color="green-darken-4" icon="mdi-currency-usd" size="small" />
+            <v-icon title="t('levelRequirement.bonus')" color="green-darken-4" icon="mdi-currency-usd" size="small" />
             <span class="text-no-wrap">
               {{ typeof item.bonus !== "undefined" ? formatNumber(item.bonus) : "-" }}
             </span>
           </v-row>
-          <v-row
-            v-if="
-              configStore.myDataTableControl.showSeedingBonus &&
-              item.seedingBonus !== '' &&
-              !isUndefined(item.seedingBonus)
-            "
-            align="center"
-            class="flex-nowrap"
-            justify="end"
-          >
+          <v-row align="center" class="flex-nowrap" justify="end">
             <v-icon
-              :title="t('levelRequirement.seedingBonus')"
+              title="t('levelRequirement.seedingBonus')"
               color="green-darken-4"
               icon="mdi-lightning-bolt-circle"
               size="small"
@@ -595,6 +599,12 @@ function viewStatistic() {
             </span>
           </v-row>
         </v-container>
+        <template v-else>
+          <v-icon title="t('levelRequirement.bonus')" color="green-darken-4" icon="mdi-currency-usd" size="small" />
+          <span class="text-no-wrap">
+            {{ typeof item.bonus !== "undefined" ? formatNumber(item.bonus) : "-" }}
+          </span>
+        </template>
       </template>
 
       <template #item.bonusPerHour="{ item }">

--- a/src/entries/options/views/Settings/SetBase/DownloadWindow.vue
+++ b/src/entries/options/views/Settings/SetBase/DownloadWindow.vue
@@ -37,11 +37,11 @@ async function clearLastDownloader(v: boolean) {
         :label="t('SetBase.download.localDownloadMethod')"
         :items="
           LocalDownloadMethod.map((item) => ({
-            title: t(`SetBase.download.localDownloadMethod.${item}`),
+            title: t(`SetBase.download.localDownloadMethodOptions.${item}`),
             value: item,
           }))
         "
-        :hint="t(`SetBase.download.localDownloadMethod.${configStore.download.localDownloadMethod}Tip`)"
+        :hint="t(`SetBase.download.localDownloadMethodOptions.${configStore.download.localDownloadMethod}Tip`)"
         persistent-hint
       />
       <v-switch

--- a/src/entries/options/views/Settings/SetDownloader/Index.vue
+++ b/src/entries/options/views/Settings/SetDownloader/Index.vue
@@ -240,7 +240,7 @@ async function confirmDeleteDownloader(downloaderId: TDownloaderKey) {
 
           <!-- 该下载服务器下载路径和标签选择 -->
           <v-btn
-            :title="t('SetDownloader.index.table.setPathAndTag')"
+            :title="t('SetDownloader.index.table.action.setPathAndTag')"
             color="amber"
             icon="mdi-folder-settings"
             size="small"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -194,7 +194,9 @@
   },
   "MediaServerEntity": {
     "searchPlaceholder": "Search term",
-    "detail": "Details"
+    "detail": "Details",
+    "loadMore": "Load More",
+    "noItems": "No Items, use Search Input or Load More Button to Load"
   },
   "MyData": {
     "index": {
@@ -372,13 +374,14 @@
       "tableMultiSortNote": "Multi-column sorting: Click any table header field to start sorting, which will display the number \\\"1\\\" on the field. Click other fields sequentially to display \\\"2\\\", \\\"3\\\", indicating sorting priority. Click the same field again to toggle between ascending, descending, or cancel sorting. The sorting order is determined by these numbers, with smaller numbers having higher priority."
     },
     "download": {
-      "localDownloadMethod": {
+      "localDownloadMethod": "Local Download Method",
+      "localDownloadMethodOptions": {
         "web": "Web Page",
-        "webTip": "Open the page corresponding to the download link (only applicable to the simplest method; if conditions are not met, it will fall back to @:SetBase.download.localDownloadMethod.extension )",
+        "webTip": "Open the page corresponding to the download link (only applicable to the simplest method; if conditions are not met, it will fall back to @:SetBase.download.localDownloadMethodOptions.extension )",
         "browser": "Browser Method",
         "browserTip": "(RECOMMEND) Use the browser's download method provided by the extension to download directly",
         "extension": "Extension Proxy",
-        "extensionTip": "The extension downloads the torrent in the background and proxies it to @:SetBase.download.localDownloadMethod.browser for downloading"
+        "extensionTip": "The extension downloads the torrent in the background and proxies it to @:SetBase.download.localDownloadMethodOptions.browser for downloading"
       },
       "saveDownloadHistory": "Save download history (Please do not disable this function unless necessary)",
       "localDownloadTitle": "Local Download",

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -194,7 +194,9 @@
   },
   "MediaServerEntity": {
     "searchPlaceholder": "搜索词",
-    "detail": "详情"
+    "detail": "详情",
+    "loadMore": "加载更多",
+    "noItems": "暂无内容，请使用搜索框或点击加载更多按钮"
   },
   "MyData": {
     "index": {
@@ -372,13 +374,14 @@
       "tableMultiSortNote": "多列排序使用方法：点击任意表头字段开始排序，字段上会显示数字“1”。再点击其他字段，依次显示“2”“3”，表示排序优先级。再次点击相同字段可切换升序、降序或取消排序。排序顺序由这些数字决定，数字越小优先级越高。"
     },
     "download": {
-      "localDownloadMethod": {
+      "localDownloadMethod": "本地下载方式",
+      "localDownloadMethodOptions": {
         "web": "网页打开",
-        "webTip": "打开下载链接对应的页面（只适用于最简单的方式，如果不符合条件，则会回落到 @:SetBase.download.localDownloadMethod.extension ）",
+        "webTip": "打开下载链接对应的页面（只适用于最简单的方式，如果不符合条件，则会回落到 @:SetBase.download.localDownloadMethodOptions.extension ）",
         "browser": "浏览器方法",
         "browserTip": "（推荐）调用浏览器为插件提供的下载方法直接下载",
         "extension": "插件中转",
-        "extensionTip": "插件后台下载种子，并中转到 @:SetBase.download.localDownloadMethod.browser 进行下载"
+        "extensionTip": "插件后台下载种子，并中转到 @:SetBase.download.localDownloadMethodOptions.browser 进行下载"
       },
       "saveDownloadHistory": "是否保存下载历史（如非必要请勿关闭此功能）",
       "localDownloadTitle": "本地下载",


### PR DESCRIPTION
- MediaServerEntity 页面“暂无内容”“加载更多”提示改为多语言调用，补全中英文翻译
- MyData 页面做种数、魔力/积分等列的条件渲染逻辑优化
- SetBase 下载方式 select 及 hint 的多语言 key 路径统一
- SetDownloader 页面“设置路径和标签”按钮多语言 key 路径修正
- locales/en.json、zh_CN.json 补全相关字段，修正 key 路径