### PR TITLE
feat(git-rev-sync): enhance git.count() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ PT-Depiler 是一个开源项目，遵循 [MIT 许可证](http://opensource.org/
 
 Copyright (c) 2020-present [pt-plugins](https://github.com/pt-plugins)
 
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=pt-plugins/PT-depiler&type=Date)](https://www.star-history.com/#pt-plugins/PT-depiler&Date)
+
 --------------
 
 特别感谢以下所有为本项目做出贡献的人 😍！

--- a/patches/git-rev-sync.patch
+++ b/patches/git-rev-sync.patch
@@ -1,0 +1,46 @@
+diff --git a/README.md b/README.md
+index fe04fc7673df9074dc7a4021f384ae92a76cc446..846cca9ff33737d26a01aa494ee3fab15c964916 100644
+--- a/README.md
++++ b/README.md
+@@ -48,9 +48,9 @@ return the result of `git rev-parse HEAD`; optional `filePath` parameter can be
+ 
+ return the current branch; optional `filePath` parameter can be used to run the command against a repo outside the current working directory
+ 
+-#### `git.count()` &rarr; &lt;Number&gt;
++#### `git.count([branch])` &rarr; &lt;Number&gt;
+ 
+-return the count of commits across all branches; this method will fail if the `git` command is not found in `PATH`
++returns the count of commits across all branches; optional `branch` parameter can be used to limit the count to a specific branch; this method will fail if the `git` command is not found in `PATH`
+ 
+ #### `git.date()` &rarr; &lt;Date&gt;
+ 
+diff --git a/index.js b/index.js
+index e0d0eea776cd8b319e7470c5bd9f5f6a8533f908..e91b52e07691b2ad6e2028325d8ea2a33aa9f01a 100644
+--- a/index.js
++++ b/index.js
+@@ -168,8 +168,8 @@ function date() {
+   return new Date(_command('git', ['log', '--no-color', '-n', '1', '--pretty=format:"%ad"']));
+ }
+ 
+-function count() {
+-  return parseInt(_command('git', ['rev-list', '--all', '--count']), 10);
++function count(branch) {
++  return parseInt(_command('git', ['rev-list', '--count', branch || '--all']), 10);
+ }
+ 
+ function log() {
+diff --git a/tests/index.js b/tests/index.js
+index 21a2dcf445416fec8a7b77a267448ee440fda22d..2bea362df0180c7b50975a07da8b10b11274c7ef 100644
+--- a/tests/index.js
++++ b/tests/index.js
+@@ -19,6 +19,10 @@ result = git.count();
+ assert.notEqual(result, 0, 'count() returns a non-zero number');
+ assert.equal(Math.abs(result), result, 'count() returns a positive number');
+ 
++result = git.count('HEAD');
++assert.notEqual(result, 0, 'count() returns a non-zero number');
++assert.equal(Math.abs(result), result, 'count() returns a positive number');
++
+ result = git.date();
+ assert.equal(result instanceof Date, true, 'date() returns a date');
+ 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  git-rev-sync:
+    hash: 3d9c4d584af1267020d909cdabbeb70f980a70f49789c9391c199648c693158e
+    path: patches/git-rev-sync.patch
+
 importers:
 
   .:
@@ -149,7 +154,7 @@ importers:
         version: 10.0.0
       git-rev-sync:
         specifier: ^3.0.2
-        version: 3.0.2
+        version: 3.0.2(patch_hash=3d9c4d584af1267020d909cdabbeb70f980a70f49789c9391c199648c693158e)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -5729,7 +5734,7 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  git-rev-sync@3.0.2:
+  git-rev-sync@3.0.2(patch_hash=3d9c4d584af1267020d909cdabbeb70f980a70f49789c9391c199648c693158e):
     dependencies:
       escape-string-regexp: 1.0.5
       graceful-fs: 4.1.15

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+patchedDependencies:
+  git-rev-sync: patches/git-rev-sync.patch

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,7 +34,9 @@ const permissions = [
   "unlimitedStorage",
 ];
 
-const base_version = `${pkg.version}.${git.count()}`;
+// @ts-ignore
+const git_count = git.count("HEAD");
+const base_version = `${pkg.version}.${git_count}`;
 const commit_version = `${base_version}+${git.short(__dirname)}`;
 
 // https://vitejs.dev/config/
@@ -215,7 +217,7 @@ export default defineConfig({
       short: git.short(__dirname),
       long: git.long(__dirname),
       date: +git.date(),
-      count: git.count(),
+      count: git_count,
       branch: git.branch(__dirname),
     },
     __BUILD_TIME__: +Date.now(),


### PR DESCRIPTION
鉴于 git-rev-sync 库已经不更新，我们可以考虑直接使用 pnpm patch <package> 的方式，拓展 `git.count()` 方法。实现 commmit count 在 action/checkout 的 fetch-depth:0 条件下，不受其他分支的影响。

refs: https://github.com/kurttheviking/git-rev-sync-js/pull/64
closed: https://github.com/pt-plugins/PT-depiler/pull/385