### PR TITLE
feat(UserInfo): 添加清除LastUserInfo缓存功能

### DIFF
--- a/src/entries/options/stores/metadata.ts
+++ b/src/entries/options/stores/metadata.ts
@@ -346,9 +346,22 @@ export const useMetadataStore = defineStore("metadata", {
 
     async removeSite(siteId: TSiteID) {
       delete this.sites[siteId];
+      // 同时清理站点的lastUserInfo缓存
+      if (this.lastUserInfo[siteId]) {
+        delete this.lastUserInfo[siteId];
+      }
       await this.buildSiteHostMap();
       await this.buildSiteNameMap();
       await this.$save();
+    },
+
+    async clearSiteLastUserInfo(siteId: TSiteID) {
+      if (this.lastUserInfo[siteId]) {
+        delete this.lastUserInfo[siteId];
+        await this.$save();
+        return true;
+      }
+      return false;
     },
 
     /**

--- a/src/entries/options/views/Overview/MyData/HistoryDataViewDialog.vue
+++ b/src/entries/options/views/Overview/MyData/HistoryDataViewDialog.vue
@@ -8,6 +8,8 @@ import type { DataTableHeader } from "vuetify/lib/components/VDataTable/types";
 import { sendMessage } from "@/messages.ts";
 import { formatNumber, formatSize, formatDate } from "@/options/utils.ts";
 import { fixUserInfo, formatRatio } from "./utils.ts";
+import { useMetadataStore } from "@/options/stores/metadata.ts";
+import { useRuntimeStore } from "@/options/stores/runtime";
 
 import SiteName from "@/options/components/SiteName.vue";
 import NavButton from "@/options/components/NavButton.vue";
@@ -17,6 +19,8 @@ const props = defineProps<{
   siteId: TSiteID | null;
 }>();
 const { t } = useI18n();
+const metadataStore = useMetadataStore();
+const runtimeStore = useRuntimeStore();
 
 const currentDate = formatDate(+new Date(), "yyyy-MM-dd");
 const jsonData = ref<any>({});
@@ -76,6 +80,17 @@ function exportSiteHistoryData() {
 
   const exportedSolutionBlob = new Blob([JSON.stringify(exportData, null, 2)], { type: "application/json" });
   saveAs(exportedSolutionBlob, `site-history-data-${props.siteId}.json`); // FIXME filename
+}
+
+async function clearSiteLastUserInfo() {
+  if (!props.siteId || !confirm(t("MyData.HistoryDataView.clearLastUserInfoConfirm"))) {
+    return;
+  }
+
+  const cleared = await metadataStore.clearSiteLastUserInfo(props.siteId);
+  if (cleared) {
+    runtimeStore.showSnakebar(t("MyData.HistoryDataView.clearLastUserInfoSuccess"), { color: "success" });
+  }
 }
 </script>
 
@@ -210,6 +225,15 @@ function exportSiteHistoryData() {
               @click="deleteSiteUserInfo(tableSelected)"
             />
             <NavButton color="info" icon="mdi-export" text="导出" @click="exportSiteHistoryData" />
+
+            <v-divider class="mx-2" vertical />
+
+            <NavButton
+              color="warning"
+              icon="mdi-cached"
+              :text="t('MyData.HistoryDataView.clearLastUserInfo')"
+              @click="clearSiteLastUserInfo"
+            />
             <v-spacer />
           </template>
         </v-data-table>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -273,6 +273,9 @@
     "HistoryDataView": {
       "title": "User History Data @ ",
       "deleteConfirm": "Confirm to delete this history data?",
+      "clearLastUserInfo": "Clear Cache",
+      "clearLastUserInfoConfirm": "Confirm to clear site user info cache? This will re-fetch all fields on next refresh.",
+      "clearLastUserInfoSuccess": "Site user info cache cleared, new data will be fetched on next refresh.",
       "action": {
         "viewRaw": "View Raw Data"
       }

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -273,6 +273,9 @@
     "HistoryDataView": {
       "title": "用户历史数据",
       "deleteConfirm": "确认删除这条历史数据吗？",
+      "clearLastUserInfo": "清除缓存",
+      "clearLastUserInfoConfirm": "确认清除站点用户信息缓存吗？这将在下次刷新时重新获取所有字段。",
+      "clearLastUserInfoSuccess": "站点用户信息缓存已清除，下次刷新将获取新数据。",
       "action": {
         "viewRaw": "查看原始数据"
       }


### PR DESCRIPTION
## 🚀 功能概述

在用户历史数据查看对话框中添加清除站点 LastUserInfo 缓存的功能，允许用户手动清除 pickLast 缓存数据。

## 📋 更改内容

### 核心功能
- ✅ 在 `metadata.ts` 中添加 `clearSiteLastUserInfo()` 方法
- ✅ 在 `HistoryDataViewDialog.vue` 中添加清除缓存按钮和逻辑
- ✅ 添加确认对话框和成功通知
- ✅ 完整的中英文国际化支持

### 技术实现
- **存储管理**: 直接操作 metadata store 中的 `lastUserInfo` 对象
- **UI 集成**: 在工具栏中添加带警告色的清除按钮 
- **用户体验**: 包含确认提示和操作反馈
- **代码质量**: 完整的 TypeScript 类型支持

### 附加改进
- 🔧 在删除站点时同步清理相关缓存数据
- 🌍 完善的多语言支持（中文/英文）

## 🛠 技术细节

### API 设计
```typescript
async clearSiteLastUserInfo(siteId: TSiteID): Promise<boolean>
```

### UI 集成
- 位置：HistoryDataViewDialog 工具栏
- 图标：`mdi-cached`
- 颜色：`warning` （提醒用户这是一个重要操作）

## 📸 用户界面

新增的清除缓存按钮位于历史数据查看对话框的工具栏中，使用警告色突出显示其重要性。

## 🔍 测试验证

- ✅ TypeScript 编译通过
- ✅ 构建流程正常
- ✅ 功能逻辑验证完成
- ✅ 国际化文本正确显示

## 📚 相关说明

此功能解决了用户需要手动清除站点用户信息缓存的需求，特别是在以下场景：
- 用户信息发生变化需要重新获取
- pickLast 机制缓存了过期数据
- 调试和开发阶段需要清除缓存

## 🎯 影响范围

- **文件变更**: 4 个文件
- **新增代码**: 43 行
- **向后兼容**: ✅ 完全兼容
- **性能影响**: 🟢 无负面影响

## 🔄 pickLast 机制说明

PT-depiler 使用 pickLast 机制来避免重复获取不变的用户信息字段（如用户ID、用户名、加入时间等）。此功能允许用户在需要时手动清除这些缓存，确保获取最新的用户信息。