### PR TITLE
fix(pkg/site): 修复 HDBits 做种数&做种量错误

### DIFF
--- a/src/packages/site/definitions/hdbits.ts
+++ b/src/packages/site/definitions/hdbits.ts
@@ -217,7 +217,10 @@ export const siteMetadata: ISiteMetadata = {
             selector: ["td.heading:contains('Currently'):contains('seeding') + td"],
             filters: [{ name: "replace", args: ["-", ""] }, { name: "parseNumber" }],
           },
-          seedingSize: { selector: ["td.heading:contains('Seeding size') + td"], filters: [{ name: "parseSize" }] },
+          seedingSize: {
+            selector: ["td.rowhead:contains('Seeding size') + td"],
+            filters: [{ name: "parseSize" }],
+          },
         },
       },
     ],

--- a/src/packages/site/definitions/hdbits.ts
+++ b/src/packages/site/definitions/hdbits.ts
@@ -215,7 +215,7 @@ export const siteMetadata: ISiteMetadata = {
           },
           seeding: {
             selector: ["td.heading:contains('Currently'):contains('seeding') + td"],
-            filters: [{ name: "parseNumber" }],
+            filters: [{ name: "replace", args: ["-", ""] }, { name: "parseNumber" }],
           },
           seedingSize: { selector: ["td.heading:contains('Seeding size') + td"], filters: [{ name: "parseSize" }] },
         },


### PR DESCRIPTION
## Summary by Sourcery

Fix parsing of seeding count and seeding size fields in the HDBits site definition

Bug Fixes:
- Add replace filter to strip '-' before parsing the seeding count
- Extract and parse the seeding size field using the parseSize filter