### PR TITLE
fix(qBittorrent): 同时支持 qBittorrent 5.1.0 及以下版本的暂停参数

### DIFF
--- a/src/packages/downloader/entity/qBittorrent.ts
+++ b/src/packages/downloader/entity/qBittorrent.ts
@@ -337,8 +337,11 @@ export default class QBittorrent extends AbstractBittorrentClient<TorrentClientC
     }
 
     if (options.addAtPaused) {
-      // Add torrents in the paused state. Possible values are true, false (default)
+      // 同时发送新旧两个参数，让 qBittorrent 自动选择识别
+      // qBittorrent < 5.1.0 使用 'paused' 参数
       formData.append("paused", options.addAtPaused ? "true" : "false");
+      // qBittorrent 5.1.0+ 使用 'stopped' 参数
+      formData.append("stopped", options.addAtPaused ? "true" : "false");
     }
 
     if (options.uploadSpeedLimit && options.uploadSpeedLimit > 0) {


### PR DESCRIPTION
Enable compatibility with both older and newer versions of qBittorrent by sending the appropriate pause parameters.

## Summary by Sourcery

Enhancements:
- Append both legacy ('paused') and new ('stopped') form parameters to maintain compatibility across qBittorrent versions