### PR TITLE
fix: 修复Unit3D站点bonus积分解析错误

### DIFF
--- a/src/packages/site/schemas/Unit3D.ts
+++ b/src/packages/site/schemas/Unit3D.ts
@@ -13,6 +13,7 @@ import { parseSizeString, parseValidTimeString } from "../utils";
 const idTrans: string[] = ["User ID", "用户 ID", "用ID", "用户ID"];
 const seedingSizeTrans: string[] = ["Seeding Size", "Seeding size", "做种体积", "做種體積"];
 const joinTimeTrans: string[] = ["Registration date", "注册日期", "註冊日期"];
+const averageSeedingTimeTrans: string[] = ["Average Seedtime", "Average seedtime", "平均做种时间", "平均做種時間"];
 
 export const SchemaMetadata: Partial<ISiteMetadata> = {
   version: 0,
@@ -261,6 +262,14 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
           ...seedingSizeTrans.map((x) => `dt:contains('${x}') + dd`),
         ],
         filters: [(query: string) => parseSizeString(query.replace(/,/g, ""))],
+      },
+      averageSeedingTime: {
+        // table.table-condensed:first
+        selector: [
+          ...averageSeedingTimeTrans.map((x) => `td:contains('${x}') + td`),
+          ...averageSeedingTimeTrans.map((x) => `dt:contains('${x}') + dd`),
+        ],
+        filters: [{ name: "parseTTL" }],
       },
       levelName: {
         selector: "div.content span.badge-user",

--- a/src/packages/site/utils/filter.ts
+++ b/src/packages/site/utils/filter.ts
@@ -112,7 +112,7 @@ export const definedFilters: Record<string, TQueryFilterFn> = {
   parseNumber: (query) => {
     const queryMatch = query
       .trim()
-      .replace(/[ ,\n]/g, "")
+      .replace(/[\s,\n]/g, "")
       .match(/([\d.]+)/);
     return queryMatch && queryMatch.length >= 2 ? parseFloat(queryMatch[1]) : 0;
   },


### PR DESCRIPTION
修改parseNumber过滤器，使用\s替代单个空格字符来匹配所有类型的空白字符