### PR TITLE
feat(pkg/site/secretcinema): 完整适配 SecretCinema

### DIFF
--- a/src/packages/site/definitions/secretcinema.ts
+++ b/src/packages/site/definitions/secretcinema.ts
@@ -1,75 +1,111 @@
-import type { ISiteMetadata } from "../types";
-import { SchemaMetadata } from "../schemas/GazelleJSONAPI";
+import type { ISiteMetadata, ITorrent, IUserInfo, ISearchInput } from "../types";
+import {
+  parseTimeWithZone,
+  parseSizeString,
+  definedFilters,
+  extractContent,
+  buildCategoryOptionsFromList,
+} from "../utils";
+import Sizzle from "sizzle";
+import GazelleJSONAPI, {
+  SchemaMetadata,
+  groupBrowseResult,
+  groupTorrent,
+  torrentBrowseResult,
+  browseJsonResponse,
+} from "../schemas/GazelleJSONAPI";
+import BittorrentSite from "../schemas/AbstractBittorrentSite";
 
-// 自定义 filter 函数：处理 Secret Cinema 的数值字段
-const parseSecretCinemaNumber = (query: string | number) => {
-  if (typeof query === "number") {
-    return query;
-  }
-  const match = query.match(/[\d.]+/);
-  if (match) {
-    const value = parseFloat(match[0]);
-    return isNaN(value) ? 0 : value;
-  }
-  return 0;
+const movieCats = ["SD", "720p", "1080p", "4k", "DVD-R", "BDMV"];
+const musicCats = ["CD", "DVD", "WEB", "Vinyl"];
+
+const mediaCategorySets = {
+  Movies: new Set<string>(movieCats),
+  Music: new Set<string>(musicCats),
 };
+
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,
 
-  version: 1,
+  version: 2,
   id: "secretcinema",
   name: "Secret Cinema",
-  aka: ["秘密影院", "Secret Cinema PW"],
-  description: "专注于高质量电影资源的私人PT站点",
-  tags: ["电影", "高清", "蓝光", "4K"],
+  aka: ["SC"],
+  description: "Secret Cinema is a Private ratioless site for rare MOVIES.",
+  tags: ["电影", "电子书", "音乐"],
+  timezoneOffset: `+0100`,
 
   type: "private",
   schema: "GazelleJSONAPI",
 
-  urls: ["https://secret-cinema.pw/"],
+  urls: ["uggcf://frperg-pvarzn.cj/"],
 
-  favicon: "./secretcinema.ico",
-
-  search: {
-    ...SchemaMetadata.search!,
-    selectors: {
-      ...SchemaMetadata.search!.selectors!,
-      // Secret Cinema 特有的搜索选择器
-      title: {
-        selector: ["a[href*='torrents.php?id=']:first"],
-      },
-      subTitle: {
-        selector: ["a[href*='torrents.php?id=']:first + div"],
-      },
-      size: {
-        selector: ["td:contains('MB')", "td:contains('GB')", "td:contains('TB')"],
-        filters: [{ name: "parseSize" }],
-      },
-      seeders: {
-        selector: ["td:nth-child(3)", "td.seeders"],
-        filters: [{ name: "parseNumber" }],
-      },
-      leechers: {
-        selector: ["td:nth-child(4)", "td.leechers"],
-        filters: [{ name: "parseNumber" }],
-      },
-      completed: {
-        selector: ["td:nth-child(5)", "td.completed"],
-        filters: [{ name: "parseNumber" }],
-      },
-      comments: {
-        selector: ["td:nth-child(6)", "td.comments"],
-        filters: [{ name: "parseNumber" }],
-      },
-      time: {
-        selector: ["td:nth-child(7)", "td.time"],
-        filters: [{ name: "parseTime" }],
-      },
-      tags: [
-        { name: "Freeleech", selector: "span[title*='Freeleech']", color: "green" },
-        { name: "Neutral", selector: "span[title*='Neutral']", color: "blue" },
-        { name: "Personal", selector: "span[title*='Personal']", color: "purple" },
+  category: [
+    {
+      name: "Category",
+      key: "filter_cat",
+      options: [
+        { name: "Movies", value: 1 },
+        { name: "Music", value: 2 },
+        { name: "E-Books", value: 3 },
       ],
+      cross: { mode: "appendQuote" },
+    },
+    {
+      name: "Source",
+      key: "media",
+      options: buildCategoryOptionsFromList([movieCats, musicCats]),
+    },
+  ],
+
+  list: [
+    {
+      urlPattern: ["/torrents.php"],
+      excludeUrlPattern: [/\/torrents\.php\?(?:.*&)?(id|torrentid)=\d+/],
+      mergeSearchSelectors: false,
+      selectors: {
+        rows: { selector: "div.torrent_card > div.torrent_info" },
+        title: {
+          selector: "a[href*='torrents.php?id=']:first > b",
+        },
+        url: { selector: "a[href*='torrents.php?id=']:first", attr: "href" },
+        link: { selector: "a[href^='torrents.php?action=download']", attr: "href" },
+        size: {
+          selector: "div.activity_info > div:nth-child(2)",
+          filters: [{ name: "parseSize" }],
+        },
+        seeders: {
+          selector: "div.torrent_seed",
+          filters: [{ name: "parseNumber" }],
+        },
+        leechers: {
+          selector: "div.torrent_peers",
+          filters: [{ name: "parseNumber" }],
+        },
+        completed: {
+          selector: "div.torrent_snatched",
+          filters: [{ name: "parseNumber" }],
+        },
+        time: {
+          selector: "span.time",
+          filters: [
+            { name: "parseTTL" },
+            (ts: number) => {
+              const offsetMinutes = new Date().getTimezoneOffset();
+              const offsetMs = offsetMinutes * 60 * 1000;
+              return ts + 1 * 3600000 + offsetMs; // UTC+1
+            },
+          ],
+        },
+      },
+    },
+  ],
+
+  userInfo: {
+    ...SchemaMetadata.userInfo!,
+    selectors: {
+      ...SchemaMetadata.userInfo!.selectors!,
+      ratio: { text: "N/A" },
     },
   },
 
@@ -84,7 +120,6 @@ export const siteMetadata: ISiteMetadata = {
       name: "Cinematographer",
       interval: "P2M",
       percentile: 50,
-      seedingPercentile: 95,
       privilege:
         "Can access the Secret Pharmacy forum and create 1 personal collage. Can also invite new members upon having enough Seeding Points.",
     },
@@ -111,30 +146,80 @@ export const siteMetadata: ISiteMetadata = {
       privilege: "Past staff member. Same perks as Cinephiles, plus a few more.",
     },
   ],
-
-  userInfo: {
-    ...SchemaMetadata.userInfo!,
-    selectors: {
-      ...SchemaMetadata.userInfo!.selectors!,
-      // Secret Cinema 特有的用户信息字段覆盖
-      bonus: {
-        selector: ["response.userstats.bonus"],
-        filters: [parseSecretCinemaNumber],
-      },
-      seedingSize: {
-        selector: ["response.userstats.seedingSize"],
-        filters: [parseSecretCinemaNumber],
-      },
-      leeching: {
-        selector: ["response.userstats.leeching"],
-        filters: [parseSecretCinemaNumber],
-      },
-    },
-  },
-
-  list: [
-    {
-      urlPattern: ["/torrents.php"],
-    },
-  ],
 };
+
+export default class SecretCinema extends GazelleJSONAPI {
+  protected override async transformUnGroupTorrent(group: torrentBrowseResult): Promise<ITorrent> {
+    const torrents = await super.transformUnGroupTorrent(group);
+    torrents.tags = []; // ratioless 站点不再额外添加种子优惠相关标签
+    return torrents;
+  }
+
+  protected override async transformGroupTorrent(group: groupBrowseResult, torrent: groupTorrent): Promise<ITorrent> {
+    const { authkey, passkey } = await this.getAuthKey();
+
+    return {
+      site: this.metadata.id, // 补全种子的 site 属性
+      id: torrent.torrentId,
+      title: `${group.artist} - ${extractContent(group.groupName)} [${group.groupYear}]`,
+      subTitle:
+        `${torrent.media}` +
+        (torrent.hasLog ? " / Log" : "") +
+        (torrent.hasCue ? " / Cue" : "") +
+        (torrent.remastered ? ` / ${torrent.remasterYear}` : "") +
+        (torrent.remasterTitle ? ` / ${extractContent(torrent.remasterTitle)}` : "") +
+        (torrent.scene ? " / Scene" : ""),
+      url: `${this.url}torrents.php?id=${group.groupId}&torrentid=${torrent.torrentId}`,
+      link: `${this.url}torrents.php?action=download&id=${torrent.torrentId}&authkey=${authkey}&torrent_pass=${passkey}`,
+      time: parseTimeWithZone(torrent.time, this.metadata.timezoneOffset),
+      size: torrent.size,
+      seeders: torrent.seeders,
+      leechers: torrent.leechers,
+      completed: torrent.snatches,
+      category:
+        group.releaseType === "Music"
+          ? group.releaseType
+          : (Object.entries(mediaCategorySets).find(([_, v]) => v.has(torrent.media))?.[0] ?? "E-Books"),
+    } as ITorrent;
+  }
+
+  public override async transformSearchPage(
+    doc: browseJsonResponse | any,
+    searchConfig: ISearchInput,
+  ): Promise<ITorrent[]> {
+    if (doc instanceof Document) {
+      return BittorrentSite.prototype.transformSearchPage.call(this, doc, searchConfig);
+    }
+    return super.transformSearchPage(doc, searchConfig);
+  }
+
+  protected override async getSeedingSize(userId?: number): Promise<Partial<IUserInfo>> {
+    await this.sleepAction(this.metadata.userInfo?.requestDelay);
+
+    const userSeedingTorrent: Partial<IUserInfo> = { seedingBonus: 0, percentile: 0, seedingSize: 0 };
+
+    const { data: userPage } = await this.request<Document>({
+      url: "/user.php",
+      params: { id: userId },
+      responseType: "document",
+    });
+    userSeedingTorrent.seedingBonus! = definedFilters.parseNumber(
+      Sizzle("li:contains('Seeding Points: ')", userPage)[0].textContent,
+    );
+    userSeedingTorrent.percentile! = definedFilters.parseNumber(
+      Sizzle("li:contains('Overall rank: ')", userPage)[0].textContent,
+    );
+
+    const { data: seedPage } = await this.request<Document>({
+      url: "/torrents.php",
+      params: { type: "seeding", userid: userId },
+      responseType: "document",
+    });
+    const rows = Sizzle("tr.torrent_row > td.nobr", seedPage);
+    rows.forEach((element) => {
+      userSeedingTorrent.seedingSize! += parseSizeString((element as HTMLElement).innerText.trim());
+    });
+
+    return userSeedingTorrent;
+  }
+}


### PR DESCRIPTION
- 补齐高级搜索和 content-script 功能
- 根据站点实际情况解析 `category` 和 `title` 数据

其它更改：
`GazelleJSONAPI` 中 `transformUnGroupTorrent` 将站点提供的 tags 作为副标题而不是实际 tags，一是为了跟 `transformGroupTorrent` 行为对齐（使用优惠信息作为 tags），二是我感觉 Gazelle 的 tags 可能功能上并不与 ptd 的 tags 直接对应，而且可能会非常多从而影响显示

## Summary by Sourcery

Adapt SecretCinema site integration to fully support its JSON API, listing, and user stats while aligning title, subtitle, tag, and category handling with other Gazelle-based sites.

New Features:
- Add SecretCinema-specific category and source filters and implement advanced list/search handling for its torrents.
- Implement SecretCinema-specific torrent transformation logic, including media-aware category mapping and custom title/subtitle formatting.
- Add SecretCinema-specific scraping of seeding points, percentile rank, and total seeding size from HTML pages.

Enhancements:
- Update SecretCinema site metadata, including descriptions, aliases, tags, timezone, and obfuscated base URL.
- Standardize GazelleJSONAPI title/subtitle handling by stripping HTML from group names and using site-provided tags as subtitles.
- Change GazelleJSONAPI ungrouped torrent tags to reflect leech status (freeleech/neutral) instead of raw site tags, and disable these tags for SecretCinema.