### PR TITLE
fix(pkg/size): fix red selector casing in seedingSize definition

### DIFF
--- a/src/packages/site/definitions/redacted.ts
+++ b/src/packages/site/definitions/redacted.ts
@@ -31,7 +31,7 @@ export const siteMetadata: ISiteMetadata = {
       },
       // /ajax.php?action=community_stats
       seedingSize: {
-        selector: ["response.seedingSize"],
+        selector: ["response.seedingsize"],
         filters: [{ name: "parseSize" }],
       },
     },


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the seedingSize selector to use 'response.seedingsize' instead of 'response.seedingSize'