### PR TITLE
fix(UserLevelRequirementsTd): 修复 Interval 和 Date 相互转换的错误

### DIFF
--- a/src/entries/options/views/Overview/MyData/UserLevelRequirementsTd.vue
+++ b/src/entries/options/views/Overview/MyData/UserLevelRequirementsTd.vue
@@ -159,7 +159,12 @@ const userLevelGroupIcon = computed(() => {
                         }}
                       </span>
                       <span>&nbsp;({{ userLevel.name }}):&nbsp;</span>
-                      <UserLevelsComponent :level-requirement="userLevel" />
+                      <!-- 展示用户等级要求时， interval 向 date 的转换应该基于 joinTime 计算 -->
+                      <UserLevelsComponent
+                        :user-info="userInfo"
+                        :level-requirement="userLevel"
+                        :useJoinTimeAsRef="true"
+                      />
                     </div>
 
                     <div class="text-ellipsis text-truncate" :title="userLevel.privilege">

--- a/src/entries/options/views/Overview/MyData/UserLevelRequirementsTd.vue
+++ b/src/entries/options/views/Overview/MyData/UserLevelRequirementsTd.vue
@@ -150,15 +150,7 @@ const userLevelGroupIcon = computed(() => {
                     </template>
 
                     <div>
-                      <span v-if="userLevel.interval">
-                        {{
-                          formatDate(
-                            convertIsoDurationToDate(userLevel.interval, userInfo.joinTime ?? currentTime),
-                            "yyyy-MM-dd",
-                          )
-                        }}
-                      </span>
-                      <span>&nbsp;({{ userLevel.name }}):&nbsp;</span>
+                      <span>{{ userLevel.name }}:&nbsp;</span>
                       <!-- 展示用户等级要求时， interval 向 date 的转换应该基于 joinTime 计算 -->
                       <UserLevelsComponent
                         :user-info="userInfo"

--- a/src/entries/options/views/Overview/MyData/UserLevelShowSpan.vue
+++ b/src/entries/options/views/Overview/MyData/UserLevelShowSpan.vue
@@ -49,12 +49,18 @@ function getIntervalDisplay(interval: number | isoDuration) {
 }
 
 function formatDuration(duration: number | isoDuration) {
-  if (typeof duration === "number") {
-    // 如果是秒数，先转换为ISO duration格式再显示
-    const isoDurationStr = convertSecondsToIsoDuration(duration);
-    return isoDurationStr.substring(1);
-  } else {
-    return duration.substring(1);
+  try {
+    if (typeof duration === "number") {
+      // 如果是秒数，先转换为ISO duration格式再显示
+      const isoDurationStr = convertSecondsToIsoDuration(duration);
+      return isoDurationStr.substring(1);
+    } else {
+      if (duration === "P") return "0D"; // 修正：如果 duration 只有 P，返回 0D
+      return duration.substring(1);
+    }
+  } catch (e) {
+    console.error("Error formatting duration:", e);
+    return "";
   }
 }
 

--- a/src/entries/options/views/Overview/MyData/UserLevelShowSpan.vue
+++ b/src/entries/options/views/Overview/MyData/UserLevelShowSpan.vue
@@ -59,7 +59,7 @@ function formatDuration(duration: number | isoDuration) {
       return duration.substring(1);
     }
   } catch (e) {
-    console.error("Error formatting duration:", e);
+    console.error("Error formatting duration:", duration, e);
     return "";
   }
 }
@@ -79,7 +79,7 @@ function formatIntervalDate(duration: number | isoDuration): string {
       return typeof result === "string" ? result : "";
     }
   } catch (e) {
-    console.error("Error formatting interval date:", e);
+    console.error("Error formatting interval date:", duration, e);
     return "";
   }
 }

--- a/src/entries/options/views/Overview/MyData/UserLevelShowSpan.vue
+++ b/src/entries/options/views/Overview/MyData/UserLevelShowSpan.vue
@@ -1,12 +1,25 @@
 <script setup lang="ts">
 import { useI18n } from "vue-i18n";
-import { IImplicitUserInfo, isoDuration, convertIsoDurationToDate, convertSecondsToIsoDuration } from "@ptd/site";
+import {
+  IImplicitUserInfo,
+  isoDuration,
+  convertIsoDurationToDate,
+  convertSecondsToIsoDuration,
+  type IUserInfo,
+} from "@ptd/site";
 import { formatNumber, formatSize, formatDate, simplifyNumber } from "@/options/utils";
 import { useConfigStore } from "@/options/stores/config";
 
