### PR TITLE
fix(pkg/site/mteam): 站点增加origin header验证

### DIFF
--- a/src/packages/site/definitions/mteam.ts
+++ b/src/packages/site/definitions/mteam.ts
@@ -622,7 +622,7 @@ export default class MTeam extends PrivateSite {
     axiosConfig.headers = {
       ...(axiosConfig.headers ?? {}),
       "x-api-key": this.userConfig.inputSetting!.token ?? "", // FIXME 是否允许我们设置一个空字符？
-      "origin": this.url,   // 251028 站点增加cors认证
+      "origin": this.url,   // MTeam site requires Origin header for CORS validation (added 2025-10-28)
     };
 
     return super.request<T>(axiosConfig, checkLogin);


### PR DESCRIPTION
2025.10.28 MT站点更新，api调用增加了cors验证，而插件在调用api时，浏览器自动加上了 `origin: chrome-extension://icpcejfgehfbgopgeiggpcpfedfbceaa` 的请求头，会导致无法获取到数据。
但由于插件目前的设计和浏览器安全设置，我们无法在请求api时移除 origin ，所以只能走覆写 origin 的方法。
插件底层 `axios/replaceUnsafeHeader` 会自动调用 chrome.declarativeNetRequest 来强行设置 origin 头，以确保通过站点的cors验证并获取到正确数据。

closed: #716

## Summary by Sourcery

Bug Fixes:
- Include the "origin" header in axiosConfig for mteam site requests to pass new CORS checks