### PR TITLE
fix(pkg/site): 修改Unit3D种子时间解析方法并增加tag获取选择器，更新bitporn子标题选择器

### DIFF
--- a/src/packages/site/definitions/bitporn.ts
+++ b/src/packages/site/definitions/bitporn.ts
@@ -158,12 +158,12 @@ export const siteMetadata: ISiteMetadata = {
     selectors: {
       ...SchemaMetadata.search!.selectors,
       subTitle: {
-        selector: ["td.torrent-search--list__overview div[style]"],
+        selector: ["div.torrent-keywords-container"],
         elementProcess: (element: any) => {
           if (!element) return 0;
 
           // 查找所有span元素
-          const spans = element.querySelectorAll("span[style]");
+          const spans = element.querySelectorAll("a.torrent-keywords-badge");
 
           // 提取所有span元素中的文本内容
           const allText = Array.from(spans)

--- a/src/packages/site/schemas/Unit3D.ts
+++ b/src/packages/site/schemas/Unit3D.ts
@@ -10,7 +10,7 @@ import {
   NeedLoginError,
   ITorrent,
 } from "../types";
-import { parseSizeString, parseValidTimeString } from "../utils";
+import { parseTimeToLive, parseValidTimeString } from "../utils";
 
 /**
  * Trans Array
@@ -90,7 +90,19 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
         filters: [(query: string) => query.replace("/download_check/", "/download/")],
       },
       // /resources/views/torrent/results.blade.php#L399-L401
-      time: { selector: ["time"], filters: [{ name: "parseTTL" }] },
+      time: {
+        selector: ["time"],
+        elementProcess: (element: any) => {
+          if (!element) return undefined;
+          // 优先使用title属性
+          if (element.title) {
+            return parseValidTimeString(element.title);
+          } else {
+            const textContent = element.textContent || element.innerText || "";
+            return parseTimeToLive(textContent);
+          }
+        },
+      },
       // /resources/views/torrent/results.blade.php#L402-L404
       size: {
         selector: ['td>span.text-blue:contains("B")', "td.torrent-search--list__size"],
@@ -165,28 +177,28 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
         {
           name: "Free",
           selector:
-            "i.fa-star.text-gold, i.fa-globe, i[title*='100%'], i.torrent-icons__featured, i[title*='Featured'], i[data-original-title*='Featured'], i[data-original-title*='Free']",
+            "i.fa-star.text-gold, i.fa-globe, i[title*='100%'], span[title*='100%'], i.torrent-icons__featured, i[title*='Featured'], span[title*='feature'], i[data-original-title*='Featured'], i[data-original-title*='Free']",
           color: "blue",
         },
         {
           name: "2xUp",
           selector:
-            "i.fa-gem.text-green, i.torrent-icons__double-upload, i.torrent-icons__featured, i[title*='Double Upload'], i[title*='Featured'], i[data-original-title*='Double Upload'], i[data-original-title*='Featured']",
+            "i.fa-gem.text-green, i.fa-chevron-double-up, i.torrent-icons__double-upload, i.torrent-icons__featured, i[title*='Double Upload'], i[title*='Featured'], span[title*='feature'], i[data-original-title*='Double Upload'], i[data-original-title*='Featured']",
           color: "lime",
         },
         {
           name: "75%",
-          selector: "i[title*='75%']",
+          selector: "i[title*='75%'], span[title*='75%']",
           color: "lime-darken-3",
         },
         {
           name: "50%",
-          selector: "i[title*='50%']",
+          selector: "i[title*='50%'], span[title*='50%']",
           color: "deep-orange-darken-1",
         },
         {
           name: "25%",
-          selector: "i[title*='25%']",
+          selector: "i[title*='25%'], span[title*='25%']",
           color: "blue",
         },
         {


### PR DESCRIPTION
## Summary by Sourcery

Fix Unit3D time parsing logic and broaden element selectors; update bitporn subtitle extraction to new container and badge link selectors

Bug Fixes:
- Fix Unit3D torrent time parsing to use title attribute and fallback to text content

Enhancements:
- Expand Unit3D status icon selectors to include span tags and additional class variants
- Update bitporn subtitle extractor to target the keywords container and badge link elements instead