### PR TITLE
修改慕雪阁域名

### DIFF
--- a/src/packages/site/definitions/muxuege.ts
+++ b/src/packages/site/definitions/muxuege.ts
@@ -16,7 +16,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["uggcf://cg.zhkrtrt.bet/"],
+  urls: ["https://pt.muxuege.org/"],
   favicon: "./_default_nexusphp.png",
 
   category: [


### PR DESCRIPTION
修改慕雪阁域名

## Summary by Sourcery

Update Muxuege site metadata to use the new domain and extend NexusPHP schema imports

Enhancements:
- Change site URL to https://pt.muxuege.org/
- Import additional category and state types (CategoryInclbookmarked, CategoryIncldead, CategorySpstate) from NexusPHP schema