### PR TITLE
fix(site/pkg): 修复 BroadcastTheNet 搜索结果标题不完整

### DIFF
--- a/src/packages/site/definitions/broadcasthenet.ts
+++ b/src/packages/site/definitions/broadcasthenet.ts
@@ -45,6 +45,7 @@ export const siteMetadata: ISiteMetadata = {
       },
       title: {
         selector: "span[style='float:none;']", // BTN的种子标题选择器
+        attr: "title",
       },
       category: {
         selector: "a[href*='filter_cat'] img", // BTN的分类选择器


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add "attr: 'title'" to the title selector in BroadcasTheNet site metadata to ensure complete search result titles