### PR TITLE
fix(pkg/site/seedpool): 更新seedpool站点元数据

### DIFF
--- a/src/packages/site/definitions/seedpool.ts
+++ b/src/packages/site/definitions/seedpool.ts
@@ -37,6 +37,8 @@ export const siteMetadata: ISiteMetadata = {
     ...SchemaMetadata.userInfo!,
     selectors: {
       ...SchemaMetadata.userInfo!.selectors!,
+      bonus: { text: "N/A" },
+      bonusPerHour: { text: "N/A" },
       seeding: {
         selector: ["li.ratio-bar__uploaded a:has( > i.fa-arrow-up) + a"],
         filters: [{ name: "parseNumber" }],


### PR DESCRIPTION
seedpool 把积分移除了，改为直接发 buffer，因此 `bouns` 和 `bonusPerHour` 字段不再能准确反映用户数据

## Summary by Sourcery

Bug Fixes:
- Set bonus and bonusPerHour selectors to display “N/A” since seedpool no longer uses point values