### PR TITLE
fix: 优化获取 commit 数量的方法

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import process from "node:process";
 import path from "node:path";
+import { execSync } from "node:child_process";
 
 // Vite And it's plugins
 import { defineConfig } from "vite";
@@ -34,7 +35,8 @@ const permissions = [
   "unlimitedStorage",
 ];
 
-const base_version = `${pkg.version}.${git.count()}`;
+const commit_count = parseInt(execSync('git rev-list --count HEAD', { encoding: 'utf8' }).trim(), 10);
+const base_version = `${pkg.version}.${commit_count}`;
 const commit_version = `${base_version}+${git.short(__dirname)}`;
 
 // https://vitejs.dev/config/
@@ -215,7 +217,7 @@ export default defineConfig({
       short: git.short(__dirname),
       long: git.long(__dirname),
       date: +git.date(),
-      count: git.count(),
+      count: commit_count,
       branch: git.branch(__dirname),
     },
     __BUILD_TIME__: +Date.now(),


### PR DESCRIPTION
根据 [git-rev-sync](https://www.npmjs.com/package/git-rev-sync) 的说明以及 [代码](https://www.npmjs.com/package/git-rev-sync?activeTab=code)，其提供的 `git.count()` 会统计**所有分支**的 commit 总数（`git rev-list --all --count`），这容易造成理解上的偏差。因为 dependabot 提供的一部分 commit 在合并前以分支的形式存在，会影响 `git.count()`。

比如在当前这个时间，master分支只有932个commit，dependabot 另有4个commit在待合并分支中，`pnpm build:dist`编译完成的manifest.json中版本为：
```
"version":"0.0.4.936"
"version_name":"0.0.4.936+3d0e821"
```

而假如当前时间 dependabot 提供的 commit 被拒绝合并，且没有新 commit 的话，反而会导致新编译的版本号降低。

因此，将 `git.count()` 调整为直接调用 `git` 命令来只获取当前分支截止到当前commit的数量。
