### PR TITLE
feat(site): 添加对Unit3D相似页面插件支持

### DIFF
--- a/src/packages/site/definitions/monikadesign.ts
+++ b/src/packages/site/definitions/monikadesign.ts
@@ -224,6 +224,13 @@ export const siteMetadata: ISiteMetadata = {
     },
   },
 
+  list: [
+    ...SchemaMetadata.list!,
+    {
+      urlPattern: ["/torrents/airing/"],
+    },
+  ],
+
   userInfo: {
     ...SchemaMetadata.userInfo!,
     selectors: {

--- a/src/packages/site/schemas/Unit3D.ts
+++ b/src/packages/site/schemas/Unit3D.ts
@@ -226,6 +226,36 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
   list: [
     {
       urlPattern: ["/torrents(?:/?$|\\?\[\^/\]*$)"],
+      excludeUrlPattern: ["/torrents?view=card", "/torrents?view=grouped", "/torrents/view=poster"],
+    },
+    {
+      urlPattern: ["/torrents/similar/"],
+      mergeSearchSelectors: false,
+      selectors: {
+        rows: {
+          selector: [
+            "table.similar-torrents__torrents > tbody > tr",
+            "table > tbody > tr:has(td a[href*='/torrents/download/'])",
+          ],
+        },
+        id: {
+          selector: ["a[href*='/torrents/']:not([href*='/download'])"],
+          attr: "href",
+          filters: [(query: string) => query.match(/\/torrents\/(\d+)/)![1]],
+        },
+        title: {
+          selector: ["a[href*='/torrents/']:not([href*='/download'])"],
+        },
+        url: {
+          selector: ["a[href*='/torrents/']:not([href*='/download'])"],
+          attr: "href",
+        },
+        link: {
+          selector: ["a[href*='/download/']", "a[href*='/download_check/']"],
+          attr: "href",
+          filters: [(query: string) => query.replace("/download_check/", "/download/")],
+        },
+      },
     },
   ],
 

--- a/src/packages/site/schemas/Unit3D.ts
+++ b/src/packages/site/schemas/Unit3D.ts
@@ -226,7 +226,7 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
   list: [
     {
       urlPattern: ["/torrents(?:/?$|\\?\[\^/\]*$)"],
-      excludeUrlPattern: ["/torrents?view=card", "/torrents?view=grouped", "/torrents/view=poster"],
+      excludeUrlPattern: ["/torrents?view=card", "/torrents?view=grouped", "/torrents?view=poster"],
     },
     {
       urlPattern: ["/torrents/similar/"],


### PR DESCRIPTION
Enhance the Unit3D plugin by adding support for similar pages, including specific URL patterns and selectors for extracting torrent information.

## Summary by Sourcery

Add support for Unit3D similar torrents pages and extend MonikaDesign site definition with new URL patterns while refining existing torrent list filters

New Features:
- Support scraping of '/torrents/similar/' pages in the Unit3D plugin with dedicated URL pattern and selectors for torrent rows, IDs, titles, URLs, and download links
- Add '/torrents/airing/' URL pattern to the MonikaDesign site definition

Enhancements:
- Exclude card, grouped, and poster view endpoints from the main '/torrents' list to avoid irrelevant page modes