### PR TITLE
refactor(pkg/site): 移除冗余代码并优化Torrent下载链接处理

### DIFF
--- a/src/packages/site/definitions/animelovers.ts
+++ b/src/packages/site/definitions/animelovers.ts
@@ -1,5 +1,5 @@
-import { EResultParseStatus, type ISiteMetadata, type ITorrent, type IUserInfo } from "../types";
-import Unit3D, { SchemaMetadata } from "../schemas/Unit3D.ts";
+import { type ISiteMetadata } from "../types";
+import { SchemaMetadata } from "../schemas/Unit3D.ts";
 import { buildCategoryOptions, parseSizeString, parseValidTimeString } from "../utils";
 
 const idTrans: string[] = ["User ID", "用户 ID", "用ID", "用户ID"];
@@ -430,36 +430,3 @@ export const siteMetadata: ISiteMetadata = {
     },
   ],
 };
-
-export default class Fearnopeer extends Unit3D {
-  public override async getUserInfoResult(lastUserInfo: Partial<IUserInfo> = {}): Promise<IUserInfo> {
-    let flushUserInfo = await super.getUserInfoResult(lastUserInfo);
-    let userName = flushUserInfo?.name;
-    if (flushUserInfo?.status === EResultParseStatus.success && userName) {
-      // 获取时魔
-      flushUserInfo.bonusPerHour = await this.getBonusPerHourFromBonusTransactionsPage(userName);
-    }
-    return flushUserInfo;
-  }
-
-  protected async getBonusPerHourFromBonusTransactionsPage(userName: string): Promise<string> {
-    const { data: document } = await this.request<Document>(
-      {
-        url: `/users/${userName}/earnings`,
-        responseType: "document",
-      },
-      true,
-    );
-    return this.getFieldData(document, this.metadata.userInfo?.selectors?.bonusPerHour!);
-  }
-
-  public override async getTorrentDownloadLink(torrent: ITorrent): Promise<string> {
-    const downloadLink = await super.getTorrentDownloadLink(torrent);
-    if (downloadLink && !downloadLink.includes("/download/")) {
-      const mockRequestConfig = torrent.url?.startsWith("http") ? { url: torrent.url } : { baseURL: this.url };
-      return this.fixLink(`/torrents/download/${torrent.id}`, mockRequestConfig);
-    }
-
-    return downloadLink;
-  }
-}

--- a/src/packages/site/definitions/bitporn.ts
+++ b/src/packages/site/definitions/bitporn.ts
@@ -1,8 +1,8 @@
 /**
  * @JackettIssue https://github.com/Jackett/Jackett/issues/14816
  */
-import { type ISiteMetadata, type ITorrent, type IUserInfo } from "../types";
-import Unit3D, { SchemaMetadata } from "../schemas/Unit3D";
+import { type ISiteMetadata } from "../types";
+import { SchemaMetadata } from "../schemas/Unit3D";
 import { parseSizeString, parseValidTimeString } from "../utils";
 
 const idTrans: string[] = ["User ID", "用户 ID", "用ID", "用户ID"];
@@ -406,15 +406,3 @@ export const siteMetadata: ISiteMetadata = {
     },
   ],
 };
-
-export default class BitPorn extends Unit3D {
-  public override async getTorrentDownloadLink(torrent: ITorrent): Promise<string> {
-    const downloadLink = await super.getTorrentDownloadLink(torrent);
-    if (downloadLink && !downloadLink.includes("/download/")) {
-      const mockRequestConfig = torrent.url?.startsWith("http") ? { url: torrent.url } : { baseURL: this.url };
-      return this.fixLink(`/torrents/download/${torrent.id}`, mockRequestConfig);
-    }
-
-    return downloadLink;
-  }
-}

--- a/src/packages/site/definitions/fearnopeer.ts
+++ b/src/packages/site/definitions/fearnopeer.ts
@@ -1,5 +1,5 @@
-import { type ISiteMetadata, type ITorrent, type IUserInfo } from "../types";
-import Unit3D, { SchemaMetadata } from "../schemas/Unit3D.ts";
+import { type ISiteMetadata } from "../types";
+import { SchemaMetadata } from "../schemas/Unit3D.ts";
 import { buildCategoryOptions, parseSizeString, parseValidTimeString } from "../utils";
 
 const idTrans: string[] = ["User ID", "用户 ID", "用ID", "用户ID"];
