### PR TITLE
fix(SetSearchSolution): 修复筛选时站点图标不更新的问题

### DIFF
--- a/src/entries/options/components/SiteFavicon.vue
+++ b/src/entries/options/components/SiteFavicon.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, shallowRef } from "vue";
+import { onMounted, shallowRef, watch } from "vue";
 import { NO_IMAGE, type TSiteID } from "@ptd/site";
 
 import { sendMessage } from "@/messages.ts";
@@ -20,14 +20,25 @@ const {
 
 const siteFavicon = shallowRef<string>(NO_IMAGE);
 
-onMounted(async () => {
+async function loadFavicon() {
   let favicon = await sendMessage("getSiteFavicon", { site: siteId, flush: flushOnPre });
   if (favicon === NO_IMAGE && flushOnNoImage) {
     favicon = await sendMessage("getSiteFavicon", { site: siteId, flush: true }); // 强制刷新
   }
 
   siteFavicon.value = favicon;
+}
+
+onMounted(() => {
+  loadFavicon();
 });
+
+watch(
+  () => siteId,
+  () => {
+    loadFavicon();
+  },
+);
 
 function doFlush() {
   if (!flushOnClick) return;


### PR DESCRIPTION
在设置自定义搜索方案过程中，使用筛选器时，站点图标不更新，需要重新打开 Dialog 才会更新。如下图：

<img width="439" height="218" alt="bug-2025-07-23_230454" src="https://github.com/user-attachments/assets/0c529525-895f-41f5-90f2-dfa421c1fa26" />
