### PR TITLE
fix(pkg/site): 海棠PT  从PTPP导入时提示暂不支持

### DIFF
--- a/src/packages/site/definitions/htpt.ts
+++ b/src/packages/site/definitions/htpt.ts
@@ -17,7 +17,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["uggcf://jjj.ugcg.pp/"],
+  urls: ["uggcf://jjj.ugcg.pp/", "uggcf://ugcg.pp/"],
 
   category: [
     {


### PR DESCRIPTION
PTPP导出的备份中：
<img width="185" height="51" alt="Notepad4_8Ka2HjxK4c" src="https://github.com/user-attachments/assets/727a2717-c322-434f-81be-ac82ecd13580" />
和PTD中siteMetadata的url不一致，导致从PTPP的备份导入时提示暂不支持：
<img width="518" height="106" alt="firefox_feM34BBtj1" src="https://github.com/user-attachments/assets/323f318c-3354-4ccc-8420-f651cac4ee9c" />

## Summary by Sourcery

Bug Fixes:
- Include the ugcg.pp URL in HTPT site metadata to support imports from PTPP backups.