### PR TITLE
fix(pkg/site): Exoticaz HR页无法启动侧边栏

### DIFF
--- a/src/packages/site/definitions/exoticaz.ts
+++ b/src/packages/site/definitions/exoticaz.ts
@@ -118,6 +118,7 @@ export const siteMetadata: ISiteMetadata = {
   },
 
   list: [
+    ...(SchemaMetadata.list ?? []),
     // 种子列表页
     {
       urlPattern: ["/torrents"],

--- a/src/packages/site/schemas/AvistazNetwork.ts
+++ b/src/packages/site/schemas/AvistazNetwork.ts
@@ -193,6 +193,7 @@ export const SchemaMetadata: Pick<
         ...commonListSelectors,
         rows: { selector: "div.card-body.p-2 > div.table-responsive > table > tbody > tr" },
 
+        title: { selector: 'div.mb-1 a[title]', attr: 'title' },
         link: { selector: "div.float-right a[href*='/download/torrent/']", attr: "href" },
         size: { selector: "span.text-yellow[data-original-title='File Size']", filters: [{ "name": "parseSize" }] },
 


### PR DESCRIPTION
refs: https://github.com/pt-plugins/PT-depiler/issues/787

此次commit变动了基类代码 可能影响Avistaz 请涉及到的用户注意 如有问题请反馈

## Summary by Sourcery

Fix sidebar initialization on Exoticaz HR page by merging in the base schema list and enhance AvistazNetwork schema to extract torrent titles.

Bug Fixes:
- Include base schema list in Exoticaz site definition to restore sidebar functionality
- Add title field selector to AvistazNetwork schema for proper title extraction