### PR TITLE
fix(pkg/site): add noLoginAssert for huno 2fa

### DIFF
--- a/src/packages/site/definitions/huno.ts
+++ b/src/packages/site/definitions/huno.ts
@@ -135,6 +135,11 @@ export const siteMetadata: ISiteMetadata = {
     },
   },
 
+  noLoginAssert: {
+    ...SchemaMetadata.noLoginAssert,
+    urlPatterns: [/doLogin|login|verify|checkpoint|returnto|twofactor/gi],
+  },
+
   userInfo: {
     pickLast: ["name", "id"],
     selectors: {


### PR DESCRIPTION
will need to enter 2FA code on https://hawke.uno/twofactor/needed every few weeks

statistics will show 0/0 if blocked by 2FA

## Summary by Sourcery

Add noLoginAssert configuration for Huno site definition to properly handle two-factor authentication pages and prevent incorrect login assertions.

Bug Fixes:
- Prevent statistics from showing 0/0 when blocked by two-factor authentication flows.

Enhancements:
- Introduce noLoginAssert field extending SchemaMetadata.noLoginAssert with URL patterns for login, checkpoint, and twofactor routes.