### PR TITLE
refactor: remove lastAccessAt metadata from hhanclub and keepfrds def…

### DIFF
--- a/src/packages/site/definitions/hhanclub.ts
+++ b/src/packages/site/definitions/hhanclub.ts
@@ -257,6 +257,15 @@ export const siteMetadata: ISiteMetadata = {
         ],
         filters: [{ name: "parseNumber" }],
       },
+      lastAccessAt: {
+        selector: ["span:contains('最近动向') + span"],
+        filters: [
+          (query: string) => {
+            query = query.split(" (")[0];
+            return parseValidTimeString(query);
+          },
+        ],
+      },
     },
   },
 

--- a/src/packages/site/definitions/keepfrds.ts
+++ b/src/packages/site/definitions/keepfrds.ts
@@ -250,6 +250,7 @@ export const siteMetadata: ISiteMetadata = {
           "hnrUnsatisfied",
           "hnrPreWarning",
           "bonusPerHour", // 使用我们自定义的 selector 和 filter
+          "lastAccessAt",
         ],
       },
     ],

--- a/src/packages/site/definitions/u2.ts
+++ b/src/packages/site/definitions/u2.ts
@@ -142,7 +142,7 @@ export const siteMetadata: ISiteMetadata = {
       {
         requestConfig: { url: "/userdetails.php", responseType: "document" },
         assertion: { id: "params.id" },
-        fields: ["name", "levelName", "uploaded", "downloaded", "bonus", "messageCount", "joinTime"],
+        fields: ["name", "levelName", "uploaded", "downloaded", "bonus", "messageCount", "joinTime", "lastAccessAt"],
       },
       {
         requestConfig: { url: "/mprecent.php", responseType: "document" },


### PR DESCRIPTION
…initions

refactor: improve raw query handling in parseValidTimeString function

## Summary by Sourcery

Refine date parsing utilities and remove unused last-access metadata from specific site definitions.

Enhancements:
- Improve parseValidTimeString to normalize raw input by trimming whitespace and consistently returning the cleaned value when parsing fails.
- Remove lastAccessAt metadata fields from hhanclub and keepfrds site definitions to simplify profile metadata handling.