### PR TITLE
fix(pkg/site/jptv4us): remove unnecessary patch for homepage 500 error

### DIFF
--- a/src/packages/site/definitions/jptv4us.ts
+++ b/src/packages/site/definitions/jptv4us.ts
@@ -1,5 +1,5 @@
 import { type ISiteMetadata } from "../types.ts";
-import Unit3D, { SchemaMetadata } from "../schemas/Unit3D.ts";
+import { SchemaMetadata } from "../schemas/Unit3D.ts";
 import { buildCategoryOptionsFromList } from "../utils";
 
 export const siteMetadata: ISiteMetadata = {
@@ -172,22 +172,3 @@ export const siteMetadata: ISiteMetadata = {
     },
   ],
 };
-
-export default class JPTV4us extends Unit3D {
-  protected override async getUserNameFromSite(): Promise<string> {
-    await this.sleepAction(this.metadata.userInfo?.requestDelay);
-
-    const { data: indexDocument } = await this.request<Document>(
-      {
-        url: "/torrents",
-        responseType: "document",
-      },
-      true,
-    );
-    return this.getFieldData(
-      indexDocument,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
-      this.metadata.userInfo?.selectors?.name!,
-    );
-  }
-}


### PR DESCRIPTION
> Mon, Nov 10, 2025 9:07 AM
> 
> The server has been upgraded to latest version of unit3d. However, in some cases, workaround are needed.
> ...
> Homepage HTTP 500 Error? Try changing your setting
> Before the upgrade, some users cannot visit the front page. This is one of the unit3d bugs.
> It should be fixed after the upgrade. If not, try to make some changes in your setting page and save it.

## Summary by Sourcery

Enhancements:
- Simplify the JPTV4us site definition by relying on the shared Unit3D schema metadata instead of a site-specific subclass.