### PR TITLE
feat(MyData): 新增解析状态 EResultParseStatus.CFBlocked 并改进提示

### DIFF
--- a/src/entries/options/components/ResultParseStatus.vue
+++ b/src/entries/options/components/ResultParseStatus.vue
@@ -16,6 +16,9 @@ const { t } = useI18n();
   <template v-else-if="status === EResultParseStatus.success">{{ t("resultParseStatus.success") }}</template>
   <template v-else-if="status === EResultParseStatus.parseError">{{ t("resultParseStatus.parseError") }}</template>
   <template v-else-if="status === EResultParseStatus.passParse">{{ t("resultParseStatus.passParse") }}</template>
+  <template v-else-if="status === EResultParseStatus.CFBlocked">
+    <span :title="t('resultParseStatus.CFBlockedNotes')">{{ t("resultParseStatus.CFBlocked") }}</span>
+  </template>
   <template v-else-if="status === EResultParseStatus.needLogin">{{ t("resultParseStatus.needLogin") }}</template>
   <template v-else-if="status === EResultParseStatus.noResults">{{ t("resultParseStatus.noResults") }}</template>
   <template v-else>{{ t("resultParseStatus.unknown") }}</template>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -156,6 +156,8 @@
     "success": "Fetch Successful!",
     "parseError": "Parse Error!",
     "passParse": "Not Enabled!",
+    "CFBlocked": "Cloudflare Error!",
+    "CFBlockedNotes": "It may be because the site has enabled CloudFlare's security protection, which makes it impossible to retrieve data. Usually you need to wait for the site to recover on its own.",
     "needLogin": "Login Required!",
     "noResults": "No Results!",
     "unknown": "Unknown Status!"

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -156,6 +156,8 @@
     "success": "获取成功！",
     "parseError": "解析错误！",
     "passParse": "未启用！",
+    "CFBlocked": "CloudFlare 错误！",
+    "CFBlockedNotes": "CloudFlare 返回的错误，可能是因为站点启用了 CloudFlare 的安全防护，导致无法获取数据。通常需要等待站点自行恢复。",
     "needLogin": "需要登录！",
     "noResults": "无结果！",
     "unknown": "未知状态！"

--- a/src/packages/site/schemas/AbstractBittorrentSite.ts
+++ b/src/packages/site/schemas/AbstractBittorrentSite.ts
@@ -69,7 +69,7 @@ export default class BittorrentSite {
     return this.userConfig.downloadInterval ?? this.metadata.download?.interval ?? 0;
   }
 
-  protected get CFBlockCheckHttpStatusCodes(): number[] | false {
+  protected get CFBlockCheckHttpStatusCodes(): number[] {
     return [
       403, // Forbidden
       521, // used by cloudflare to signal the original webserver is refusing the connection
@@ -93,7 +93,7 @@ export default class BittorrentSite {
 
         // 403 需进一步判断
         const responseText =
-          request.responseType === "document" ? request.responseXML?.documentElement.outerHTML : request.responseText;
+          request.responseType === "document" ? request.responseXML?.documentElement?.outerHTML : request.responseText;
         if (typeof responseText === "undefined") {
           return false; // 检查最终的Text，如果什么都没有, bypass
         } else if (/Enable JavaScript and cookies to continue/.test(responseText)) {
@@ -102,7 +102,7 @@ export default class BittorrentSite {
         return false;
       }
     } catch (e) {
-      // Catch Nothing
+      console.error("[CFBlockCheck] An error occurred while checking CF block status:", e);
     }
     return false;
   }

--- a/src/packages/site/schemas/AbstractPrivateSite.ts
+++ b/src/packages/site/schemas/AbstractPrivateSite.ts
@@ -7,6 +7,7 @@ import BittorrentSite from "./AbstractBittorrentSite";
 import { guessUserLevelId } from "../utils";
 import {
   EResultParseStatus,
+  CFBlockedError,
   NeedLoginError,
   type IElementQuery,
   type ISiteMetadata,
@@ -33,9 +34,6 @@ export default class PrivateSite extends BittorrentSite {
         403, // Forbidden
         502, // Bad Gateway
         504, // Gateway Timeout
-        521, // used by cloudflare to signal the original webserver is refusing the connection
-        522, // used by cloudflare to signal the original webserver is not reachable at all (timeout)
-        523, // used by cloudflare to signal the original webserver is not reachable at all (Origin is unreachable)
       ]
     );
   }
@@ -195,7 +193,9 @@ export default class PrivateSite extends BittorrentSite {
 
       flushUserInfo.status = EResultParseStatus.parseError;
 
-      if (error instanceof NeedLoginError) {
+      if (error instanceof CFBlockedError) {
+        flushUserInfo.status = EResultParseStatus.CFBlocked;
+      } else if (error instanceof NeedLoginError) {
         flushUserInfo.status = EResultParseStatus.needLogin;
       }
     }

--- a/src/packages/site/types/base.ts
+++ b/src/packages/site/types/base.ts
@@ -1,4 +1,5 @@
 // Error classes
+export class CFBlockedError extends Error {}
 export class NeedLoginError extends Error {}
 export class NoTorrentsError extends Error {}
 
@@ -32,6 +33,7 @@ export enum EResultParseStatus {
   success, // 搜索成功
   parseError, // 解析错误
   passParse, // 跳过解析
+  CFBlocked, // Cloudflare 封锁
   needLogin, // 需要登录
   noResults, // 等同于原先的 noTorrents 和 torrentTableIsEmpty ，这两个在结果上没有区别
 }

--- a/src/packages/site/types/site.ts
+++ b/src/packages/site/types/site.ts
@@ -239,7 +239,7 @@ export interface ISiteMetadata {
    */
   noLoginAssert?: {
     /**
-     * HTTP 状态码，表示未登录的状态码，未设置时默认 [401, 403, 502, 504, 521, 522, 523]
+     * HTTP 状态码，表示未登录的状态码，未设置时默认 [401, 403, 502, 504]
      * 如果站点响应的状态码在该数组中，则认为未登录
      */
     httpStatusCodes?: number[] | false;


### PR DESCRIPTION
效果如下：

<img width="844" height="358" alt="2025-07-18_125740" src="https://github.com/user-attachments/assets/f544a279-1479-4a27-a19f-ca966648bc42" />



对于 CF 盾，不再显示为“需要登录”，可以进行区分，减少误解