### PR TITLE
feat(pkg/site): multi messageCount for piggo

### DIFF
--- a/src/packages/site/definitions/piggo.ts
+++ b/src/packages/site/definitions/piggo.ts
@@ -120,13 +120,16 @@ export const siteMetadata: ISiteMetadata = {
       ...SchemaMetadata.userInfo!.selectors!,
       messageCount: {
         text: 0,
-        selector: "div.message-alert > a[href*='messages.php']",
-        filters: [
-          (query: string | number) => {
-            const queryMatch = String(query || "").match(/(\d+)/);
-            return queryMatch && queryMatch.length >= 2 ? parseInt(queryMatch[1]) : 0;
-          },
-        ],
+        selector: "div.message-alerts-container",
+        elementProcess: (e: HTMLElement) => {
+          let total = 0;
+          const alertDivs = e.querySelectorAll("div.message-alert");
+          for (const div of alertDivs) {
+            const numberMatch = div.textContent?.match(/(\d+)/);
+            total += numberMatch && numberMatch.length >= 2 ? parseInt(numberMatch[1], 10) : 0;
+          }
+          return total;
+        },
       },
       hnrPreWarning: {
         text: 0,


### PR DESCRIPTION
now we can process different types of alerts, as the picture shows below:

<img width="1425" height="68" alt="2025-12-01_194906" src="https://github.com/user-attachments/assets/eea5c71d-eb49-41f4-ade2-f18e8bd92621" />

## Summary by Sourcery

New Features:
- Support counting multiple message alert types by aggregating counts from all message-alert elements on the page.