### PR TITLE
fix(datetime): 增加对常见日期格式的原生处理支持

### DIFF
--- a/src/packages/site/schemas/NexusPHP.ts
+++ b/src/packages/site/schemas/NexusPHP.ts
@@ -281,10 +281,10 @@ export const SchemaMetadata: Pick<
 
   userInfo: {
     /**
-     * 我们认为NPHP站的 id, joinTime 的情况永远不变（实质上对于所有站点都应该是这样的）
+     * 我们认为NPHP站的 id 的情况永远不变（实质上对于所有站点都应该是这样的）
      * 部分 NPHP 站点允许修改 name，所以 name 不能视为不变 ！！！
      */
-    pickLast: ["id", "joinTime"],
+    pickLast: ["id"],
     selectors: {
       // "page": "/index.php",
       id: {

--- a/src/packages/site/utils/datetime.ts
+++ b/src/packages/site/utils/datetime.ts
@@ -71,6 +71,13 @@ export function parseValidTimeString(query: string, formatString: string[] = [])
       return +time;
     }
   }
+
+  // 尝试使用原生 Date 构造函数，它能处理很多常见格式
+  let nativeDate = new Date(query);
+  if (isValid(nativeDate)) {
+    return +nativeDate;
+  }
+
   return query;
 }
 


### PR DESCRIPTION
能够正确处理的情况：

✅ 前后有空格：" 2024-01-15 " → 正确解析
✅ 简单前缀文字："Date: 2024-01-15" → 正确解析
✅ 某些英文前缀："Time is 2024-01-15 10:30:00" → 正确解析
✅ 后缀括号："2024-01-15 (updated)" → 正确解析
✅ 时区标识："2024-01-15 10:30:00 GMT" → 正确解析
无法处理的情况：

❌ 复杂描述："Published on 2024-01-15 at 10:30" → 解析失败
❌ 中文字符："发布时间：2024-01-15" → 解析失败
❌ 无效格式："2024-13-45" → 解析失败