### PR TITLE
add secret-cinema.ts 

### DIFF
--- a/src/packages/site/definitions/broadcasthenet.ts
+++ b/src/packages/site/definitions/broadcasthenet.ts
@@ -241,7 +241,7 @@ export const siteMetadata: ISiteMetadata = {
       totalTraffic: "250GB",
       bonus: 250000,
       snatches: 250,
-      interval: "P4W",
+      interval: "P1M",
       privilege:
         "Has access to the Power User forum, Official and Unofficial Invites forums, Top 10 filters, and can access notifications.",
     },
@@ -251,7 +251,7 @@ export const siteMetadata: ISiteMetadata = {
       totalTraffic: "500GB",
       bonus: 500000,
       snatches: 500,
-      interval: "P2M3W",
+      interval: "P3M",
       privilege: "Has access to the Extreme User forum.",
     },
     {
@@ -260,7 +260,7 @@ export const siteMetadata: ISiteMetadata = {
       totalTraffic: "1TB",
       bonus: 850000,
       snatches: 1000,
-      interval: "P5M2W",
+      interval: "P6M",
       privilege:
         "Has access to the Elite forum and can set own Custom Title, and the ability to send invites purchased from the Lumens Store.",
     },
@@ -270,7 +270,7 @@ export const siteMetadata: ISiteMetadata = {
       totalTraffic: "2.5TB",
       bonus: 1500000,
       snatches: 1500,
-      interval: "P8M1W",
+      interval: "P9M",
       privilege: "Has access to the Guru forum.",
     },
     {
@@ -279,7 +279,7 @@ export const siteMetadata: ISiteMetadata = {
       totalTraffic: "7.5TB",
       bonus: 3000000,
       snatches: 3000,
-      interval: "P11M4W",
+      interval: "P1Y",
       privilege: "Has access to the Master forum.",
     },
     {

--- a/src/packages/site/definitions/secret-cinema.ts
+++ b/src/packages/site/definitions/secret-cinema.ts
@@ -1,0 +1,160 @@
+import type { ISiteMetadata } from "../types";
+import { SchemaMetadata } from "../schemas/GazelleJSONAPI";
+export const siteMetadata: ISiteMetadata = {
+  ...SchemaMetadata,
+
+  version: 1,
+  id: "secret-cinema",
+  name: "Secret Cinema",
+  aka: ["秘密影院", "Secret Cinema PW"],
+  description: "专注于高质量电影资源的私人PT站点",
+  tags: ["电影", "高清", "蓝光", "4K"],
+
+  type: "private",
+  schema: "GazelleJSONAPI",
+
+  urls: ["https://secret-cinema.pw/"],
+
+  search: {
+    ...SchemaMetadata.search!,
+    selectors: {
+      ...SchemaMetadata.search!.selectors!,
+      // Secret Cinema 特有的搜索选择器
+      title: {
+        selector: ["a[href*='torrents.php?id=']:first"],
+      },
+      subTitle: {
+        selector: ["a[href*='torrents.php?id=']:first + div"],
+      },
+      size: {
+        selector: ["td:contains('MB')", "td:contains('GB')", "td:contains('TB')"],
+        filters: [{ name: "parseSize" }],
+      },
+      seeders: {
+        selector: ["td:nth-child(3)", "td.seeders"],
+        filters: [{ name: "parseNumber" }],
+      },
+      leechers: {
+        selector: ["td:nth-child(4)", "td.leechers"],
+        filters: [{ name: "parseNumber" }],
+      },
+      completed: {
+        selector: ["td:nth-child(5)", "td.completed"],
+        filters: [{ name: "parseNumber" }],
+      },
+      comments: {
+        selector: ["td:nth-child(6)", "td.comments"],
+        filters: [{ name: "parseNumber" }],
+      },
+      time: {
+        selector: ["td:nth-child(7)", "td.time"],
+        filters: [{ name: "parseTime" }],
+      },
+      tags: [
+        { name: "Freeleech", selector: "span[title*='Freeleech']", color: "green" },
+        { name: "Neutral", selector: "span[title*='Neutral']", color: "blue" },
+        { name: "Personal", selector: "span[title*='Personal']", color: "purple" },
+      ],
+    },
+  },
+
+  levelRequirements: [
+    {
+      id: 0,
+      name: "Actor",
+      privilege: "The default class for all members.",
+    },
+    {
+      id: 1,
+      name: "Cinematographer",
+      interval: "P2M",
+      percentile: 50,
+      seedingPercentile: 95,
+      privilege:
+        "Can access the Secret Pharmacy forum and create 1 personal collage. Can also invite new members upon having enough Seeding Points.",
+    },
+    {
+      id: 2,
+      name: "Director",
+      interval: "P4M",
+      percentile: 70,
+      privilege:
+        "Can access the Secret Pharmacy forum, create 3 personal collages and is awarded an invite occasionally",
+    },
+    {
+      id: 3,
+      name: "Cinephile",
+      interval: "P6M",
+      percentile: 90,
+      privilege:
+        "Can access the Secret Pharmacy and Ilium Cinephilium forums, create 10 personal collages and is awarded an invite occasionally.",
+    },
+    {
+      id: 4,
+      name: "Legend",
+      privilege: "Past staff member. Same perks as Cinephiles, plus a few more.",
+    },
+  ],
+
+  userInfo: {
+    ...SchemaMetadata.userInfo!,
+    selectors: {
+      ...SchemaMetadata.userInfo!.selectors!,
+      // Secret Cinema 特有的用户信息字段覆盖
+      bonus: {
+        selector: ["response.userstats.bonus"],
+        filters: [
+          (query: string | number) => {
+            if (typeof query === "number") {
+              return query;
+            }
+            const match = query.match(/[\d.]+/);
+            if (match) {
+              const value = parseFloat(match[0]);
+              return isNaN(value) ? 0 : value;
+            }
+            return 0;
+          },
+        ],
+      },
+      seedingSize: {
+        selector: ["response.userstats.seedingSize"],
+        filters: [
+          (query: string | number) => {
+            if (typeof query === "number") {
+              return query;
+            }
+            const match = query.match(/[\d.]+/);
+            if (match) {
+              const value = parseFloat(match[0]);
+              return isNaN(value) ? 0 : value;
+            }
+            return 0;
+          },
+        ],
+      },
+      leeching: {
+        selector: ["response.userstats.leeching"],
+        filters: [
+          (query: string | number) => {
+            if (typeof query === "number") {
+              return query;
+            }
+            const match = query.match(/[\d.]+/);
+            if (match) {
+              const value = parseFloat(match[0]);
+              return isNaN(value) ? 0 : value;
+            }
+            return 0;
+          },
+        ],
+      },
+    },
+  },
+
+  list: [
+    {
+      urlPattern: ["/torrents.php"],
+    },
+  ],
+};

--- a/src/packages/site/definitions/secretcinema.ts
+++ b/src/packages/site/definitions/secretcinema.ts
@@ -4,7 +4,7 @@ export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,
 
   version: 1,
-  id: "secret-cinema",
+  id: "secretcinema",
   name: "Secret Cinema",
   aka: ["秘密影院", "Secret Cinema PW"],
   description: "专注于高质量电影资源的私人PT站点",
@@ -13,7 +13,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "GazelleJSONAPI",
 
-  urls: ["https://secret-cinema.pw/"],
+  urls: ["https://secretcinema.pw/"],
 
   search: {
     ...SchemaMetadata.search!,

--- a/src/packages/site/definitions/secretcinema.ts
+++ b/src/packages/site/definitions/secretcinema.ts
@@ -1,5 +1,18 @@
 import type { ISiteMetadata } from "../types";
 import { SchemaMetadata } from "../schemas/GazelleJSONAPI";
+
+// 自定义 filter 函数：处理 Secret Cinema 的数值字段
+const parseSecretCinemaNumber = (query: string | number) => {
+  if (typeof query === "number") {
+    return query;
+  }
+  const match = query.match(/[\d.]+/);
+  if (match) {
+    const value = parseFloat(match[0]);
+    return isNaN(value) ? 0 : value;
+  }
+  return 0;
+};
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,
 
@@ -9,11 +22,12 @@ export const siteMetadata: ISiteMetadata = {
   aka: ["秘密影院", "Secret Cinema PW"],
   description: "专注于高质量电影资源的私人PT站点",
   tags: ["电影", "高清", "蓝光", "4K"],
+  favicon: "./secretcinema.ico",
 
   type: "private",
   schema: "GazelleJSONAPI",
 
-  urls: ["https://secretcinema.pw/"],
+  urls: ["https://secret-cinema.pw/"],
 
   search: {
     ...SchemaMetadata.search!,
@@ -92,6 +106,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       id: 4,
       name: "Legend",
+      groupType: "vip",
       privilege: "Past staff member. Same perks as Cinephiles, plus a few more.",
     },
   ],
@@ -103,51 +118,15 @@ export const siteMetadata: ISiteMetadata = {
       // Secret Cinema 特有的用户信息字段覆盖
       bonus: {
         selector: ["response.userstats.bonus"],
-        filters: [
-          (query: string | number) => {
-            if (typeof query === "number") {
-              return query;
-            }
-            const match = query.match(/[\d.]+/);
-            if (match) {
-              const value = parseFloat(match[0]);
-              return isNaN(value) ? 0 : value;
-            }
-            return 0;
-          },
-        ],
+        filters: [parseSecretCinemaNumber],
       },
       seedingSize: {
         selector: ["response.userstats.seedingSize"],
-        filters: [
-          (query: string | number) => {
-            if (typeof query === "number") {
-              return query;
-            }
-            const match = query.match(/[\d.]+/);
-            if (match) {
-              const value = parseFloat(match[0]);
-              return isNaN(value) ? 0 : value;
-            }
-            return 0;
-          },
-        ],
+        filters: [parseSecretCinemaNumber],
       },
       leeching: {
         selector: ["response.userstats.leeching"],
-        filters: [
-          (query: string | number) => {
-            if (typeof query === "number") {
-              return query;
-            }
-            const match = query.match(/[\d.]+/);
-            if (match) {
-              const value = parseFloat(match[0]);
-              return isNaN(value) ? 0 : value;
-            }
-            return 0;
-          },
-        ],
+        filters: [parseSecretCinemaNumber],
       },
     },
   },


### PR DESCRIPTION
add  secret-cinema.ts

## Summary by Sourcery

Introduce a new GazelleJSONAPI site definition for Secret Cinema including metadata, search configuration, user classes, and user info parsing

New Features:
- Add secret-cinema.ts to register Secret Cinema private tracker with core metadata
- Support search result parsing with custom selectors and filters for titles, sizes, seeders, leechers, and tags

Enhancements:
- Define level requirements with class intervals, percentiles, and privileges
- Override userInfo selectors with filters for bonus, seeding size, and leeching metrics