### PR TITLE
fix(pkg/site): hdspace 时间解析在部分浏览器上不正常

### DIFF
--- a/src/packages/site/definitions/hdspace.ts
+++ b/src/packages/site/definitions/hdspace.ts
@@ -122,7 +122,7 @@ export const siteMetadata: ISiteMetadata = {
           ],
           "td:nth-child(5):not(:contains('day'))": [
             { name: "trim" },
-            { name: "parseTime", args: ["MMMM dd, yyyy, HH:mm:ss"] },
+            { name: "parseTime", args: ["MMMM dd, yyyy,\u00A0HH:mm:ss"] },
           ],
         },
       },
@@ -225,7 +225,7 @@ export const siteMetadata: ISiteMetadata = {
         selectors: {
           joinTime: {
             selector: "td.header:contains('Joined on') + td",
-            filters: [{ name: "trim" }, { name: "parseTime", args: ["MMMM dd, yyyy, HH:mm:ss"] }],
+            filters: [{ name: "trim" }, { name: "parseTime", args: ["MMMM dd, yyyy,\u00A0HH:mm:ss"] }],
           },
           // FIXME 暂未实现 uploads, seedingSize
         },


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Include non-breaking space in parseTime format strings to ensure correct date parsing across browsers