### PR TITLE
星陨阁新增域名；域名rot13 加密

### DIFF
--- a/src/packages/site/definitions/xingyunge.ts
+++ b/src/packages/site/definitions/xingyunge.ts
@@ -14,7 +14,7 @@ export const siteMetadata: ISiteMetadata = {
   schema: "NexusPHP",
 
   urls: ["uggcf://cg.kvatlhatrcg.bet/", "uggcf://cg.kvatlhatrcg.pa/"],
-  formerHosts: ["https://xingyunge.top/"],
+  formerHosts: ["xingyunge.top"],
 
   levelRequirements: [
     {


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Update Xingyunge site configuration to store domain URLs in ROT13-encoded form.