### PR TITLE
perf(pkg/site): 适配憨憨音乐区列表页面

### DIFF
--- a/src/packages/site/definitions/hhanclub.ts
+++ b/src/packages/site/definitions/hhanclub.ts
@@ -246,6 +246,15 @@ export const siteMetadata: ISiteMetadata = {
     },
   },
 
+  list: [
+    {
+      urlPattern: ["/torrents.php"],
+    },
+    {
+      urlPattern: ["/special.php"],
+    },
+  ],
+
   levelRequirements: [
     {
       id: 0,


### PR DESCRIPTION
憨憨音乐区有特殊的url，直接点击顶部菜单的音乐区按钮进入时插件会不显示列表页相关的按钮