### PR TITLE
fix: 允许删除离线站点当天获取的错误数据

### DIFF
--- a/src/entries/options/views/Overview/MyData/UserDataTimeline/Index.vue
+++ b/src/entries/options/views/Overview/MyData/UserDataTimeline/Index.vue
@@ -203,7 +203,6 @@ onMounted(async () => {
   resetTimelineDataWithControl();
 
   isLoading.value = false;
-  console.debug(fixedLastUserInfo);
 });
 
 function exportTimelineImg() {


### PR DESCRIPTION
## 问题描述

当站点关闭后，最后一次获取到的数据都是错误的0，而且最后一次的历史记录始终无法删除，导致用户无法使用最后一次站点正常时获取的数据留作纪念。

具体表现为：
- 站点标记为已离线后，最后一次获取的数据都是0（错误数据）
- 删除按钮被禁用，无法删除当天的错误数据
- 删除历史记录后，`metadata.lastUserInfo` 缓存未更新，仍显示已删除的数据

## 修复方案

### 1. 允许删除离线站点的错误数据
- 当站点标记为已离线（`isOffline`）时，允许删除当天获取的错误数据
- 错误数据判断：上传量、下载量、做种数、做种体积、魔力值全部为0
- 修改 `HistoryDataViewDialog.vue` 的删除权限判断逻辑

### 2. 修复删除后缓存未更新的问题
- 修改 `userInfo.ts` 中的 `removeSiteUserInfo` 处理函数
- 删除历史记录时，同步检查并更新 `metadata.lastUserInfo` 缓存
- 如果删除的是最后一次成功数据，则从剩余历史记录中查找最新的成功数据更新缓存
- 如果所有历史记录都被删除，则清除该站点在 `metadata.lastUserInfo` 中的缓存

### 3. 清理调试日志
- 移除 `UserDataTimeline/Index.vue` 中的 `console.debug` 调试日志

## 修改文件

- `src/entries/options/views/Overview/MyData/HistoryDataViewDialog.vue`
- `src/entries/offscreen/utils/userInfo.ts`
- `src/entries/options/views/Overview/MyData/UserDataTimeline/Index.vue`

## 测试

已测试验证：
- 离线站点可以删除当天的错误数据
- 删除后历史记录正确更新，不再显示已删除的数据
- `metadata.lastUserInfo` 缓存正确同步更新

## Summary by Sourcery

Allow users to delete zeroed data entries for offline sites, ensure lastUserInfo cache stays in sync after deletions, and improve the Haidan site metadata parsing pipeline while cleaning up debug logs.

New Features:
- Enhance Haidan site metadata to fetch and parse seeding count and total size via AJAX with deduplication

Bug Fixes:
- Allow deletion of today’s erroneous data for offline sites by adjusting permission logic in the history dialog
- Synchronize metadata.lastUserInfo cache after history record removal to prevent stale data

Enhancements:
- Update Haidan site URL to use HTTPS and refine parsing filters
- Remove debug logging from the user data timeline component