### PR TITLE
fix(pkg/site): 修复fnp不显示未读消息，修复aidoru-online不检测登录

### DIFF
--- a/src/packages/site/definitions/aidoruonline.ts
+++ b/src/packages/site/definitions/aidoruonline.ts
@@ -356,6 +356,15 @@ export default class AidoruOnline extends PrivateSite {
       },
       true,
     );
+    // 获取所有包含href属性的元素
+    const allHrefElements = indexDocument.querySelectorAll("[href]");
+    const allHrefs = Array.from(allHrefElements).map((el) => el.getAttribute("href"));
+    // 检查是否有包含login的href
+    const hasLoginHref = allHrefs.some((href) => href && href.toLowerCase().includes("action=login"));
+    if (hasLoginHref) {
+      throw new NeedLoginError("检测到包含action=login的链接，需要重新登录");
+    }
+
     return this.getFieldData(indexDocument, this.metadata.userInfo?.selectors?.id!);
   }
 
@@ -366,6 +375,10 @@ export default class AidoruOnline extends PrivateSite {
       url: "/account.php",
       responseType: "document",
     });
+
+    if (!userDetailDocument || !userDetailDocument.title) {
+      throw new NeedLoginError("请求未获取到数据，需要重新登录");
+    }
 
     return this.getFieldsData(
       userDetailDocument,

--- a/src/packages/site/schemas/Unit3D.ts
+++ b/src/packages/site/schemas/Unit3D.ts
@@ -405,7 +405,9 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
       },
       messageCount: {
         text: 0,
-        selector: ['a[href*="/mail"] .point, a[href*="/notifications"] .point, ul.top-nav__icon-bar circle'],
+        selector: [
+          'a[href*="/mail"] .point, a[href*="/notifications"] .point, ul.top-nav__icon-bar circle, a.top-nav--right__icon-link[href*="/conversations"] span.notification-dot',
+        ],
         elementProcess: () => 11, // 并不能直接知道还有多少个消息未读，所以置为11，会直接出线红点而不是具体数字
       },
       uploads: {


### PR DESCRIPTION
1、修复fnp不显示未读消息：
  添加对应的选择器a.top-nav--right__icon-link[href*="/conversations"] span.notification-dot

2、修复aidoru-online不检测登录：
  解析页面前检查页面是否需要登录

## Summary by Sourcery

Fix unread message dot detection on Unit3D and improve login detection on AidoruOnline

Bug Fixes:
- Detect login requirement in AidoruOnline by scanning for login links and missing page title
- Add selector for unread conversation notification dots in Unit3D message count