### PR TITLE
feat(i18n): 优化出现 CFBlock 错误时的提示

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -157,7 +157,7 @@
     "parseError": "Parse Error!",
     "passParse": "Not Enabled!",
     "CFBlocked": "Cloudflare Error!",
-    "CFBlockedNotes": "It may be because the site has enabled CloudFlare's security protection, which makes it impossible to retrieve data. Usually you need to wait for the site to recover on its own.",
+    "CFBlockedNotes": "It may be because the site has enabled CloudFlare's security protection, which makes it impossible to retrieve data. You can first try to manually access the site once to pass the verification. If that doesn't work, just wait for the site to recover on its own.",
     "needLogin": "Login Required!",
     "noResults": "No Results!",
     "unknown": "Unknown Status!"

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -157,7 +157,7 @@
     "parseError": "解析错误！",
     "passParse": "未启用！",
     "CFBlocked": "CloudFlare 错误！",
-    "CFBlockedNotes": "CloudFlare 返回的错误，可能是因为站点启用了 CloudFlare 的安全防护，导致无法获取数据。通常需要等待站点自行恢复。",
+    "CFBlockedNotes": "CloudFlare 返回的错误，可能是因为站点启用了 CloudFlare 的安全防护，导致无法获取数据。可以先尝试手动访问一次站点，以通过 CF 验证。如果不起作用，请等待站点自行恢复。",
     "needLogin": "需要登录！",
     "noResults": "无结果！",
     "unknown": "未知状态！"


### PR DESCRIPTION
引导用户可以尝试“手动访问一次站点”，以获取有效的 `cf_clearance`

