### PR TITLE
feat: add default H&R tags with red color for global sites

### DIFF
--- a/src/packages/site/definitions/asiancinema.ts
+++ b/src/packages/site/definitions/asiancinema.ts
@@ -23,6 +23,20 @@ export const siteMetadata: ISiteMetadata = {
     },
   },
 
+  search: {
+    ...SchemaMetadata.search,
+    selectors: {
+      ...SchemaMetadata.search?.selectors,
+      tags: [
+        {
+          name: "H&R",
+          selector: "*",
+          color: "red",
+        },
+      ],
+    },
+  },
+
   levelRequirements: [
     {
       id: 0,

--- a/src/packages/site/definitions/beyondhd.ts
+++ b/src/packages/site/definitions/beyondhd.ts
@@ -641,6 +641,8 @@ export default class BeyondHD extends PrivateSite {
       tags.push({ name: "中字" });
     }
 
+    tags.push({ name: "H&R", color: "black" });
+
     torrent.tags = tags;
     return torrent;
   }

--- a/src/packages/site/definitions/beyondhd.ts
+++ b/src/packages/site/definitions/beyondhd.ts
@@ -641,7 +641,7 @@ export default class BeyondHD extends PrivateSite {
       tags.push({ name: "中字" });
     }
 
-    tags.push({ name: "H&R", color: "black" });
+    tags.push({ name: "H&R", color: "red" });
 
     torrent.tags = tags;
     return torrent;

--- a/src/packages/site/definitions/blutopia.ts
+++ b/src/packages/site/definitions/blutopia.ts
@@ -233,8 +233,8 @@ export const siteMetadata: ISiteMetadata = {
         ...SchemaMetadata.search!.selectors!.tags!,
         {
           name: "H&R",
-          selector: ":self",
-          color: "black",
+          selector: "*",
+          color: "red",
         },
       ],
     },

--- a/src/packages/site/definitions/blutopia.ts
+++ b/src/packages/site/definitions/blutopia.ts
@@ -229,6 +229,14 @@ export const siteMetadata: ISiteMetadata = {
       comments: {
         selector: ["i.torrent-icons__comments"],
       },
+      tags: [
+        ...SchemaMetadata.search!.selectors!.tags!,
+        {
+          name: "H&R",
+          selector: ":self",
+          color: "black",
+        },
+      ],
     },
   },
 };

--- a/src/packages/site/definitions/broadcasthenet.ts
+++ b/src/packages/site/definitions/broadcasthenet.ts
@@ -61,6 +61,14 @@ export const siteMetadata: ISiteMetadata = {
           { name: "parseTTL" }, // 使用parseTTL转换相对时间为绝对时间
         ],
       },
+      tags: [
+        ...SchemaMetadata.search!.selectors!.tags!,
+        {
+          name: "H&R",
+          selector: ":self",
+          color: "black",
+        },
+      ],
     },
   },
 

--- a/src/packages/site/definitions/broadcasthenet.ts
+++ b/src/packages/site/definitions/broadcasthenet.ts
@@ -62,11 +62,10 @@ export const siteMetadata: ISiteMetadata = {
         ],
       },
       tags: [
-        ...SchemaMetadata.search!.selectors!.tags!,
         {
           name: "H&R",
-          selector: ":self",
-          color: "black",
+          selector: "*",
+          color: "red",
         },
       ],
     },

--- a/src/packages/site/definitions/huno.ts
+++ b/src/packages/site/definitions/huno.ts
@@ -143,7 +143,7 @@ export const siteMetadata: ISiteMetadata = {
         { name: "Internal", selector: "i.far.fa-bolt", color: "#b793f0" },
         { name: "Worthy", selector: "i.far.fa-medal", color: "#00c07f" },
         { name: "Sticky", selector: "i.far.fa-thumbtack", color: "#d32f2f" },
-        { name: "H&R", selector: ":self", color: "black" },
+        { name: "H&R", selector: "*", color: "red" },
       ],
     },
   },

--- a/src/packages/site/definitions/huno.ts
+++ b/src/packages/site/definitions/huno.ts
@@ -143,6 +143,7 @@ export const siteMetadata: ISiteMetadata = {
         { name: "Internal", selector: "i.far.fa-bolt", color: "#b793f0" },
         { name: "Worthy", selector: "i.far.fa-medal", color: "#00c07f" },
         { name: "Sticky", selector: "i.far.fa-thumbtack", color: "#d32f2f" },
+        { name: "H&R", selector: ":self", color: "black" },
       ],
     },
   },

--- a/src/packages/site/definitions/torrentleech.ts
+++ b/src/packages/site/definitions/torrentleech.ts
@@ -274,7 +274,7 @@ export default class TorrentLeech extends PrivateSite {
     if (row.tags?.includes("FREELEECH")) {
       torrent.tags.push({ name: "Free", color: "blue" });
     }
-    torrent.tags.push({ name: "H&R", color: "black" });
+    torrent.tags.push({ name: "H&R", color: "red" });
 
     return torrent;
   }

--- a/src/packages/site/definitions/torrentleech.ts
+++ b/src/packages/site/definitions/torrentleech.ts
@@ -274,6 +274,7 @@ export default class TorrentLeech extends PrivateSite {
     if (row.tags?.includes("FREELEECH")) {
       torrent.tags.push({ name: "Free", color: "blue" });
     }
+    torrent.tags.push({ name: "H&R", color: "black" });
 
     return torrent;
   }


### PR DESCRIPTION
Introduce default H&R tags for global H&R sites and update their color to red, enhancing visibility and searchability.