### PR TITLE
feat(pkg/site/redacted): RED 添加 Freeload 标签

### DIFF
--- a/src/packages/site/utils/tags.ts
+++ b/src/packages/site/utils/tags.ts
@@ -12,7 +12,8 @@ interface IPreDefinedTorrentTag extends ITorrentTag {
  */
 export const preDefinedTorrentTagMap: IPreDefinedTorrentTag[] = [
   // 优惠类
-  { name: "NL.", color: "deep-purple", aka: [] }, // 中性种子（0xUP & 0xDL）
+  { name: "NL.", color: "deep-purple", aka: ["Neutral"] }, // 中性种子（0xUP & 0xDL）
+  { name: "Freeload", color: "red", aka: [] }, // Freeload
   { name: "Free", color: "blue", aka: [] }, // 免费下载
   { name: "2xFree", color: "green", aka: [] }, // 免费下载 + 2x 上传
   { name: "2xUp", color: "lime", aka: [] }, // 2x 上传


### PR DESCRIPTION
## Summary by Sourcery

Add freeload torrent tagging support for the Redacted site integration.

New Features:
- Tag Redacted torrents as 'Freeload' based on freeload flags in group and ungrouped torrent browse results.
- Extend the predefined torrent tag map with a red 'Freeload' tag and add 'Neutral' as an alias for the existing 'NL.' tag.