### PR TITLE
fix(pkg/site): 修复和适配站点：bitporn、fearnopeer、monikadesign、happyfappy、nyaa

### DIFF
--- a/src/packages/site/definitions/bitporn.ts
+++ b/src/packages/site/definitions/bitporn.ts
@@ -1,4 +1,4 @@
-import { ETorrentStatus, EResultParseStatus, type ISiteMetadata, type IUserInfo } from "../types";
+import { ETorrentStatus, EResultParseStatus, type ISiteMetadata, type ITorrent, type IUserInfo } from "../types";
 import Unit3D, { SchemaMetadata } from "../schemas/Unit3D";
 import { parseSizeString, parseValidTimeString } from "../utils";
 
@@ -219,7 +219,7 @@ export const siteMetadata: ISiteMetadata = {
       tags: [
         {
           name: "Free",
-          selector: "span[title*='feature'], span[title*='100% Freeleech']",
+          selector: "span[title*='feature'], span[title*='100% Freeleech'], i.fa-globe",
           color: "blue",
         },
         {
@@ -278,7 +278,7 @@ export const siteMetadata: ISiteMetadata = {
 
   list: [
     {
-      urlPattern: ["/torrents\[\^/\]"],
+      urlPattern: ["/torrents(?:/?$|\\?\[\^/\]*$)"],
     },
   ],
 
@@ -457,5 +457,15 @@ export default class BitPorn extends Unit3D {
       true,
     );
     return this.getFieldData(document, this.metadata.userInfo?.selectors?.bonusPerHour!);
+  }
+
+  public override async getTorrentDownloadLink(torrent: ITorrent): Promise<string> {
+    const downloadLink = await super.getTorrentDownloadLink(torrent);
+    if (downloadLink && !downloadLink.includes("/download/")) {
+      const mockRequestConfig = torrent.url?.startsWith("http") ? { url: torrent.url } : { baseURL: this.url };
+      return this.fixLink(`/torrents/download/${torrent.id}`, mockRequestConfig);
+    }
+
+    return downloadLink;
   }
 }

--- a/src/packages/site/definitions/fearnopeer.ts
+++ b/src/packages/site/definitions/fearnopeer.ts
@@ -1,4 +1,4 @@
-import { ETorrentStatus, EResultParseStatus, type ISiteMetadata, type IUserInfo } from "../types";
+import { ETorrentStatus, EResultParseStatus, type ISiteMetadata, type ITorrent, type IUserInfo } from "../types";
 import Unit3D, { SchemaMetadata } from "../schemas/Unit3D.ts";
 import { buildCategoryOptions, parseSizeString, parseValidTimeString } from "../utils";
 
@@ -308,7 +308,7 @@ export const siteMetadata: ISiteMetadata = {
 
   list: [
     {
-      urlPattern: ["/torrents\[\^/\]"],
+      urlPattern: ["/torrents(?:/?$|\\?\[\^/\]*$)"],
     },
   ],
 
@@ -488,5 +488,15 @@ export default class Fearnopeer extends Unit3D {
       true,
     );
     return this.getFieldData(document, this.metadata.userInfo?.selectors?.bonusPerHour!);
+  }
+
+  public override async getTorrentDownloadLink(torrent: ITorrent): Promise<string> {
+    const downloadLink = await super.getTorrentDownloadLink(torrent);
+    if (downloadLink && !downloadLink.includes("/download/")) {
+      const mockRequestConfig = torrent.url?.startsWith("http") ? { url: torrent.url } : { baseURL: this.url };
+      return this.fixLink(`/torrents/download/${torrent.id}`, mockRequestConfig);
+    }
+
+    return downloadLink;
   }
 }

--- a/src/packages/site/definitions/monikadesign.ts
+++ b/src/packages/site/definitions/monikadesign.ts
@@ -1,4 +1,4 @@
-import { EResultParseStatus, type ISiteMetadata, type IUserInfo } from "../types";
+import { EResultParseStatus, type ISiteMetadata, type ITorrent, type IUserInfo } from "../types";
 import Unit3D, { SchemaMetadata } from "../schemas/Unit3D.ts";
 
 export const siteMetadata: ISiteMetadata = {
@@ -220,7 +220,7 @@ export const siteMetadata: ISiteMetadata = {
 
   list: [
     {
-      urlPattern: ["/torrents\[\^/\]"],
+      urlPattern: ["/torrents(?:/?$|\\?\[\^/\]*$)"],
     },
   ],
 
@@ -322,5 +322,18 @@ export default class MonikaDesign extends Unit3D {
       true,
     );
     return this.getFieldData(document, this.metadata.userInfo?.selectors?.bonusPerHour!);
+  }
+
+  public override async getTorrentDownloadLink(torrent: ITorrent): Promise<string> {
+    const downloadLink = await super.getTorrentDownloadLink(torrent);
+    if (downloadLink && !downloadLink.includes("/download/")) {
+      const { data: detailDocument } = await this.request<Document>({
+        url: downloadLink,
+        responseType: "document",
+      });
+      return this.getFieldData(detailDocument, this.metadata.search?.selectors?.link!);
+    }
+
+    return downloadLink;
   }
 }

--- a/src/packages/site/definitions/nyaa.ts
+++ b/src/packages/site/definitions/nyaa.ts
@@ -1,0 +1,181 @@
+
+import { type ISiteMetadata, type ITorrent } from "../types";
+import BittorrentSite from "../schemas/AbstractBittorrentSite";
+import { rot13 } from "../utils";
+
+const WORK_SAFE_URL = rot13("uggcf://alnn.fv/")
+const NON_WORK_SAFE_URL = rot13("uggcf://fhxrorv.alnn.fv/")
+
+export const siteMetadata: ISiteMetadata = {
+  id: "nyaa",
+  version: 1,
+  name: "Nyaa",
+  tags: ["综合"],
+  collaborator: ["hyuan280"],
+
+  type: "public",
+
+  urls: ["uggcf://alnn.fv/", "uggcf://fhxrorv.alnn.fv/"],
+
+  category: [
+    {
+      name: "搜索站点",
+      key: "url",
+      options: [
+        { name: "表站", value: WORK_SAFE_URL },
+        { name: "里站", value: NON_WORK_SAFE_URL },
+      ],
+      generateRequestConfig: (selectedOptions) => {
+        return { requestConfig: { baseURL: selectedOptions.toString() } };
+      },
+    },
+    {
+      name: "过滤",
+      key: "f",
+      options: [
+        { name: "No filter", value: "0" },
+        { name: "No remakes", value: "1" },
+        { name: "Trusted only", value: "2" },
+      ],
+    },
+    {
+      name: "类别（表站）",
+      key: "c_safe",
+      options: [
+        { name: "All categories", value: "0_0" },
+        { name: "Anime", value: "1_0" },
+        { name: "Anime - AMV", value: "1_1" },
+        { name: "Anime - English", value: "1_2" },
+        { name: "Anime - Non-English", value: "1_3" },
+        { name: "Anime - Raw", value: "1_4" },
+        { name: "Audio", value: "2_0" },
+        { name: "Audio - Lossless", value: "2_1" },
+        { name: "Audio - Lossy", value: "2_2" },
+        { name: "Literature", value: "3_0" },
+        { name: "Literature - English", value: "3_1" },
+        { name: "Literature - Non-English", value: "3_2" },
+        { name: "Literature - Raw", value: "3_3" },
+        { name: "Live Action", value: "4_0" },
+        { name: "Live Action - English", value: "4_1" },
+        { name: "Live Action - Idol/PV", value: "4_2" },
+        { name: "Live Action - Non-English", value: "4_3" },
+        { name: "Live Action - Raw", value: "4_4" },
+        { name: "Pictures", value: "5_0" },
+        { name: "Pictures - Graphics", value: "5_1" },
+        { name: "Pictures - Photos", value: "5_2" },
+        { name: "Software", value: "6_0" },
+        { name: "Software - Apps", value: "6_1" },
+        { name: "Software - Games", value: "6_2" },
+      ],
+      generateRequestConfig: (selectedOptions) => {
+        return { requestConfig: { params: { c: selectedOptions.toString() } } };
+      },
+    },
+    {
+      name: "类别（里站）",
+      key: "c_unsafe",
+      options: [
+        { name: "All categories", value: "0_0" },
+        { name: "Art", value: "1_0" },
+        { name: "Art - Anime", value: "1_1" },
+        { name: "Art - Doujinshi", value: "1_2" },
+        { name: "Art - Games", value: "1_3" },
+        { name: "Art - Manga", value: "1_4" },
+        { name: "Art - Pictures", value: "1_5" },
+        { name: "Real Life", value: "2_0" },
+        { name: "Real Life - Pictures", value: "2_1" },
+        { name: "Real Life - Videos", value: "2_2" },
+      ],
+      generateRequestConfig: (selectedOptions) => {
+        return { requestConfig: { params: { c: selectedOptions.toString() } } };
+      },
+    },
+  ],
+
+  search: {
+    // 一页75个，没试出怎么改，就用默认的吧
+    requestConfig: {
+      url: "/",
+    },
+    keywordPath: "params.q",
+    selectors: {
+      rows: { selector: "table.torrent-list > tbody > tr" },
+      id: {
+        selector: ["a[href*='/view/']:not([href*='#']"],
+        attr: "href",
+        filters: [(query: string) => query.match(/\/view\/(\d+)/)![1]],
+      },
+      title: { selector: ["a[href*='/view/']:not([href*='#']"] },
+      subTitle: {
+        // 详细的分类显示到副标题
+        selector: ["img.category-icon"],
+        attr: "alt",
+      },
+      url: { selector: ["a[href*='/view/']:not([href*='#']"], attr: "href" },
+      link: { selector: ["a[href*='/download/']"], attr: "href" },
+      time: { selector: ["td[data-timestamp]"], attr: "data-timestamp", filters: [{ name: "parseNumber" }] },
+      size: { selector: ["td:nth-child(4)"], filters: [{ name: "parseSize" }] },
+      seeders: { selector: ["td:nth-child(6)"], filters: [{ name: "parseNumber" }] },
+      leechers: { selector: ["td:nth-child(7)"], filters: [{ name: "parseNumber" }] },
+      completed: { selector: ["td:nth-child(8)"], filters: [{ name: "parseNumber" }] },
+      comments: { selector: ["i.fa-comments-o"], filters: [{ name: "parseNumber" }] },
+      category: {
+        // 简洁显示分类的大类 Anime - AMV => Anime
+        selector: ["img.category-icon"],
+        attr: "alt",
+        filters: [(query: string) => query.split("-")[0].trim()],
+      },
+    },
+  },
+
+  searchEntry: {
+    area_work_safe: {
+      name: "表站",
+      requestConfig: {
+        baseURL: WORK_SAFE_URL,
+      },
+    },
+    area_non_work_safe: {
+      name: "里站",
+      requestConfig: {
+        baseURL: NON_WORK_SAFE_URL,
+      },
+      enabled: false,
+    },
+  },
+
+  list: [
+    {
+      urlPattern: ["si/?(\\?.*)?$"],
+    },
+  ],
+
+  detail: {
+    urlPattern: ["si/view/\\d+"],
+    selectors: {
+      title: { selector: ["div.container div.panel-heading > h3.panel-title"] },
+      id: {
+        selector: ":self",
+        elementProcess: (element: Document) => {
+          const url = element.URL;
+          const match = url.match(/\/view\/(\d+)/);
+          return match ? match[1] : url;
+        },
+      },
+      link: { selector: ["a[href*='/download/']"], attr: "href" },
+    },
+  },
+
+};
+
+export default class Nyaa extends BittorrentSite {
+  public override async getTorrentDownloadLink(torrent: ITorrent): Promise<string> {
+    const downloadLink = await super.getTorrentDownloadLink(torrent);
+    if (downloadLink && !downloadLink.includes("/download/")) {
+      const mockRequestConfig = torrent.url?.startsWith("http") ? { url: torrent.url } : { baseURL: this.url };
+      return this.fixLink(`/download/${torrent.id}.torrent`, mockRequestConfig);
+    }
+
+    return downloadLink;
+  }
+};


### PR DESCRIPTION
- 修复Unit3D站点bitporn、fearnopeer、monikadesign种子列表
 1.修改urlPattern以正确匹配web网址
 2.增加下载地址解析，适配拖拽下载
 3.bitporn增加全局免费的free标签
- 为happyfappy增加web网页的种子列表
- 增加公网站点Nyaa种子搜索和列表