### PR TITLE
feat: 为MyData表格添加bonus数字简化功能

### DIFF
--- a/src/entries/options/stores/config.ts
+++ b/src/entries/options/stores/config.ts
@@ -112,7 +112,7 @@ export const useConfigStore = defineStore("config", {
       joinTimeFormat: "added",
       updateAtFormatAsAlive: false,
       showIntervalAsDate: false,
-      simplifyNumbers: false,
+      simplifyBonusNumbers: false,
     },
 
     userDataTimelineControl: {

--- a/src/entries/options/stores/config.ts
+++ b/src/entries/options/stores/config.ts
@@ -112,6 +112,7 @@ export const useConfigStore = defineStore("config", {
       joinTimeFormat: "added",
       updateAtFormatAsAlive: false,
       showIntervalAsDate: false,
+      simplifyNumbers: false,
     },
 
     userDataTimelineControl: {

--- a/src/entries/options/utils.ts
+++ b/src/entries/options/utils.ts
@@ -1,5 +1,6 @@
 import { toRaw, isRef, isReactive, isProxy } from "vue";
-import { filesize, type FileSizeOptions } from "filesize";
+// Note: filesize library changed type name from FileSizeOptions to FilesizeOptions in v11.0+
+import { filesize, type FilesizeOptions } from "filesize";
 import {
   differenceInDays,
   differenceInHours,
@@ -40,7 +41,7 @@ export const formValidateRules: Record<string, (args?: any) => (v: any) => boole
   },
 };
 
-export const formatSize = (size: number | string, options?: FileSizeOptions) => {
+export const formatSize = (size: number | string, options?: FilesizeOptions) => {
   try {
     return filesize(size, { base: 2, ...(options ?? {}) });
   } catch (e) {

--- a/src/entries/options/utils.ts
+++ b/src/entries/options/utils.ts
@@ -1,5 +1,5 @@
 import { toRaw, isRef, isReactive, isProxy } from "vue";
-import { filesize, type FilesizeOptions } from "filesize";
+import { filesize, type FileSizeOptions } from "filesize";
 import {
   differenceInDays,
   differenceInHours,
@@ -40,7 +40,7 @@ export const formValidateRules: Record<string, (args?: any) => (v: any) => boole
   },
 };
 
-export const formatSize = (size: number | string, options?: FilesizeOptions) => {
+export const formatSize = (size: number | string, options?: FileSizeOptions) => {
   try {
     return filesize(size, { base: 2, ...(options ?? {}) });
   } catch (e) {
@@ -92,3 +92,34 @@ export const formatTimeAgo = (sourceDate: Date | number | string, weekOnly: bool
 
 export const formatNumber = (num: number, options: Intl.NumberFormatOptions = {}) =>
   Number(num).toLocaleString("en-US", { maximumFractionDigits: 2, minimumFractionDigits: 2, ...options });
+
+// 数字简化函数，将大数字转换为带单位的简化形式（用于bonus相关数字）
+export const simplifyNumber = (num: number | string): string => {
+  const numValue = typeof num === "string" ? parseFloat(num) : num;
+
+  if (isNaN(numValue)) {
+    return "-";
+  }
+
+  const absNum = Math.abs(numValue);
+
+  // 定义单位和对应的阈值
+  const units = [
+    { threshold: 1000000000000, suffix: "T" },
+    { threshold: 1000000000, suffix: "B" },
+    { threshold: 1000000, suffix: "M" },
+    { threshold: 1000, suffix: "K" },
+  ];
+
+  // 找到合适的单位
+  for (const { threshold, suffix } of units) {
+    if (absNum >= threshold) {
+      const value = numValue / threshold;
+      // 如果是整数，不显示小数点
+      return value % 1 === 0 ? value.toString() + suffix : value.toFixed(2) + suffix;
+    }
+  }
+
+  // 小于1000的数字直接返回
+  return numValue.toString();
+};

--- a/src/entries/options/views/Overview/MyData/Index.vue
+++ b/src/entries/options/views/Overview/MyData/Index.vue
@@ -22,6 +22,11 @@ import HistoryDataViewDialog from "./HistoryDataViewDialog.vue";
 import { cancelFlushSiteLastUserInfo, fixUserInfo, flushSiteLastUserInfo, formatRatio } from "./utils.ts";
 
 const { t } = useI18n();
+
+// Toggle function for double-click to switch number simplification
+function toggleNumberSimplification() {
+  configStore.myDataTableControl.simplifyNumbers = !configStore.myDataTableControl.simplifyNumbers;
+}
 const router = useRouter();
 const configStore = useConfigStore();
 const runtimeStore = useRuntimeStore();
@@ -576,13 +581,19 @@ function viewStatistic() {
         >
           <v-row align="center" class="flex-nowrap" justify="end">
             <v-icon :title="t('levelRequirement.bonus')" color="green-darken-4" icon="mdi-currency-usd" size="small" />
-            <span class="text-no-wrap">{{
-              typeof item.bonus !== "undefined"
-                ? configStore.myDataTableControl.simplifyNumbers
-                  ? simplifyNumber(item.bonus)
-                  : formatNumber(item.bonus)
-                : "-"
-            }}</span>
+            <span
+              class="text-no-wrap"
+              :title="typeof item.bonus !== 'undefined' ? formatNumber(item.bonus) : '-'"
+              @dblclick="toggleNumberSimplification"
+              style="cursor: pointer; user-select: none"
+              >{{
+                typeof item.bonus !== "undefined"
+                  ? configStore.myDataTableControl.simplifyNumbers
+                    ? simplifyNumber(item.bonus)
+                    : formatNumber(item.bonus)
+                  : "-"
+              }}</span
+            >
           </v-row>
           <v-row align="center" class="flex-nowrap" justify="end">
             <v-icon
@@ -591,24 +602,36 @@ function viewStatistic() {
               icon="mdi-lightning-bolt-circle"
               size="small"
             />
-            <span class="text-no-wrap">{{
-              typeof item.seedingBonus !== "undefined"
-                ? configStore.myDataTableControl.simplifyNumbers
-                  ? simplifyNumber(item.seedingBonus)
-                  : formatNumber(item.seedingBonus)
-                : "-"
-            }}</span>
+            <span
+              class="text-no-wrap"
+              :title="typeof item.seedingBonus !== 'undefined' ? formatNumber(item.seedingBonus) : '-'"
+              @dblclick="toggleNumberSimplification"
+              style="cursor: pointer; user-select: none"
+              >{{
+                typeof item.seedingBonus !== "undefined"
+                  ? configStore.myDataTableControl.simplifyNumbers
+                    ? simplifyNumber(item.seedingBonus)
+                    : formatNumber(item.seedingBonus)
+                  : "-"
+              }}</span
+            >
           </v-row>
         </v-container>
         <template v-else>
           <v-icon :title="t('levelRequirement.bonus')" color="green-darken-4" icon="mdi-currency-usd" size="small" />
-          <span class="text-no-wrap">{{
-            typeof item.bonus !== "undefined"
-              ? configStore.myDataTableControl.simplifyNumbers
-                ? simplifyNumber(item.bonus)
-                : formatNumber(item.bonus)
-              : "-"
-          }}</span>
+          <span
+            class="text-no-wrap"
+            :title="typeof item.bonus !== 'undefined' ? formatNumber(item.bonus) : '-'"
+            @dblclick="toggleNumberSimplification"
+            style="cursor: pointer; user-select: none"
+            >{{
+              typeof item.bonus !== "undefined"
+                ? configStore.myDataTableControl.simplifyNumbers
+                  ? simplifyNumber(item.bonus)
+                  : formatNumber(item.bonus)
+                : "-"
+            }}</span
+          >
         </template>
       </template>
 

--- a/src/entries/options/views/Overview/MyData/Index.vue
+++ b/src/entries/options/views/Overview/MyData/Index.vue
@@ -10,7 +10,7 @@ import { useConfigStore } from "@/options/stores/config.ts";
 import { useRuntimeStore } from "@/options/stores/runtime.ts";
 import { useMetadataStore } from "@/options/stores/metadata.ts";
 import { useTableCustomFilter } from "@/options/directives/useAdvanceFilter.ts";
-import { formatDate, formatNumber, formatSize, formatTimeAgo } from "@/options/utils.ts";
+import { formatDate, formatNumber, formatSize, formatTimeAgo, simplifyNumber } from "@/options/utils.ts";
 
 import SiteName from "@/options/components/SiteName.vue";
 import SiteFavicon from "@/options/components/SiteFavicon.vue";
@@ -576,9 +576,13 @@ function viewStatistic() {
         >
           <v-row align="center" class="flex-nowrap" justify="end">
             <v-icon :title="t('levelRequirement.bonus')" color="green-darken-4" icon="mdi-currency-usd" size="small" />
-            <span class="text-no-wrap">
-              {{ typeof item.bonus !== "undefined" ? formatNumber(item.bonus) : "-" }}
-            </span>
+            <span class="text-no-wrap">{{
+              typeof item.bonus !== "undefined"
+                ? configStore.myDataTableControl.simplifyNumbers
+                  ? simplifyNumber(item.bonus)
+                  : formatNumber(item.bonus)
+                : "-"
+            }}</span>
           </v-row>
           <v-row align="center" class="flex-nowrap" justify="end">
             <v-icon
@@ -587,16 +591,24 @@ function viewStatistic() {
               icon="mdi-lightning-bolt-circle"
               size="small"
             />
-            <span class="text-no-wrap">
-              {{ formatNumber(item.seedingBonus) }}
-            </span>
+            <span class="text-no-wrap">{{
+              typeof item.seedingBonus !== "undefined"
+                ? configStore.myDataTableControl.simplifyNumbers
+                  ? simplifyNumber(item.seedingBonus)
+                  : formatNumber(item.seedingBonus)
+                : "-"
+            }}</span>
           </v-row>
         </v-container>
         <template v-else>
           <v-icon :title="t('levelRequirement.bonus')" color="green-darken-4" icon="mdi-currency-usd" size="small" />
-          <span class="text-no-wrap">
-            {{ typeof item.bonus !== "undefined" ? formatNumber(item.bonus) : "-" }}
-          </span>
+          <span class="text-no-wrap">{{
+            typeof item.bonus !== "undefined"
+              ? configStore.myDataTableControl.simplifyNumbers
+                ? simplifyNumber(item.bonus)
+                : formatNumber(item.bonus)
+              : "-"
+          }}</span>
         </template>
       </template>
 

--- a/src/entries/options/views/Overview/MyData/Index.vue
+++ b/src/entries/options/views/Overview/MyData/Index.vue
@@ -22,11 +22,6 @@ import HistoryDataViewDialog from "./HistoryDataViewDialog.vue";
 import { cancelFlushSiteLastUserInfo, fixUserInfo, flushSiteLastUserInfo, formatRatio } from "./utils.ts";
 
 const { t } = useI18n();
-
-// Toggle function for double-click to switch number simplification
-function toggleNumberSimplification() {
-  configStore.myDataTableControl.simplifyNumbers = !configStore.myDataTableControl.simplifyNumbers;
-}
 const router = useRouter();
 const configStore = useConfigStore();
 const runtimeStore = useRuntimeStore();
@@ -178,6 +173,11 @@ function viewStatistic() {
       sites: tableSelected.value,
     },
   });
+}
+
+// Toggle function for double-click to switch number simplification
+function toggleNumberSimplification() {
+  configStore.myDataTableControl.simplifyBonusNumbers = !configStore.myDataTableControl.simplifyBonusNumbers;
 }
 </script>
 
@@ -588,7 +588,7 @@ function viewStatistic() {
               style="cursor: pointer; user-select: none"
               >{{
                 typeof item.bonus !== "undefined"
-                  ? configStore.myDataTableControl.simplifyNumbers
+                  ? configStore.myDataTableControl.simplifyBonusNumbers
                     ? simplifyNumber(item.bonus)
                     : formatNumber(item.bonus)
                   : "-"
@@ -609,7 +609,7 @@ function viewStatistic() {
               style="cursor: pointer; user-select: none"
               >{{
                 typeof item.seedingBonus !== "undefined"
-                  ? configStore.myDataTableControl.simplifyNumbers
+                  ? configStore.myDataTableControl.simplifyBonusNumbers
                     ? simplifyNumber(item.seedingBonus)
                     : formatNumber(item.seedingBonus)
                   : "-"
@@ -626,7 +626,7 @@ function viewStatistic() {
             style="cursor: pointer; user-select: none"
             >{{
               typeof item.bonus !== "undefined"
-                ? configStore.myDataTableControl.simplifyNumbers
+                ? configStore.myDataTableControl.simplifyBonusNumbers
                   ? simplifyNumber(item.bonus)
                   : formatNumber(item.bonus)
                 : "-"

--- a/src/entries/options/views/Overview/MyData/UserLevelShowSpan.vue
+++ b/src/entries/options/views/Overview/MyData/UserLevelShowSpan.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useI18n } from "vue-i18n";
 import { IImplicitUserInfo, isoDuration, convertIsoDurationToDate } from "@ptd/site";
-import { formatNumber, formatSize, formatDate } from "@/options/utils";
+import { formatNumber, formatSize, formatDate, simplifyNumber } from "@/options/utils";
 import { useConfigStore } from "@/options/stores/config";
 
 const { levelRequirement } = defineProps<{
@@ -132,7 +132,9 @@ function formatIntervalDate(duration: number | isoDuration): string {
   <template v-if="levelRequirement.bonus">
     <v-icon :title="t('levelRequirement.bonus')" color="green-darken-4" icon="mdi-currency-usd" size="small" />
     {{
-      formatNumber(levelRequirement.bonus) +
+      (configStore.myDataTableControl.simplifyNumbers
+        ? simplifyNumber(levelRequirement.bonus)
+        : formatNumber(levelRequirement.bonus)) +
       (levelRequirement.bonusNeededInterval ? ` (${levelRequirement.bonusNeededInterval})` : "")
     }};
   </template>
@@ -145,7 +147,9 @@ function formatIntervalDate(duration: number | isoDuration): string {
       size="small"
     />
     {{
-      formatNumber(levelRequirement.seedingBonus) +
+      (configStore.myDataTableControl.simplifyNumbers
+        ? simplifyNumber(levelRequirement.seedingBonus)
+        : formatNumber(levelRequirement.seedingBonus)) +
       (levelRequirement.seedingBonusNeededInterval ? ` (${levelRequirement.seedingBonusNeededInterval})` : "")
     }};
   </template>

--- a/src/entries/options/views/Overview/MyData/UserLevelShowSpan.vue
+++ b/src/entries/options/views/Overview/MyData/UserLevelShowSpan.vue
@@ -17,6 +17,11 @@ function toggleIntervalDisplay() {
   configStore.myDataTableControl.showIntervalAsDate = !configStore.myDataTableControl.showIntervalAsDate;
 }
 
+// Toggle function for double-click to switch number simplification
+function toggleNumberSimplification() {
+  configStore.myDataTableControl.simplifyNumbers = !configStore.myDataTableControl.simplifyNumbers;
+}
+
 // Get interval display text and title
 function getIntervalDisplay(interval: number | isoDuration) {
   const showAsDate = configStore.myDataTableControl.showIntervalAsDate;
@@ -131,12 +136,17 @@ function formatIntervalDate(duration: number | isoDuration): string {
 
   <template v-if="levelRequirement.bonus">
     <v-icon :title="t('levelRequirement.bonus')" color="green-darken-4" icon="mdi-currency-usd" size="small" />
-    {{
-      (configStore.myDataTableControl.simplifyNumbers
-        ? simplifyNumber(levelRequirement.bonus)
-        : formatNumber(levelRequirement.bonus)) +
-      (levelRequirement.bonusNeededInterval ? ` (${levelRequirement.bonusNeededInterval})` : "")
-    }};
+    <span
+      :title="formatNumber(levelRequirement.bonus)"
+      @dblclick="toggleNumberSimplification"
+      style="cursor: pointer; user-select: none"
+      >{{
+        (configStore.myDataTableControl.simplifyNumbers
+          ? simplifyNumber(levelRequirement.bonus)
+          : formatNumber(levelRequirement.bonus)) +
+        (levelRequirement.bonusNeededInterval ? ` (${levelRequirement.bonusNeededInterval})` : "")
+      }}</span
+    >;
   </template>
 
   <template v-if="levelRequirement.seedingBonus">
@@ -146,12 +156,17 @@ function formatIntervalDate(duration: number | isoDuration): string {
       icon="mdi-lightning-bolt-circle"
       size="small"
     />
-    {{
-      (configStore.myDataTableControl.simplifyNumbers
-        ? simplifyNumber(levelRequirement.seedingBonus)
-        : formatNumber(levelRequirement.seedingBonus)) +
-      (levelRequirement.seedingBonusNeededInterval ? ` (${levelRequirement.seedingBonusNeededInterval})` : "")
-    }};
+    <span
+      :title="formatNumber(levelRequirement.seedingBonus)"
+      @dblclick="toggleNumberSimplification"
+      style="cursor: pointer; user-select: none"
+      >{{
+        (configStore.myDataTableControl.simplifyNumbers
+          ? simplifyNumber(levelRequirement.seedingBonus)
+          : formatNumber(levelRequirement.seedingBonus)) +
+        (levelRequirement.seedingBonusNeededInterval ? ` (${levelRequirement.seedingBonusNeededInterval})` : "")
+      }}</span
+    >;
   </template>
 
   <template v-if="levelRequirement.bonusPerHour">

--- a/src/entries/options/views/Overview/MyData/UserLevelShowSpan.vue
+++ b/src/entries/options/views/Overview/MyData/UserLevelShowSpan.vue
@@ -19,7 +19,7 @@ function toggleIntervalDisplay() {
 
 // Toggle function for double-click to switch number simplification
 function toggleNumberSimplification() {
-  configStore.myDataTableControl.simplifyNumbers = !configStore.myDataTableControl.simplifyNumbers;
+  configStore.myDataTableControl.simplifyBonusNumbers = !configStore.myDataTableControl.simplifyBonusNumbers;
 }
 
 // Get interval display text and title
@@ -141,7 +141,7 @@ function formatIntervalDate(duration: number | isoDuration): string {
       @dblclick="toggleNumberSimplification"
       style="cursor: pointer; user-select: none"
       >{{
-        (configStore.myDataTableControl.simplifyNumbers
+        (configStore.myDataTableControl.simplifyBonusNumbers
           ? simplifyNumber(levelRequirement.bonus)
           : formatNumber(levelRequirement.bonus)) +
         (levelRequirement.bonusNeededInterval ? ` (${levelRequirement.bonusNeededInterval})` : "")
@@ -161,7 +161,7 @@ function formatIntervalDate(duration: number | isoDuration): string {
       @dblclick="toggleNumberSimplification"
       style="cursor: pointer; user-select: none"
       >{{
-        (configStore.myDataTableControl.simplifyNumbers
+        (configStore.myDataTableControl.simplifyBonusNumbers
           ? simplifyNumber(levelRequirement.seedingBonus)
           : formatNumber(levelRequirement.seedingBonus)) +
         (levelRequirement.seedingBonusNeededInterval ? ` (${levelRequirement.seedingBonusNeededInterval})` : "")

--- a/src/entries/shared/types/storages/config.ts
+++ b/src/entries/shared/types/storages/config.ts
@@ -103,7 +103,7 @@ export interface IConfigPiniaStorageSchema {
     // 是否将 interval 显示为日期格式而不是持续时间格式
     showIntervalAsDate: boolean;
     // 是否简化数字显示（将大数字转换为带单位的简化形式）
-    simplifyNumbers: boolean;
+    simplifyBonusNumbers: boolean;
   };
 
   userDataTimelineControl: {

--- a/src/entries/shared/types/storages/config.ts
+++ b/src/entries/shared/types/storages/config.ts
@@ -102,6 +102,8 @@ export interface IConfigPiniaStorageSchema {
     updateAtFormatAsAlive: boolean;
     // 是否将 interval 显示为日期格式而不是持续时间格式
     showIntervalAsDate: boolean;
+    // 是否简化数字显示（将大数字转换为带单位的简化形式）
+    simplifyNumbers: boolean;
   };
 
   userDataTimelineControl: {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -225,6 +225,7 @@
       "showSeedingBonus": "Show Seeding Bonus",
       "updateAtFormatAsAlive": "Display update At as Relative Time",
       "showIntervalAsDate": "Display level requirement time as date format",
+      "simplifyNumbers": "Simplify Numbers",
       "multiOpen": "Open in batch",
       "viewTimeline": "Timeline",
       "viewStatistic": "Data Chart",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -225,7 +225,7 @@
       "showSeedingBonus": "Show Seeding Bonus",
       "updateAtFormatAsAlive": "Display update At as Relative Time",
       "showIntervalAsDate": "Display level requirement time as date format",
-      "simplifyNumbers": "Simplify Numbers",
+      "simplifyBonusNumbers": "Simplify Bonus Numbers",
       "multiOpen": "Open in batch",
       "viewTimeline": "Timeline",
       "viewStatistic": "Data Chart",

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -225,7 +225,7 @@
       "showSeedingBonus": "显示做种积分",
       "updateAtFormatAsAlive": "更新时间显示为相对时间",
       "showIntervalAsDate": "等级要求时间显示为日期格式",
-      "simplifyNumbers": "简化数字显示",
+      "simplifyBonusNumbers": "简化积分数字显示",
       "multiOpen": "批量打开",
       "viewTimeline": "时间轴",
       "viewStatistic": "数据图表",

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -225,6 +225,7 @@
       "showSeedingBonus": "显示做种积分",
       "updateAtFormatAsAlive": "更新时间显示为相对时间",
       "showIntervalAsDate": "等级要求时间显示为日期格式",
+      "simplifyNumbers": "简化数字显示",
       "multiOpen": "批量打开",
       "viewTimeline": "时间轴",
       "viewStatistic": "数据图表",


### PR DESCRIPTION
为MyData表格添加数字简化显示功能，使用国际标准缩写（K/M/B/T）替代长数字，提升用户体验。

## 主要变更

### 🎯 核心功能
- **数字简化显示**: 支持 K/M/B/T 国际缩写格式
- **智能小数处理**: 整数不显示小数，非整数保留2位小数
- **用户控制**: 可通过设置菜单开启/关闭功能

### 📁 影响范围
- 仅应用于 `bonus` 和 `seedingBonus` 字段
- 覆盖 `MyData/Index.vue` 和 `UserLevelShowSpan.vue` 组件

### 🔧 技术实现
- 新增 `simplifyNumbers` 配置选项
- 实现优化的 `simplifyNumber` 工具函数
- 数组驱动的循环结构，易于维护
- 完整的 TypeScript 类型支持

### 🌐 国际化
- 添加中文翻译: \"简化数字显示\"
- 添加英文翻译: \"Simplify Numbers\"

## 测试验证

- ✅ 类型检查通过
- ✅ 构建成功
- ✅ 功能测试完成
- ✅ 国际化文本正确

## 兼容性

- 向后兼容，默认关闭新功能
- 不影响现有数据显示逻辑
- 用户可自由选择开启或关闭