### PR TITLE
fix(pkg/site): hdvideo 复活

### DIFF
--- a/src/packages/site/definitions/hdvideo.ts
+++ b/src/packages/site/definitions/hdvideo.ts
@@ -1,5 +1,5 @@
 import type { ISiteMetadata } from "../types";
-import { SchemaMetadata } from "../schemas/NexusPHP.ts";
+import { SchemaMetadata } from "../schemas/NexusPHP";
 
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,


### PR DESCRIPTION
closed: https://github.com/pt-plugins/PT-depiler/issues/783

## Summary by Sourcery

Revive the HDVideo site configuration by reactivating it, updating its URL, and incorporating shared NexusPHP schema metadata.

Enhancements:
- Revive the HDVideo site configuration by removing the isDead flag
- Update the site URL to hdvideo.top and record the former host hdvideo.one
- Integrate common NexusPHP schema metadata into the site definition