### PR TITLE
fix(search): 修复种子状态判断逻辑

### DIFF
--- a/src/entries/options/utils.ts
+++ b/src/entries/options/utils.ts
@@ -43,7 +43,7 @@ export const formValidateRules: Record<string, (args?: any) => (v: any) => boole
 
 export const formatSize = (size: number | string, options?: FilesizeOptions) => {
   try {
-    return filesize(size, { base: 2, ...(options ?? {}) });
+    return filesize(size, { base: 2, round: 2, pad: true, ...(options ?? {}) });
   } catch (e) {
     return size;
   }

--- a/src/packages/site/definitions/chdbits.ts
+++ b/src/packages/site/definitions/chdbits.ts
@@ -1,4 +1,4 @@
-import { type ISiteMetadata } from "../types";
+import { ETorrentStatus, type ISiteMetadata } from "../types";
 import { SchemaMetadata } from "../schemas/NexusPHP";
 
 export const siteMetadata: ISiteMetadata = {
@@ -143,6 +143,58 @@ export const siteMetadata: ISiteMetadata = {
       ],
     },
   ],
+
+  search: {
+    ...SchemaMetadata.search,
+    selectors: {
+      ...SchemaMetadata.search!.selectors,
+      progress: {
+        selector: ["td.rowfollow:last"],
+        elementProcess: (element: HTMLElement) => {
+          const text = element.textContent?.trim() || "";
+          // 如果是"--"表示未知
+          if (text === "--") {
+            return 0;
+          }
+          const percentMatch = text.match(/(\d+)%/);
+          return percentMatch ? parseInt(percentMatch[1]) : 0;
+        },
+      },
+      status: {
+        selector: ["td.rowfollow:last"],
+        elementProcess: (element: HTMLElement) => {
+          const text = element.textContent?.trim() || "";
+          const style = element.getAttribute("style");
+
+          // 如果是"--"表示未知状态
+          if (text === "--") {
+            return ETorrentStatus.unknown;
+          }
+
+          // 检查是否包含百分比
+          const percentMatch = text.match(/(\d+)%/);
+          if (!percentMatch) {
+            return ETorrentStatus.unknown;
+          }
+
+          const percentage = parseInt(percentMatch[1]);
+          if (style) {
+            if (percentage === 100) {
+              return ETorrentStatus.seeding;
+            } else {
+              return ETorrentStatus.downloading;
+            }
+          } else {
+            if (percentage === 100) {
+              return ETorrentStatus.completed;
+            } else {
+              return ETorrentStatus.inactive;
+            }
+          }
+        },
+      },
+    },
+  },
 
   levelRequirements: [
     {

--- a/src/packages/site/schemas/AbstractBittorrentSite.ts
+++ b/src/packages/site/schemas/AbstractBittorrentSite.ts
@@ -544,7 +544,7 @@ export default class BittorrentSite {
     typeof torrent.completed != "undefined" && (torrent.completed = tryToNumber(torrent.completed));
     typeof torrent.comments != "undefined" && (torrent.comments = tryToNumber(torrent.comments));
     typeof torrent.category != "undefined" && (torrent.category = tryToNumber(torrent.category));
-    typeof torrent.status != "undefined" && (torrent.status = ETorrentStatus.unknown);
+    typeof torrent.status == "undefined" && (torrent.status = ETorrentStatus.unknown);
 
     // 仅当设置了时区偏移时，才进行转换
     if (this.metadata.timezoneOffset && typeof torrent.time !== "undefined") {


### PR DESCRIPTION
## 问题描述
修复搜索结果中种子状态判断逻辑的问题。

## 更改内容

### 1. 修复基础模式中的状态设置逻辑 (`src/packages/site/schemas/AbstractBittorrentSite.ts`)
- 修复了一个逻辑错误：将 `typeof torrent.status != "undefined"` 改为 `typeof torrent.status == "undefined"`
- 确保只有在状态未定义时才设置为未知状态

### 2. 优化文件大小格式化 (`src/entries/options/utils.ts`)
- 为文件大小显示添加了 `round: 2` 和 `pad: true` 选项，提升显示一致性

## 测试
已站点测试，种子状态现在能够正确识别和显示。

## 类型
- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 性能优化