### PR TITLE
refactor: 移除下载历史表格№列并优化排序配置

### DIFF
--- a/src/entries/options/stores/config.ts
+++ b/src/entries/options/stores/config.ts
@@ -29,6 +29,25 @@ export const useConfigStore = defineStore("config", {
         }
       }
 
+      // 清理基于 id 字段的 DownloadHistory 排序配置
+      if (state.tableBehavior?.DownloadHistory?.sortBy) {
+        const sortBy = state.tableBehavior.DownloadHistory.sortBy;
+        // 过滤掉基于 id 字段的排序项
+        const filteredSortBy = sortBy.filter((sort: any) => sort.key !== "id");
+
+        // 如果过滤后数组长度发生变化，说明移除了基于 id 的排序项
+        if (filteredSortBy.length !== sortBy.length) {
+          // 如果过滤后没有任何排序项，使用默认的 downloadAt 排序
+          if (filteredSortBy.length === 0) {
+            state.tableBehavior.DownloadHistory.sortBy = [{ key: "downloadAt", order: "desc" }];
+          } else {
+            // 否则保留其他有效的排序项
+            state.tableBehavior.DownloadHistory.sortBy = filteredSortBy;
+          }
+          needsSave = true;
+        }
+      }
+
       if (needsSave) {
         context.store.$save();
       }
@@ -101,7 +120,7 @@ export const useConfigStore = defineStore("config", {
       },
       DownloadHistory: {
         itemsPerPage: 10,
-        sortBy: [{ key: "id", order: "desc" }],
+        sortBy: [{ key: "downloadAt", order: "desc" }],
       },
       SearchResultSnapshot: {
         itemsPerPage: 25,

--- a/src/entries/options/views/Overview/DownloadHistory/Index.vue
+++ b/src/entries/options/views/Overview/DownloadHistory/Index.vue
@@ -35,7 +35,6 @@ const { tableFilterRef, tableWaitFilterRef, tableFilterFn } = tableCustomFilter;
 const tableHeader = computed(
   () =>
     [
-      { title: "№", key: "id", align: "center" },
       { title: t("DownloadHistory.table.site"), key: "siteId", align: "center" },
       {
         title: t("DownloadHistory.table.title"),


### PR DESCRIPTION
## 概述

此PR移除了下载历史表格中的"№"列，并优化了相关的排序配置，提升用户体验和界面简洁性。

## 主要修改

### 1. 界面优化
- **移除下载历史表格中的"№"列**：该列对用户价值有限，移除后界面更加简洁
- 保持所有现有功能正常工作（选择、操作等）

### 2. 排序优化
- **默认排序改进**：从按ID排序改为按下载时间排序，更符合用户使用习惯
- **智能配置清理**：自动处理已保存的基于ID字段的排序配置

### 3. 向后兼容性
- **智能清理机制**：自动检测并移除基于`id`字段的排序配置
- **多重排序支持**：只移除`id`排序项，保留用户设置的其他有效排序
- **平滑迁移**：确保现有用户的排序偏好得到妥善处理

## 技术细节

### 文件修改
1. `src/entries/options/views/Overview/DownloadHistory/Index.vue`
   - 从`tableHeader`中移除`{ title: "№", key: "id", align: "center" }`

2. `src/entries/options/stores/config.ts`
   - 默认排序配置：`{ key: "id", order: "desc" }` → `{ key: "downloadAt", order: "desc" }`
   - 添加`afterRestore`钩子中的智能清理逻辑

### 功能保证
- ✅ **选择功能**：继续使用`item-value="id"`，多选功能正常
- ✅ **过滤功能**：基于`filter-keys="['id']"`，不受影响  
- ✅ **操作功能**：重新下载、删除等基于`item.id`，完全正常
- ✅ **排序功能**：现在默认按下载时间排序，更有意义

### 清理逻辑示例
- **单一ID排序**：`[{ key: "id", order: "desc" }]` → `[{ key: "downloadAt", order: "desc" }]`
- **多重排序**：`[{ key: "id", order: "desc" }, { key: "downloadAt", order: "asc" }]` → `[{ key: "downloadAt", order: "asc" }]`
- **无ID排序**：`[{ key: "downloadAt", order: "asc" }]` → 不受影响

## 测试

- ✅ 构建成功：`pnpm build:dist` 通过
- ✅ 类型检查通过，无TypeScript错误
- ✅ 代码格式化和lint通过

## 用户影响

- **新用户**：享受更简洁的界面和更合理的默认排序
- **现有用户**：平滑过渡，自动清理无效配置，保留有效的排序偏好
- **功能完整性**：所有现有功能继续正常工作

## 截图

### 修改前
表格包含№列，按ID排序

### 修改后
表格更简洁，按下载时间排序，用户体验更佳