### PR TITLE
feat(contextMenus): 增强右键菜单下载功能，添加标题和URL元数据支持

### DIFF
--- a/src/entries/background/utils/contextMenus.ts
+++ b/src/entries/background/utils/contextMenus.ts
@@ -58,9 +58,19 @@ function clearContextMenus() {
 
 onMessage("clearContextMenus", async () => clearContextMenus());
 
-function downloadLinkPush(link: string, downloader: IDownloaderMetadata, folder?: string) {
+function downloadLinkPush(
+  link: string,
+  downloader: IDownloaderMetadata,
+  folder?: string,
+  title?: string,
+  url?: string,
+) {
   sendMessage("downloadTorrentToDownloader", {
-    torrent: { link }, // 组装一个最小的种子对象
+    torrent: {
+      link,
+      title,
+      url,
+    }, // 组装包含标题和URL的种子对象
     downloaderId: downloader.id,
     addTorrentOptions: {
       addAtPaused: !(downloader?.feature?.DefaultAutoStart ?? true),
@@ -243,7 +253,7 @@ async function initContextMenus(tab: chrome.tabs.Tab) {
           contexts: ["link"],
           // 此处不用担心子目录问题，因为如果有子目录，此处的 onclick 不会被 chrome 触发
           onclick: (info: chrome.contextMenus.OnClickData, tab: chrome.tabs.Tab) => {
-            downloadLinkPush(info.linkUrl!, downloader);
+            downloadLinkPush(info.linkUrl!, downloader, undefined, tab?.title, tab?.url);
           },
         });
 
@@ -287,7 +297,7 @@ async function initContextMenus(tab: chrome.tabs.Tab) {
               title: `-> ${suggestFolder || chrome.i18n.getMessage("contextMenuSendToDownloaderDefaultFolder")}`, // 如果是空字符串，则显示为 "默认文件夹"
               contexts: ["link"],
               onclick: (info: chrome.contextMenus.OnClickData, tab: chrome.tabs.Tab) => {
-                downloadLinkPush(info.linkUrl!, downloader, suggestFolder);
+                downloadLinkPush(info.linkUrl!, downloader, suggestFolder, tab?.title, tab?.url);
               },
             });
           }


### PR DESCRIPTION
## 概述

此PR增强了右键菜单的下载功能，在通过右键菜单发送种子到下载器时，现在会包含页面标题和URL作为元数据。

## 改动内容

- 为 `downloadLinkPush` 函数添加了 `title` 和 `url` 参数
- 在调用下载功能时传递当前标签页的标题和URL
- 为种子下载提供更多的上下文信息

## 技术细节

### 修改的文件
- `src/entries/background/utils/contextMenus.ts`

### 主要变更
1. **函数签名更新**: `downloadLinkPush` 函数现在接受可选的 `title` 和 `url` 参数
2. **种子对象增强**: 传递给下载器的种子对象现在包含标题和URL信息
3. **调用点更新**: 所有调用 `downloadLinkPush` 的地方都已更新以传递标签页元数据

### 向后兼容性
- 新增的参数都是可选的，确保向后兼容
- 不会破坏现有的下载功能

## 收益

- 提供更丰富的种子元数据给下载器
- 便于用户在下载器中识别种子来源
- 改善整体用户体验

## 测试

请测试以下场景：
- [ ] 通过右键菜单直接发送到下载器
- [ ] 通过右键菜单发送到下载器的特定文件夹
- [ ] 验证标题和URL是否正确传递

## 相关Issue

此更改改进了右键菜单功能，为种子下载提供了更好的上下文信息。