### PR TITLE
fix: 修复媒体库plex剧集访问链接

### DIFF
--- a/src/packages/mediaServer/entity/plex.ts
+++ b/src/packages/mediaServer/entity/plex.ts
@@ -192,7 +192,7 @@ export default class Plex extends AbstractMediaServer<IPlexConfig> {
           server: this.config.id!,
           // @ts-ignore
           name: item.parentTitle ? `${item.parentTitle} (${item.title})` : item.title,
-          url: `${this.webBaseUrl}#!/server/${serverIdentity}/details?key=${item.key}`,
+          url: `${this.webBaseUrl}#!/server/${serverIdentity}/details?key=${item.key.replace(/\/children$/, '')}`,
           type: item.type === "movie" ? "Movie" : item.type,
           description: item.summary,
           // @ts-ignore


### PR DESCRIPTION
item.key的值包含且以'/children'结尾导致剧集链接访问一直加载中
<img width="1773" height="935" alt="image" src="https://github.com/user-attachments/assets/28dcac45-0a19-455c-acc9-d198bbe1269d" />
正常能访问的链接
<img width="1582" height="907" alt="image" src="https://github.com/user-attachments/assets/693a4f68-babe-4109-a23c-3b377e7c75f6" />

