### PR TITLE
fix(pkg/site/frds): lastAccessAt

### DIFF
--- a/src/packages/site/definitions/keepfrds.ts
+++ b/src/packages/site/definitions/keepfrds.ts
@@ -227,11 +227,8 @@ export const siteMetadata: ISiteMetadata = {
         ],
       },
       lastAccessAt: {
-        selector: "#outer tr:contains('最近动向') > td:eq(2)",
-        filters: [
-          (query: string) => query.trim().split("(")[0].trim(),
-          { name: "parseTime", args: ["yyyy-MM-dd HH:mm:ss"] },
-        ],
+        selector: ".last_seen span",
+        filters: [(query: HTMLSpanElement) => query?.title, { name: "parseTime", args: ["yyyy-MM-dd HH:mm:ss"] }],
       },
     },
     process: [


### PR DESCRIPTION
这么写行不行

## Summary by Sourcery

Bug Fixes:
- Fix last access time scraping for keepfrds by targeting the updated last seen element and reading its title attribute.