### PR TITLE
feat(search): 添加IMDB搜索Fallback逻辑，优化关键词处理

### DIFF
--- a/src/packages/site/schemas/AbstractBittorrentSite.ts
+++ b/src/packages/site/schemas/AbstractBittorrentSite.ts
@@ -219,6 +219,22 @@ export default class BittorrentSite {
       }
     }
 
+    // 4.5. 如果站点没有配置高级搜索词支持，但检测到高级搜索词格式的处理
+    if (keywords && !advanceKeywordConfig) {
+      // 只有IMDB搜索才fallback到普通关键词搜索
+      if (/^imdb\|/.test(keywords)) {
+        const match = keywords.match(/^imdb\|(.+)$/);
+        if (match && match[1]) {
+          keywords = match[1]; // 提取实际的搜索值作为普通关键词
+        }
+      }
+      // 其他高级搜索词格式（douban|, bangumi|, anidb|, tmdb|, tvdb|, mal|）直接跳过
+      else if (/^(douban|bangumi|anidb|tmdb|tvdb|mal)\|/.test(keywords)) {
+        result.status = EResultParseStatus.passParse;
+        return result;
+      }
+    }
+
     // 5. 首先将搜索关键词根据 keywordsParam 放入请求配置中，注意如果是 advanceKeyword 已经被去除了前缀 `${advanceKeywordType}|`
     if (keywords) {
       set(requestConfig, searchEntry.keywordPath || "params.keywords", keywords || "");


### PR DESCRIPTION
# IMDB搜索Fallback修复

## 问题描述

当站点没有配置IMDB搜索支持（`advanceKeywordParams.imdb`）时，使用"imdb|ttxxxxx"格式搜索会导致错误，因为关键词未被正确处理。

## 解决方案

在`AbstractBittorrentSite.ts`中添加了智能的fallback逻辑：
- **只有IMDB搜索**会fallback到普通关键词搜索（提取"ttxxxxx"部分）
- **其他高级搜索词**（douban、bangumi、anidb、tmdb、tvdb、mal）如果没有配置会返回`EResultParseStatus.passParse`

## 修改内容

**文件**: `src/packages/site/schemas/AbstractBittorrentSite.ts`
**位置**: `getSearchResult`方法，在步骤4和步骤5之间

添加了以下逻辑：

```typescript
// 4.5. 如果站点没有配置高级搜索词支持，但检测到高级搜索词格式的处理
if (keywords && !advanceKeywordConfig) {
  // 只有IMDB搜索才fallback到普通关键词搜索
  if (/^imdb\|/.test(keywords)) {
    const match = keywords.match(/^imdb\|(.+)$/);
    if (match && match[1]) {
      keywords = match[1]; // 提取实际的搜索值作为普通关键词
    }
  }
  // 其他高级搜索词格式（douban|, bangumi|, anidb|, tmdb|, tvdb|, mal|）直接跳过
  else if (/^(douban|bangumi|anidb|tmdb|tvdb|mal)\|/.test(keywords)) {
    result.status = EResultParseStatus.passParse;
    return result;
  }
}
```

## 预期行为

### IMDB搜索（特殊处理）
- **修复前**: 搜索"imdb|tt0133093" → 在IPTorrents等没有IMDB配置的站点会直接搜索"imdb|tt0133093"字符串，导致无结果
- **修复后**: 搜索"imdb|tt0133093" → 自动fallback到搜索"tt0133093"，能正常返回结果

### 其他高级搜索词（跳过处理）
- **修复前**: 搜索"douban|1292052" → 在没有配置的站点会直接搜索"douban|1292052"字符串，导致无结果
- **修复后**: 搜索"douban|1292052" → 返回`passParse`状态，表示跳过此站点

### 有配置的站点
所有有相应高级搜索配置的站点不受影响，继续使用原有的高级搜索逻辑。

## 设计理念

这种区别处理是基于以下考虑：
1. **IMDB ID通常具有通用性** - "tt0133093"这样的ID在大多数站点都能作为有效的搜索关键词
2. **其他ID缺乏通用性** - 豆瓣ID、Bangumi ID等通常只在特定站点有意义，盲目搜索可能产生误导性结果
3. **用户体验优化** - IMDB搜索的fallback能提供有用结果，而其他类型的搜索最好明确跳过

## 影响范围

此修复应用于所有继承自`AbstractBittorrentSite`的站点，包括：
- IPTorrents（主要目标）
- 其他没有配置相应高级搜索参数的BitTorrent站点

有配置高级搜索参数的站点不受影响，继续使用原有的高级搜索逻辑。

## 测试验证

修复已通过以下测试：
1. ✅ 普通搜索关键词保持不变
2. ✅ IMDB格式在无配置时正确fallback  
3. ✅ 其他高级搜索词格式在无配置时正确返回passParse
4. ✅ 有配置的站点继续正常工作
5. ✅ 项目构建成功，无语法错误
6. ✅ 不输出调试日志，保持代码整洁
