### PR TITLE
feat(AdvanceListModule): 展示选中种子数量和选中种子体积

### DIFF
--- a/src/entries/content-script/app/components/AdvanceListModuleDialog.vue
+++ b/src/entries/content-script/app/components/AdvanceListModuleDialog.vue
@@ -36,6 +36,11 @@ const tableHeaders = computed(
 
 const selectedTorrentIds = ref<ITorrent["id"][]>([]);
 const selectedTorrents = computed(() => torrentItems.filter((x) => selectedTorrentIds.value.includes(x.id)));
+const hasSelectedTorrent = computed(() => selectedTorrentIds.value.length > 0);
+const selectedTorrentsCount = computed(() => selectedTorrentIds.value.length);
+const selectedTorrentsSize = computed(() =>
+  selectedTorrents.value.reduce((acc, torrent) => acc + (torrent.size ?? 0), 0),
+);
 
 const localDownloadMultiStatus = ref<boolean>(false);
 async function handleLocalDownloadMulti() {
@@ -135,7 +140,12 @@ function enterDialog() {
       <v-divider />
       <v-card-actions>
         <v-spacer />
+        <span v-show="hasSelectedTorrent"
+          >已选中：{{ selectedTorrentsCount }} 个种子，总大小：{{ formatSize(selectedTorrentsSize) }}</span
+        >
+
         <NavButton
+          :disabled="!hasSelectedTorrent"
           :loading="localDownloadMultiStatus"
           color="light-blue"
           icon="mdi-content-save-all"
@@ -144,6 +154,7 @@ function enterDialog() {
         />
 
         <NavButton
+          :disabled="!hasSelectedTorrent"
           :loading="linkCopyMultiStatus"
           color="light-blue"
           icon="mdi-content-copy"
@@ -152,6 +163,7 @@ function enterDialog() {
         />
 
         <NavButton
+          :disabled="!hasSelectedTorrent"
           key="remote_download_multi"
           color="light-blue"
           icon="mdi-tray-arrow-down"

--- a/src/entries/options/components/NavButton.vue
+++ b/src/entries/options/components/NavButton.vue
@@ -3,9 +3,10 @@ import { useDisplay } from "vuetify/framework";
 
 const display = useDisplay();
 
-const props = defineProps<{
+const { disabled = false, ...props } = defineProps<{
   icon: string;
   text: string;
+  disabled?: boolean;
 }>();
 </script>
 
@@ -17,6 +18,7 @@ const props = defineProps<{
     :prepend-icon="display.smAndDown.value ? undefined : props.icon"
     :rounded="display.smAndDown.value ? 0 : 4 /* default rounded */"
     :size="display.smAndDown.value ? 'small' : 'default'"
+    :disabled="disabled"
     :title="props.text"
     :variant="display.smAndDown.value ? 'text' : 'elevated'"
   >


### PR DESCRIPTION
- 在种子高级选择列表中，展示选中种子数量和选中种子体积
<img width="2409" height="1703" alt="选中" src="https://github.com/user-attachments/assets/477b992f-db52-4aae-ba41-c299dd5e5c37" />

- 未选中种子时，按钮不可点击
<img width="2401" height="305" alt="未选中" src="https://github.com/user-attachments/assets/f31ea4af-86a5-470a-86bd-6f888d518d0d" />

## Summary by Sourcery

Display selected torrent count and aggregate size in the advanced selection dialog and disable batch action buttons when no torrents are selected

New Features:
- Show the number of selected torrents and their total size in the advanced selection list

Enhancements:
- Add a disabled prop to the NavButton component
- Disable batch action buttons in the dialog when no torrents are selected