### PR TITLE
慕雪阁域名rot13加密

### DIFF
--- a/src/packages/site/definitions/muxuege.ts
+++ b/src/packages/site/definitions/muxuege.ts
@@ -16,7 +16,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["https://pt.muxuege.org/"],
+  urls: ["uggcf://cg.zhkhrtr.bet/"],
   favicon: "./_default_nexusphp.png",
 
   category: [


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Obfuscate the Muxuege site URL in siteMetadata by encoding it with rot13