### PR TITLE
fix(pkg/site/torrentleech): TL 高级搜索未正确应用搜索词

### DIFF
--- a/src/packages/site/definitions/torrentleech.ts
+++ b/src/packages/site/definitions/torrentleech.ts
@@ -103,7 +103,7 @@ export const siteMetadata: ISiteMetadata = {
         const categoryString = Array.isArray(value) ? value.join(",") : value;
         return {
           requestConfig: {
-            url: `/torrents/browse/list/categories/${categoryString}`,
+            url: `/torrents/browse/list/categories/${categoryString}/query`,
           },
         };
       },


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Include '/query' segment in the category browse URL to ensure search terms are correctly applied in advanced searches.