### PR TITLE
优化 SetSite 页面逻辑性能和代码质量

### DIFF
--- a/src/entries/options/views/Settings/SetSite/Index.vue
+++ b/src/entries/options/views/Settings/SetSite/Index.vue
@@ -34,8 +34,8 @@ const showOneClickImportDialog = ref<boolean>(false);
 const tableHeader = computed(() => {
   const baseHeaders = [
     // site favicon
-    { title: "", key: "userConfig.sortIndex", align: "center", width: 48 },
-    { title: t("SetSite.common.name"), key: "name", align: "left", width: 120, sortable: false },
+    { title: t("common.sortIndex"), key: "userConfig.sortIndex", align: "center", width: 48 },
+    { title: t("SetSite.common.name"), key: "name", align: "left", width: 120 },
     { title: t("SetSite.common.groups"), key: "groups", align: "left", minWidth: 120, sortable: false },
     { title: t("SetSite.common.url"), key: "url", align: "start", sortable: false },
     { title: t("SetSite.common.isOffline"), key: "userConfig.isOffline", align: "center", width: 180 },
@@ -73,7 +73,7 @@ const {
   parseOptions: {
     keywords: ["id", ...booleanUserConfigKeywords.map((x) => `userConfig.${x}`), "userConfig.groups"],
   },
-  titleFields: ["metadata.name", "metadata.urls", "userConfig.merge.name", "userConfig.url"],
+  titleFields: ["name", "metadata.urls", "userConfig.url"],
   format: {
     ...Object.fromEntries(booleanUserConfigKeywords.map((x) => [`userConfig.${x}`, "boolean"])),
   },
@@ -222,7 +222,7 @@ async function flushSiteFavicon(siteId: TSiteID | TSiteID[]) {
       </template>
       <template #item.name="{ item }">
         <span>
-          {{ item.userConfig?.merge?.name ?? item.metadata?.name }}
+          {{ item.name }}
           <v-tooltip max-width="400" v-if="item.metadata.description" activator="parent">
             <span v-if="typeof item.metadata.description === 'string'">{{ item.metadata.description }}</span>
             <ul v-else>

--- a/src/entries/options/views/Settings/SetSite/utils.ts
+++ b/src/entries/options/views/Settings/SetSite/utils.ts
@@ -4,34 +4,40 @@ import { definitionList, ISiteMetadata, type ISiteUserConfig, TSiteID } from "@p
 import { useMetadataStore } from "@/options/stores/metadata.ts";
 
 export async function getCanAddedSiteMetadata() {
-  const canAddedSiteMetadata: Record<TSiteID, ISiteMetadata> = {};
   const metadataStore = useMetadataStore();
   const canAddedSiteList = definitionList.filter((x) => !metadataStore.getAddedSiteIds.includes(x));
-  for (const siteId of canAddedSiteList) {
-    canAddedSiteMetadata[siteId] = await metadataStore.getSiteMetadata(siteId);
-  }
-  return canAddedSiteMetadata;
+
+  // 并行获取所有可添加站点的元数据
+  const metadataEntries = await Promise.all(
+    canAddedSiteList.map(async (siteId) => [siteId, await metadataStore.getSiteMetadata(siteId)] as const),
+  );
+
+  return Object.fromEntries(metadataEntries) as Record<TSiteID, ISiteMetadata>;
 }
 
 export interface ISiteTableItem {
   id: TSiteID;
   metadata: ISiteMetadata;
   userConfig: ISiteUserConfig;
+  name: string; // 计算出的站点名称，用于排序
 }
 
 export const allAddedSiteInfo = computedAsync<ISiteTableItem[]>(async () => {
   const metadataStore = useMetadataStore();
-  // noinspection BadExpressionStatementJS
-  Object.values(metadataStore.sites).map((x) => x);
 
-  const sitesReturn = [];
-  for (const [siteId, siteUserConfig] of Object.entries(metadataStore.sites)) {
-    sitesReturn.push({
-      id: siteId,
-      metadata: await metadataStore.getSiteMetadata(siteId),
-      userConfig: siteUserConfig,
-    });
-  }
+  // 使用 Promise.all 并行获取所有站点元数据，提高性能
+  const siteEntries = Object.entries(metadataStore.sites);
+  const sitesData = await Promise.all(
+    siteEntries.map(async ([siteId, siteUserConfig]) => {
+      const metadata = await metadataStore.getSiteMetadata(siteId);
+      return {
+        id: siteId as TSiteID,
+        metadata,
+        userConfig: siteUserConfig,
+        name: siteUserConfig?.merge?.name ?? metadata?.name ?? siteId,
+      };
+    }),
+  );
 
-  return sitesReturn;
+  return sitesData;
 });


### PR DESCRIPTION
### 性能提升
- 使用 `Promise.all` 并行获取站点元数据，替代原有的串行处理
- 在处理大量站点时显著减少加载时间

### 代码优化
- 简化 `titleFields` 配置，使用预计算的 `name` 字段
- 移除冗余的搜索字段，从 4 个减少到 3 个
- 提高搜索准确性和性能

### 代码质量
- 改进类型安全性，明确指定 `TSiteID` 类型
- 统一并行处理模式，提高代码一致性
- 移除无用代码，提升可维护性

## 🔧 技术细节
- `getCanAddedSiteMetadata`: 串行循环 → 并行映射
- `allAddedSiteInfo`: 逐个等待 → Promise.all 批量处理
- `titleFields`: 复杂路径搜索 → 简化字段搜索

## ✅ 测试
- 功能正常，排序和搜索工作正常
- 性能提升明显，特别是在站点数量较多时" --base master