### PR TITLE
fix(pkg/site): 憨憨使用基础憨豆+保种区额外做种积分计算seedingBonusPerHour

### DIFF
--- a/src/packages/site/definitions/hhanclub.ts
+++ b/src/packages/site/definitions/hhanclub.ts
@@ -1,6 +1,12 @@
-import { ETorrentStatus, type ISiteMetadata } from "../types";
-import { CategoryInclbookmarked, CategoryIncldead, CategorySpstate, SchemaMetadata } from "../schemas/NexusPHP.ts";
+import { ETorrentStatus, type ISiteMetadata, IUserInfo } from "../types";
+import NexusPHP, {
+  CategoryInclbookmarked,
+  CategoryIncldead,
+  CategorySpstate,
+  SchemaMetadata,
+} from "../schemas/NexusPHP.ts";
 import { parseValidTimeString } from "../utils";
+import Sizzle from "sizzle";
 
 const hhLinkQuery = {
   selector: ['a[href*="download.php?id="]'],
@@ -243,6 +249,14 @@ export const siteMetadata: ISiteMetadata = {
         selector: [".grid .row-span-4"],
         filters: [{ name: "parseNumber" }],
       },
+      seedingBonusPerHour: {
+        selector: [
+          "div:contains('你当前每小时能获取'):last",
+          "div:contains('You are currently getting'):last",
+          "div:contains('你當前每小時能獲取'):last",
+        ],
+        filters: [{ name: "parseNumber" }],
+      },
     },
   },
 
@@ -325,3 +339,43 @@ export const siteMetadata: ISiteMetadata = {
     },
   ],
 };
+export default class Hhanclub extends NexusPHP {
+  // 使用基础憨豆+保种区额外做种积分作为seedingBonusPerHour
+  protected async parseUserInfoForSeedingBonusPerHour(
+    flushUserInfo: Partial<IUserInfo>,
+    dataDocument: Document,
+  ): Promise<Partial<IUserInfo>> {
+    // 从mybonus.php 页面，解析出 用户每小时获得憨豆无加成的部分 数值
+    const baseSeedingBonusPerHour = this.getFieldData(
+      dataDocument,
+      this.metadata.userInfo?.selectors?.seedingBonusPerHour!,
+    );
+
+    // 请求保重区结算日志页面，并解析出最近一次结算时获得的积分 数值
+    let rescueDocument = await this.getRescueDocument(flushUserInfo.id as number);
+    // 如果有分页，从最后一页获取
+    const totalPages = Sizzle("table + div b", rescueDocument);
+    if (totalPages.length > 0) {
+      rescueDocument = await this.getRescueDocument(
+        flushUserInfo.id as number,
+        parseInt(totalPages[totalPages.length - 1].textContent || "1") - 1,
+      );
+    }
+    const rescueSeedingBonusPerDay = this.getFieldData(rescueDocument, {
+      selector: ["table tbody tr:last-child > td:nth-of-type(6)"],
+      filters: [{ name: "parseNumber" }],
+    });
+    // 加和计算真实的 总做种积分 数值
+    flushUserInfo.seedingBonusPerHour = baseSeedingBonusPerHour + rescueSeedingBonusPerDay / 24;
+    return flushUserInfo;
+  }
+
+  private async getRescueDocument(userId: number, page: number = 0): Promise<Document> {
+    const { data: rescueDocument } = await this.request<Document>({
+      url: "/rescuesettleinfo.php",
+      params: { id: userId, page },
+      responseType: "document",
+    });
+    return rescueDocument;
+  }
+}

--- a/src/packages/site/schemas/NexusPHP.ts
+++ b/src/packages/site/schemas/NexusPHP.ts
@@ -516,7 +516,7 @@ export const SchemaMetadata: Pick<
       },
       {
         requestConfig: { url: "/mybonus.php", responseType: "document" },
-        fields: ["bonusPerHour"],
+        fields: ["bonusPerHour", "seedingBonusPerHour"],
       },
     ],
   },


### PR DESCRIPTION
#681 
使用基础憨豆+保种区额外做种积分作为每小时获取的积分，解决使用时魔来计算升级所需积分的时长不准确的问题

## Summary by Sourcery

Compute the correct seeding bonus per hour for Hhanclub by combining the base bonus and rescue zone bonus

Bug Fixes:
- Fix inaccurate seeding bonus per hour calculation by including extra bonus from the rescue zone

Enhancements:
- Add seedingBonusPerHour field to site metadata selectors and schema
- Extend Hhanclub class to override parseUserInfoForSeedingBonusPerHour and sum base bonus with rescue log points
- Fetch and parse rescue settle logs (including pagination) to compute daily rescue bonus