### PR TITLE
fix(pter): update domain

### DIFF
--- a/src/packages/site/definitions/pter.ts
+++ b/src/packages/site/definitions/pter.ts
@@ -27,8 +27,8 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://pterclub.com/", "https://pterclub.net/"],
-  formerHosts: ["pter.club"],
+  urls: ["https://pterclub.net/"],
+  formerHosts: ["pter.club", "pterclub.com"],
 
   category: [
     {


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Remove pterclub.com from the active URLs and add it to formerHosts alongside pter.club, retaining only pterclub.net as the current URL