### PR TITLE
feat(pkg/site): 支持站点JPTV4us

### DIFF
--- a/src/packages/site/definitions/jptv4us.ts
+++ b/src/packages/site/definitions/jptv4us.ts
@@ -14,7 +14,7 @@ export const siteMetadata: ISiteMetadata = {
   schema: "Unit3D",
 
   urls: ["uggcf://wcgi4.hf/"],
-
+  favicon: "./_default_unit3d.ico",
   category: [
     {
       name: "类别",

--- a/src/packages/site/utils/favicon.ts
+++ b/src/packages/site/utils/favicon.ts
@@ -8,7 +8,7 @@
             2. 此时，ISiteMetadata 中定义的 favicon 字段配置项不起作用，强制刷新缓存不起作用（本地硬配置优先）
  *   2. localforage 中已有的 base64 缓存（根据站点的 host 值）
  *   3. ISiteMetadata 中定义的 favicon 字段
- *   4. 请求网站首页，并从返回的html中解析所需要的 favicion 字段
+ *   4. 请求网站首页，并从返回的html中解析所需要的 favicon 字段
  *   5. 使用 NO_IMAGE 替代
  *
  * special thanks to: https://github.com/spro/get-website-favicon/tree/master/lib/origin


### PR DESCRIPTION
fix #735

## Summary by Sourcery

Add support for the JPTV4us tracker by defining its site metadata and scraper implementation

New Features:
- Introduce definitions/jptv4us.ts with full ISiteMetadata for JPTV4us including categories and filters
- Implement JPTV4us class extending Unit3D with custom getUserNameFromSite logic

Enhancements:
- Fix typo in favicon.ts comment to properly spell “favicon”