### PR TITLE
fix(pkg/site/lemonhd): 修复柠檬不酸时魔

### DIFF
--- a/src/packages/site/definitions/lemonhd.ts
+++ b/src/packages/site/definitions/lemonhd.ts
@@ -32,6 +32,14 @@ export const siteMetadata: ISiteMetadata = {
         selector: ["td.rowhead:contains('当前做种') + td"],
         filters: [{ name: "parseSize" }],
       },
+      bonusPerHour: {
+        selector: [
+          "div:contains('你当前每小时能获取'):first",
+          "div:contains('You are currently getting'):first",
+          "div:contains('你當前每小時能獲取'):first",
+        ],
+        filters: [{ name: "parseNumber" }],
+      },
     },
   },
 


### PR DESCRIPTION
fix(lemonhd): 修复柠檬不酸显示时魔错误问题

解决了柠檬不酸站点时魔始终为0的问题。

## Summary by Sourcery

Bug Fixes:
- Add a new bonusPerHour selector with number parsing to lemonhd.ts to fix the bonus-per-hour value always being zero