### PR TITLE
fix(utils/html): 标准化域名，去除常见子域名前缀

### DIFF
--- a/src/packages/site/utils/html.ts
+++ b/src/packages/site/utils/html.ts
@@ -55,6 +55,16 @@ export function getHostFromUrl(url: string): TSiteHost {
   try {
     const urlObj = new URL(url);
     host = urlObj.host;
+
+    // 标准化域名：去除常见的子域名前缀
+    const parts = host.split(".");
+    if (parts.length >= 3) {
+      // 只对常见的子域名前缀进行处理，避免误删重要的子域名
+      const commonSubdomains = ["www", "mobile"];
+      if (commonSubdomains.includes(parts[0].toLowerCase())) {
+        host = parts.slice(1).join(".");
+      }
+    }
   } catch (e) {}
 
   return host;


### PR DESCRIPTION
Implement a utility function to standardize domain names by removing common subdomain prefixes like "www" and "mobile." This change enhances the consistency of domain handling.