@@ -407,15 +407,3 @@ export const siteMetadata: ISiteMetadata = {
     },
   ],
 };
-
-export default class Fearnopeer extends Unit3D {
-  public override async getTorrentDownloadLink(torrent: ITorrent): Promise<string> {
-    const downloadLink = await super.getTorrentDownloadLink(torrent);
-    if (downloadLink && !downloadLink.includes("/download/")) {
-      const mockRequestConfig = torrent.url?.startsWith("http") ? { url: torrent.url } : { baseURL: this.url };
-      return this.fixLink(`/torrents/download/${torrent.id}`, mockRequestConfig);
-    }
-
-    return downloadLink;
-  }
-}

--- a/src/packages/site/definitions/monikadesign.ts
+++ b/src/packages/site/definitions/monikadesign.ts
@@ -1,5 +1,6 @@
-import { ETorrentStatus, type ISiteMetadata, type ITorrent, type IUserInfo } from "../types";
+import { ETorrentStatus, type ISiteMetadata, type ITorrent } from "../types";
 import Unit3D, { SchemaMetadata } from "../schemas/Unit3D.ts";
+import AbstractBittorrentSite from "../schemas/AbstractBittorrentSite";
 
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,
@@ -325,7 +326,9 @@ export default class MonikaDesign extends Unit3D {
   }
 
   public override async getTorrentDownloadLink(torrent: ITorrent): Promise<string> {
-    const downloadLink = await super.getTorrentDownloadLink(torrent);
+    // Call the ancestor implementation from AbstractBittorrentSite directly
+    // to bypass Unit3D's override when necessary.
+    const downloadLink = await AbstractBittorrentSite.prototype.getTorrentDownloadLink.call(this, torrent);
     if (downloadLink && !downloadLink.includes("/download/")) {
       const { data: detailDocument } = await this.request<Document>({
         url: downloadLink,

--- a/src/packages/site/schemas/Unit3D.ts
+++ b/src/packages/site/schemas/Unit3D.ts
@@ -2,7 +2,14 @@ import urlJoin from "url-join";
 import { omit, toMerged } from "es-toolkit";
 
 import PrivateSite from "./AbstractPrivateSite";
-import { ETorrentStatus, EResultParseStatus, type ISiteMetadata, type IUserInfo, NeedLoginError } from "../types";
+import {
+  ETorrentStatus,
+  EResultParseStatus,
+  type ISiteMetadata,
+  type IUserInfo,
+  NeedLoginError,
+  ITorrent,
+} from "../types";
 import { parseSizeString, parseValidTimeString } from "../utils";
 
 /**
@@ -420,5 +427,15 @@ export default class Unit3D extends PrivateSite {
       true,
     );
     return this.getFieldData(document, this.metadata.userInfo?.selectors?.bonusPerHour!);
+  }
+
+  public override async getTorrentDownloadLink(torrent: ITorrent): Promise<string> {
+    const downloadLink = await super.getTorrentDownloadLink(torrent);
+    if (downloadLink && !downloadLink.includes("/download/") && downloadLink.includes("/torrents/")) {
+      const mockRequestConfig = torrent.url?.startsWith("http") ? { url: torrent.url } : { baseURL: this.url };
+      return this.fixLink(`/torrents/download/${torrent.id}`, mockRequestConfig);
+    }
+
+    return downloadLink;
   }
 }


### PR DESCRIPTION
Optimize the handling of torrent download links and remove unnecessary code from the site classes. This improves code clarity and efficiency.

## Summary by Sourcery

Refactor site package by centralizing torrent download link handling in Unit3D, removing duplicated code from individual site definitions, and cleaning up unnecessary imports

Enhancements:
- Add default getTorrentDownloadLink override in Unit3D to consolidate and standardize torrent link correction for non-/download/ URLs
- Adjust MonikaDesign to explicitly call AbstractBittorrentSite.getTorrentDownloadLink to bypass Unit3D’s override when necessary

Chores:
- Remove redundant custom getTorrentDownloadLink and getUserInfo implementations from multiple site definition files
- Clean up unused type imports across site definitions