### PR TITLE
fix(pkg/site): 修复 HDT 用户数据部分字段解析问题

### DIFF
--- a/src/packages/site/definitions/hdtorrents.ts
+++ b/src/packages/site/definitions/hdtorrents.ts
@@ -2,7 +2,6 @@
  * @JackettDefinitions https://github.com/Jackett/Jackett/blob/master/src/Jackett.Common/Definitions/hdtorrents.yml
  * @JackettIssue https://github.com/Jackett/Jackett/issues/16002
  */
-import { tryToNumber } from "../utils.ts";
 import type { ISiteMetadata } from "../types.ts";
 import { definedFilters } from "../utils.ts";
 import urlJoin from "url-join";
@@ -217,12 +216,12 @@ export const siteMetadata: ISiteMetadata = {
           },
           ratio: {
             selector: "td.header:contains('Ratio') + td",
-            filters: [tryToNumber],
+            filters: [{ name: "replace", args: [/,/g, ""] }, { name: "parseNumber" }],
           },
           levelName: { selector: "td.header:contains('Rank') + td" },
           bonus: {
             selector: "td.header:contains('Seed Bonus Points') + td",
-            filters: [tryToNumber],
+            filters: [{ name: "replace", args: [/,/g, ""] }, { name: "parseNumber" }],
           },
           joinTime: {
             selector: "td.header:contains('Joined on') + td",


### PR DESCRIPTION
tryToNumber 不能处理带小数位的数字，转为手动解析 ratio 和 bonus 字段
fix https://github.com/pt-plugins/PT-depiler/issues/608

## Summary by Sourcery

Bug Fixes:
- Replace tryToNumber with a combination of replace and parseNumber filters for ratio and bonus to correctly parse numbers with decimals