-const { levelRequirement, hideRatioInTable = false } = defineProps<{
+const {
+  userInfo,
+  levelRequirement,
+  hideRatioInTable = false,
+  useJoinTimeAsRef = false,
+} = defineProps<{
+  userInfo: IUserInfo;
   levelRequirement: IImplicitUserInfo;
   hideRatioInTable?: boolean;
+  useJoinTimeAsRef?: boolean; // 在 formatIntervalDate 中是否使用 joinTime 作为参考时间，默认参考为 currentTime
 }>();
 
 const { t } = useI18n();
@@ -47,17 +60,20 @@ function formatDuration(duration: number | isoDuration) {
 
 function formatIntervalDate(duration: number | isoDuration): string {
   try {
+    // 展示剩余时间时，基于 current 计算；展现等级要求时，基于 joinTime 计算
+    const refTime = useJoinTimeAsRef ? (userInfo.joinTime ?? currentTime) : currentTime;
     if (typeof duration === "number") {
-      // 如果是数字（秒），直接基于当前时间计算
-      const targetDate = new Date(currentTime + duration * 1000);
+      // 如果是数字（秒）
+      const targetDate = new Date(refTime + duration * 1000);
       const result = formatDate(targetDate, "yyyy-MM-dd");
       return typeof result === "string" ? result : "";
     } else {
-      // 如果是isoDuration字符串，基于当前时间计算
-      const result = formatDate(convertIsoDurationToDate(duration, currentTime), "yyyy-MM-dd");
+      // 如果是isoDuration字符串
+      const result = formatDate(convertIsoDurationToDate(duration, refTime), "yyyy-MM-dd");
       return typeof result === "string" ? result : "";
     }
   } catch (e) {
+    console.error("Error formatting interval date:", e);
     return "";
   }
 }

--- a/src/entries/options/views/Overview/MyData/UserLevelsComponent.vue
+++ b/src/entries/options/views/Overview/MyData/UserLevelsComponent.vue
@@ -1,21 +1,40 @@
 <script setup lang="ts">
-import { type ILevelRequirement } from "@ptd/site";
+import { type ILevelRequirement, type IUserInfo } from "@ptd/site";
 
 import UserLevelShowSpan from "./UserLevelShowSpan.vue";
 
-const { levelRequirement, hideRatioInTable = false } = defineProps<{
+const {
+  userInfo,
+  levelRequirement,
+  hideRatioInTable = false,
+  useJoinTimeAsRef = false,
+} = defineProps<{
+  userInfo: IUserInfo;
   levelRequirement: Omit<ILevelRequirement, "id" | "name">;
   hideRatioInTable?: boolean;
+  useJoinTimeAsRef?: boolean;
 }>();
 </script>
 
 <template>
-  <UserLevelShowSpan :level-requirement="levelRequirement" :hide-ratio-in-table="hideRatioInTable" />
+  <UserLevelShowSpan
+    :user-info="userInfo"
+    :level-requirement="levelRequirement"
+    :hide-ratio-in-table="hideRatioInTable"
+    :useJoinTimeAsRef="useJoinTimeAsRef"
+  />
   <template v-if="levelRequirement.alternative">
     <v-icon icon="mdi-file-table-box-multiple-outline" size="small" />
     (
     <template v-for="(alternative, key) in levelRequirement.alternative" :key="key">
-      [ <UserLevelShowSpan :level-requirement="alternative" :hide-ratio-in-table="hideRatioInTable" /> ]
+      [
+      <UserLevelShowSpan
+        :user-info="userInfo"
+        :level-requirement="alternative"
+        :hide-ratio-in-table="hideRatioInTable"
+        :useJoinTimeAsRef="useJoinTimeAsRef"
+      />
+      ]
     </template>
     )
   </template>

--- a/src/entries/options/views/Overview/MyData/UserNextLevelUnMet.vue
+++ b/src/entries/options/views/Overview/MyData/UserNextLevelUnMet.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useI18n } from "vue-i18n";
 import { type IImplicitUserInfo, type ILevelRequirement, IUserInfo } from "@ptd/site";
 
 import UserLevelsComponent from "./UserLevelsComponent.vue";
@@ -15,10 +14,6 @@ const {
   showNextLevelName?: boolean;
   iconClass?: string;
 }>();
-
-const currentTime = +new Date();
-
-const { t } = useI18n();
 </script>
 
 <template>
@@ -27,7 +22,7 @@ const { t } = useI18n();
 
   <span v-if="showNextLevelName && nextLevelUnMet.level">{{ nextLevelUnMet.level.name }}:&nbsp;</span>
 
-  <UserLevelsComponent :level-requirement="nextLevelUnMet" :hide-ratio-in-table="true" />
+  <UserLevelsComponent :user-info="userInfo" :level-requirement="nextLevelUnMet" :hide-ratio-in-table="true" />
 </template>
 
 <style scoped lang="scss"></style>


### PR DESCRIPTION
错误如图：
<img width="1060" height="776" alt="2025-08-16_194925" src="https://github.com/user-attachments/assets/4d74a4ad-2a31-4a92-97cc-de2bd7727e11" />


其中：
第二个图的问题已经完全修复。
第一个图中，排查到此情境下 formatDuration 函数的传入参数 duration 为 "P"，而不是预期的 "P0D"，没有追到原因，故仅做了临时性修补。