### PR TITLE
chore: 优化 download 方法

### DIFF
--- a/src/entries/background/utils/contextMenus.ts
+++ b/src/entries/background/utils/contextMenus.ts
@@ -1,7 +1,7 @@
 import { nanoid } from "nanoid";
 import { format as dateFormat } from "date-fns";
 
-import { CAddTorrentOptions } from "@ptd/downloader";
+import { type CAddTorrentOptions } from "@ptd/downloader";
 import { getHostFromUrl } from "@ptd/site/utils/html.ts"; // 这里不能使用 @ptd/site 的主入口，会导致 sw 无法加载
 import { type ITorrent } from "@ptd/site/types/torrent.ts";
 
@@ -87,7 +87,7 @@ async function downloadLinkPush(
   }
 
   // 发送下载请求
-  sendMessage("downloadTorrentToDownloader", {
+  sendMessage("downloadTorrent", {
     torrent, // 组装包含标题、URL和站点信息的种子对象
     downloaderId: downloader.id,
     addTorrentOptions: {

--- a/src/entries/content-script/app/components/AdvanceListModuleDialog.vue
+++ b/src/entries/content-script/app/components/AdvanceListModuleDialog.vue
@@ -46,7 +46,7 @@ const localDownloadMultiStatus = ref<boolean>(false);
 async function handleLocalDownloadMulti() {
   localDownloadMultiStatus.value = true;
   for (const torrent of selectedTorrents.value) {
-    await sendMessage("downloadTorrentToLocalFile", { torrent });
+    await sendMessage("downloadTorrent", { torrent, downloaderId: "local" });
   }
   localDownloadMultiStatus.value = false;
 }

--- a/src/entries/content-script/app/pages/SiteListPage.vue
+++ b/src/entries/content-script/app/pages/SiteListPage.vue
@@ -39,7 +39,7 @@ function handleLocalDownloadMulti() {
   parseListPage()
     .then(({ torrents }) => {
       for (const torrent of torrents) {
-        sendMessage("downloadTorrentToLocalFile", { torrent });
+        sendMessage("downloadTorrent", { torrent, downloaderId: "local" });
       }
     })
     .finally(() => {

--- a/src/entries/messages.ts
+++ b/src/entries/messages.ts
@@ -7,7 +7,6 @@ import type {
   IUserInfo,
   TSiteID,
 } from "@ptd/site";
-import type { CAddTorrentOptions } from "@ptd/downloader";
 import type { ISocialInformation, TSupportSocialSite$1 } from "@ptd/social";
 import type { IMediaServerId, IMediaServerSearchOptions, IMediaServerSearchResult } from "@ptd/mediaServer";
 import type { getFaviconMetadata } from "@ptd/site";
@@ -22,33 +21,16 @@ import {
   IDownloaderMetadata,
   ISearchData,
   TSearchSnapshotKey,
-  TLocalDownloadMethod,
   TBackupFields,
   TTorrentDownloadStatus,
+  IDownloadTorrentOption,
+  IDownloadTorrentResult,
+  AugmentedRequired,
 } from "@/shared/types.ts";
 
 import { isDebug } from "~/helper.ts";
 
 type TMessageMap = Record<string, (data: any) => any>;
-
-interface IDownloadTorrentOption {
-  torrent: Partial<ITorrent>;
-  downloadId?: TTorrentDownloadKey;
-}
-
-export interface IDownloadTorrentToLocalFile extends IDownloadTorrentOption {
-  localDownloadMethod?: TLocalDownloadMethod;
-}
-
-export interface IDownloadTorrentToClientOption extends IDownloadTorrentOption {
-  downloaderId: string;
-  addTorrentOptions: CAddTorrentOptions;
-}
-
-export interface IDownloadTorrentResult {
-  downloadId: TTorrentDownloadKey;
-  downloadStatus: TTorrentDownloadStatus;
-}
 
 interface ProtocolMap extends TMessageMap {
   // 1. 与 chrome 相关的功能，需要在 service worker 中注册，主要供 offscreen, options 使用
@@ -67,8 +49,7 @@ interface ProtocolMap extends TMessageMap {
   removeDNRSessionRuleById(data: chrome.declarativeNetRequest.Rule["id"]): void;
 
   // 1.4 chrome.alarms
-  reDownloadTorrentToLocalFile(data: Required<IDownloadTorrentToLocalFile>): void;
-  reDownloadTorrentToDownloader(data: Required<IDownloadTorrentToClientOption>): void;
+  reDownloadTorrent(data: AugmentedRequired<IDownloadTorrentOption, "downloadId" | "leftInterval">): void;
 
   // 1.5 chrome.cookies
   getAllCookies(data: chrome.cookies.GetAllDetails): chrome.cookies.Cookie[];
@@ -113,8 +94,9 @@ interface ProtocolMap extends TMessageMap {
   // 2.3 下载器、下载历史 ( utils/download )
   getDownloaderConfig(downloaderId: string): IDownloaderMetadata;
   getTorrentDownloadLink(torrent: ITorrent): string;
-  downloadTorrentToLocalFile(data: IDownloadTorrentToLocalFile): IDownloadTorrentResult;
-  downloadTorrentToDownloader(data: IDownloadTorrentToClientOption): IDownloadTorrentResult;
+
+  downloadTorrent(data: IDownloadTorrentOption): IDownloadTorrentResult;
+
   getDownloadHistory(): ITorrentDownloadMetadata[];
   getDownloadHistoryById(downloadId: TTorrentDownloadKey): ITorrentDownloadMetadata;
   setDownloadHistoryStatus(data: { downloadId: TTorrentDownloadKey; status: TTorrentDownloadStatus }): void;

--- a/src/entries/offscreen/utils/download.ts
+++ b/src/entries/offscreen/utils/download.ts
@@ -1,24 +1,33 @@
 import axios, { type AxiosRequestConfig } from "axios";
 import { stringify } from "urlencode";
+import { toMerged } from "es-toolkit";
 import { isEmpty } from "es-toolkit/compat";
-import { type CAddTorrentOptions, getDownloader, getRemoteTorrentFile } from "@ptd/downloader";
+
+import { getDownloader, getRemoteTorrentFile, type CAddTorrentOptions } from "@ptd/downloader";
 import type { ITorrent } from "@ptd/site";
 
-import { IDownloadTorrentResult, onMessage, sendMessage } from "@/messages.ts";
-import {
+import { onMessage, sendMessage } from "@/messages.ts";
+import type {
   IConfigPiniaStorageSchema,
-  ISearchResultTorrent,
   ITorrentDownloadMetadata,
   TTorrentDownloadKey,
   IDownloaderMetadata,
   IMetadataPiniaStorageSchema,
   TTorrentDownloadStatus,
+  IDownloadTorrentOption,
+  IDownloadTorrentResult,
+  AugmentedRequired,
 } from "@/shared/types.ts";
 
-import { getSiteInstance } from "./site.ts";
 import { logger } from "./logger.ts";
+import { getSiteInstance } from "./site.ts";
 import { ptdIndexDb } from "../adapter/indexdb.ts";
-import { toMerged } from "es-toolkit";
+
+type TLocalDownloadOption = AugmentedRequired<IDownloadTorrentOption, "downloadId" | "localDownloadMethod">;
+type TRemoteDownloadOption = AugmentedRequired<
+  IDownloadTorrentOption,
+  "downloadId" | "downloaderId" | "addTorrentOptions"
+>;
 
 export async function getDownloaderConfig(downloaderId: string) {
   const metadataStore = (await sendMessage("getExtStorage", "metadata")) as IMetadataPiniaStorageSchema;
@@ -34,12 +43,10 @@ export async function getTorrentDownloadLink(torrent: ITorrent) {
 
 onMessage("getTorrentDownloadLink", async ({ data: torrent }) => await getTorrentDownloadLink(torrent));
 
-function buildDownloadHistory(
-  torrent: Partial<ITorrent>,
-  downloaderId: string = "local",
-  addTorrentOptions: CAddTorrentOptions = {} as CAddTorrentOptions,
-): ITorrentDownloadMetadata {
+function buildDownloadHistory(downloadOption: IDownloadTorrentOption): ITorrentDownloadMetadata {
+  const { torrent = {}, downloaderId = "local" } = downloadOption;
   return {
+    ...downloadOption,
     siteId: torrent.site ?? "unknown",
     torrentId: torrent.id ?? "unknown",
     downloaderId,
@@ -49,50 +56,103 @@ function buildDownloadHistory(
     link: torrent.link,
     downloadAt: +Date.now(),
     downloadStatus: "pending",
-    addTorrentOptions,
-    torrent: torrent as ISearchResultTorrent,
-  };
+  } as ITorrentDownloadMetadata;
 }
 
 const lastSiteDownloadAt = new Map<string, number>();
 
 async function isAllowedSaveDownloadHistory(): Promise<boolean> {
   const configStoreRaw = (await sendMessage("getExtStorage", "config")) as IConfigPiniaStorageSchema;
-  return configStoreRaw.download.saveDownloadHistory ?? true;
+  return configStoreRaw?.download?.saveDownloadHistory ?? true;
 }
 
-onMessage("downloadTorrentToLocalFile", async ({ data: { torrent, localDownloadMethod, downloadId } }) => {
+async function downloadTorrent(downloadOption: IDownloadTorrentOption) {
   const configStoreRaw = (await sendMessage("getExtStorage", "config")) as IConfigPiniaStorageSchema;
 
-  // 设置默认的本地下载方法
-  localDownloadMethod ??= configStoreRaw?.download?.localDownloadMethod ?? "web";
+  // 0. 解析传来的下载参数
+  const { torrent, downloaderId = "local", addTorrentOptions = {} as CAddTorrentOptions } = downloadOption;
+  const isDownloadToLocalFile: boolean = downloaderId === "local"; // 如果前端没有传入下载器的id，则认为下载为本地文件
 
-  // 设置下载记录情况
-  if (typeof downloadId === "undefined") {
-    const downloadHistory = buildDownloadHistory(torrent);
-    downloadId = await setDownloadHistory(downloadHistory);
+  // 1. 生成下载历史
+  let downloadId = downloadOption.downloadId!;
+  if (typeof downloadOption.downloadId === "undefined") {
+    const downloadHistory = buildDownloadHistory(downloadOption);
+    downloadOption.downloadId = downloadId = await setDownloadHistory(downloadHistory);
   }
-  let downloadStatus = await setDownloadStatus(downloadId, "pending");
+  logger({ msg: `generate download torrent task #${downloadOption.downloadId}`, data: downloadOption });
+  let downloadStatus = await setDownloadStatus(downloadId!, "pending");
 
+  // 2. 构建下载链接的请求配置
   let downloadRequestConfig: AxiosRequestConfig = { url: torrent.link, method: "GET", timeout: 30e3 };
+  let siteInstance: Awaited<ReturnType<typeof getSiteInstance<"public">>> | null = null;
+
   if (torrent.site) {
     // 生成站点，并检查站点下载间隔，如果触及到站点下载间隔，则将下载任务放入到 alarms 中等待
-    const site = await getSiteInstance<"public">(torrent.site);
+    siteInstance = await getSiteInstance<"public">(torrent.site);
 
-    if (!configStoreRaw.download.ignoreSiteDownloadIntervalWhenLocalDownload && site.downloadInterval > 0) {
-      if (new Date().getTime() - (lastSiteDownloadAt.get(torrent.site) ?? 0) < site.downloadInterval * 1000) {
+    if (
+      siteInstance.downloadInterval > 0 &&
+      // 允许本地下载时忽略站点设置中的下载间隔
+      !(isDownloadToLocalFile && configStoreRaw?.download?.ignoreSiteDownloadIntervalWhenLocalDownload)
+    ) {
+      const leftInterval =
+        siteInstance.downloadInterval * 1000 - (new Date().getTime() - (lastSiteDownloadAt.get(torrent.site) ?? 0));
+
+      if (leftInterval > 0) {
         logger({ msg: `Site ${torrent.site} download interval not reached, waiting...` });
-        sendMessage("reDownloadTorrentToLocalFile", { torrent, localDownloadMethod, downloadId }).catch();
-        return { downloadId, downloadStatus: await setDownloadStatus(downloadId, "pending") } as IDownloadTorrentResult;
+        sendMessage("reDownloadTorrent", { ...downloadOption, downloadId, leftInterval }).catch();
+        return {
+          downloadId,
+          downloadStatus: await setDownloadStatus(downloadId, "pending"),
+        } as IDownloadTorrentResult;
       }
+
+      lastSiteDownloadAt.set(torrent.site, new Date().getTime());
     }
 
-    lastSiteDownloadAt.set(torrent.site, new Date().getTime());
+    // 添加站点配置的上传速度限制
+    if (!isDownloadToLocalFile && (siteInstance.userConfig?.uploadSpeedLimit ?? 0) > 0) {
+      addTorrentOptions.uploadSpeedLimit = siteInstance.userConfig.uploadSpeedLimit;
+    }
+
     downloadRequestConfig = toMerged(
       downloadRequestConfig,
-      await site.getTorrentDownloadRequestConfig(torrent as ITorrent),
+      await siteInstance.getTorrentDownloadRequestConfig(torrent as ITorrent),
     );
   }
+  await patchDownloadHistory(downloadId!, { downloadRequestConfig }).catch(); // 存储下载请求配置，方便后续调试
+
+  try {
+    downloadStatus = await setDownloadStatus(downloadId, "downloading");
+    if (isDownloadToLocalFile) {
+      // 本地下载
+      downloadOption.localDownloadMethod ??= configStoreRaw?.download?.localDownloadMethod ?? "web";
+      downloadStatus = await downloadTorrentToLocalFile(downloadOption as TLocalDownloadOption, downloadRequestConfig);
+    } else {
+      // 远程推送
+      addTorrentOptions.localDownload ??= true; // 默认开启本地中转选项（如果传递进来的没有 localDownload 值的话）
+      if (!(configStoreRaw?.download?.allowDirectSendToClient ?? false)) {
+        addTorrentOptions.localDownload = true; // 如果不允许直接发送到下载器，则将本地中转选项强行设置为 true
+      }
+      downloadOption.addTorrentOptions = addTorrentOptions;
+      downloadStatus = await downloadTorrentToRemote(downloadOption as TRemoteDownloadOption, downloadRequestConfig);
+    }
+  } catch (e) {
+    downloadStatus = "failed";
+  }
+
+  await setDownloadStatus(downloadId, downloadStatus);
+  return { downloadId, downloadStatus } as IDownloadTorrentResult;
+}
+
+onMessage("downloadTorrent", async ({ data: downloadOption }) => await downloadTorrent(downloadOption));
+
+async function downloadTorrentToLocalFile(
+  downloadOption: TLocalDownloadOption,
+  downloadRequestConfig: AxiosRequestConfig,
+): Promise<TTorrentDownloadStatus> {
+  let { torrent, localDownloadMethod = "web", downloadId } = downloadOption;
+  let downloadStatus: TTorrentDownloadStatus = "downloading";
 
   const downloadUri = axios.getUri(downloadRequestConfig); // 组装 baseURL, url, params
   const {
@@ -106,8 +166,7 @@ onMessage("downloadTorrentToLocalFile", async ({ data: { torrent, localDownloadM
     if (downloadMethod.toUpperCase() === "GET" && isEmpty(downloadHeaders)) {
       logger({ msg: `Download torrent file with web method: ${downloadUri}` });
       window.open(downloadUri, "_blank");
-      downloadStatus = await setDownloadStatus(downloadId, "completed");
-      return { downloadId, downloadStatus };
+      return await setDownloadStatus(downloadId, "completed");
     } else {
       localDownloadMethod = "extension"; // 如果是不能直接使用 window.open 方法的情况，直接使用 extension 方法
     }
@@ -133,8 +192,7 @@ onMessage("downloadTorrentToLocalFile", async ({ data: { torrent, localDownloadM
 
       logger({ msg: `Download torrent file with browser method: ${downloadUri}`, data: downloadOptions });
       await sendMessage("downloadFile", downloadOptions);
-      downloadStatus = await setDownloadStatus(downloadId, "completed");
-      return { downloadId, downloadStatus };
+      return await setDownloadStatus(downloadId, "completed");
     } catch (e) {
       localDownloadMethod = "extension"; // 如果下载失败，直接使用 extension 方法（怎么可能？）
     }
@@ -163,46 +221,15 @@ onMessage("downloadTorrentToLocalFile", async ({ data: { torrent, localDownloadM
     }
   }
 
-  return { downloadId, downloadStatus };
-});
+  return downloadStatus;
+}
 
-onMessage("downloadTorrentToDownloader", async ({ data: { torrent, downloaderId, addTorrentOptions, downloadId } }) => {
-  const configStoreRaw = (await sendMessage("getExtStorage", "config")) as IConfigPiniaStorageSchema;
-
-  logger({ msg: "downloadTorrentToDownloader", data: { torrent, downloaderId, addTorrentOptions } });
-
-  addTorrentOptions.localDownload ??= true; // 默认开启本地中转选项（如果传递进来的没有 localDownload 值的话）
-  if (!(configStoreRaw?.download?.allowDirectSendToClient ?? false)) {
-    addTorrentOptions.localDownload = true; // 如果不允许直接发送到下载器，则将本地中转选项强行设置为 true
-  }
-
-  if (typeof downloadId === "undefined") {
-    const downloadHistory = buildDownloadHistory(torrent, downloaderId, addTorrentOptions);
-    downloadId = await setDownloadHistory(downloadHistory);
-  }
-  let downloadStatus = await setDownloadStatus(downloadId, "pending");
-
-  let downloadRequestConfig: AxiosRequestConfig = { url: torrent.link, method: "GET", timeout: 30e3 };
-  let site: Awaited<ReturnType<typeof getSiteInstance<"public">>> | null = null;
-
-  if (torrent.site) {
-    // 生成站点，并检查站点下载间隔，如果触及到站点下载间隔，则将下载任务放入到 alarms 中等待
-    site = await getSiteInstance<"public">(torrent.site);
-    if (site.downloadInterval > 0) {
-      if (new Date().getTime() - (lastSiteDownloadAt.get(torrent.site) ?? 0) < site.downloadInterval * 1000) {
-        logger({ msg: `Site ${torrent.site} download interval not reached, waiting...` });
-        sendMessage("reDownloadTorrentToDownloader", { torrent, downloaderId, addTorrentOptions, downloadId }).catch();
-        return { downloadId, downloadStatus: await setDownloadStatus(downloadId, "pending") } as IDownloadTorrentResult;
-      }
-    }
-
-    lastSiteDownloadAt.set(torrent.site, new Date().getTime());
-    downloadRequestConfig = toMerged(
-      downloadRequestConfig,
-      await site.getTorrentDownloadRequestConfig(torrent as ITorrent),
-    );
-  }
-  await patchDownloadHistory(downloadId, { downloadRequestConfig }).catch(); // 存储下载请求配置，方便后续调试
+async function downloadTorrentToRemote(
+  downloadOption: TRemoteDownloadOption,
+  downloadRequestConfig: AxiosRequestConfig,
+): Promise<TTorrentDownloadStatus> {
+  const { torrent, downloaderId, addTorrentOptions, downloadId } = downloadOption;
+  let downloadStatus: TTorrentDownloadStatus = "failed"; // 远程推送默认失败状态
 
   const downloaderConfig = await getDownloaderConfig(downloaderId);
   if (downloaderConfig.id && downloaderConfig.enabled) {
@@ -211,12 +238,6 @@ onMessage("downloadTorrentToDownloader", async ({ data: { torrent, downloaderId,
       addTorrentOptions.localDownloadOption = downloadRequestConfig;
     }
 
-    // 添加站点配置的上传速度限制
-    if (site?.userConfig?.uploadSpeedLimit && site.userConfig.uploadSpeedLimit > 0) {
-      addTorrentOptions.uploadSpeedLimit = site.userConfig.uploadSpeedLimit;
-    }
-
-    downloadStatus = await setDownloadStatus(downloadId, "downloading");
     const loggerData = { torrent, downloaderId, downloadRequestConfig, addTorrentOptions } as Record<string, any>;
     try {
       logger({ msg: "downloadTorrentToDownloader", data: loggerData });
@@ -227,20 +248,15 @@ onMessage("downloadTorrentToDownloader", async ({ data: { torrent, downloaderId,
         downloadStatus = "completed";
       } else {
         logger({ msg: "Failed to add torrent to downloader", data: loggerData });
-        downloadStatus = "failed";
       }
       patchDownloadHistory(downloadId, { addTorrentResult }).catch(); // 存储添加种子结果，方便后续调试
     } catch (e) {
       logger({ msg: "Error adding torrent to downloader", data: loggerData });
-      downloadStatus = "failed";
     }
-  } else {
-    downloadStatus = "failed";
   }
 
-  await setDownloadStatus(downloadId, downloadStatus);
-  return { downloadId: downloadId, downloadStatus } as IDownloadTorrentResult;
-});
+  return downloadStatus;
+}
 
 export async function getDownloadHistory() {
   return await (await ptdIndexDb).getAll("download_history");

--- a/src/entries/options/components/SentToDownloaderDialog.vue
+++ b/src/entries/options/components/SentToDownloaderDialog.vue
@@ -137,7 +137,7 @@ async function sendToDownloader() {
     }
 
     promises.push(
-      sendMessage("downloadTorrentToDownloader", {
+      sendMessage("downloadTorrent", {
         torrent,
         downloaderId: selectedDownloader.value?.id!,
         addTorrentOptions: realAddTorrentOptions as CAddTorrentOptions,

--- a/src/entries/options/components/TorrentTitleTd.vue
+++ b/src/entries/options/components/TorrentTitleTd.vue
@@ -3,15 +3,17 @@ import { reactive, useTemplateRef } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import { useElementSize } from "@vueuse/core";
+
 import { socialBuildUrlMap } from "@ptd/social";
+import type { ITorrent } from "@ptd/site";
 import type { ISocialInformation, TSupportSocialSite } from "@ptd/social/types.ts";
 
-import type { ISearchResultTorrent } from "@/shared/types.ts";
 import { useConfigStore } from "@/options/stores/config.ts";
 import { sendMessage } from "@/messages.ts";
 
-const { item } = defineProps<{
-  item: ISearchResultTorrent;
+const { item, showSocial = true } = defineProps<{
+  item: Partial<ITorrent>;
+  showSocial?: boolean;
 }>();
 
 const { t } = useI18n();
@@ -72,7 +74,7 @@ function doAdvanceSearch(site: TSupportSocialSite, sid: string) {
 
       <!-- 种子的媒体信息 -->
       <div ref="social" class="ml-2">
-        <template v-if="configStore.searchEntifyControl.showSocialInformation">
+        <template v-if="showSocial && configStore.searchEntifyControl.showSocialInformation">
           <template v-for="(meta, key) in socialBuildUrlMap" :key="key">
             <v-menu v-if="item[`ext_${key}`]" open-on-hover>
               <template v-slot:activator="{ props }">

--- a/src/entries/options/views/Overview/DownloadHistory/ReDownloadSelectDialog.vue
+++ b/src/entries/options/views/Overview/DownloadHistory/ReDownloadSelectDialog.vue
@@ -55,10 +55,10 @@ function reDownload(reDownloadType: TReDownloadType) {
       if (history) {
         const historyTorrent = history.torrent;
         if (reDownloadType === "local" || history.downloaderId === "local") {
-          promises.push(sendMessage("downloadTorrentToLocalFile", { torrent: historyTorrent }));
+          promises.push(sendMessage("downloadTorrent", { torrent: historyTorrent, downloaderId: "local" }));
         } else {
           promises.push(
-            sendMessage("downloadTorrentToDownloader", {
+            sendMessage("downloadTorrent", {
               torrent: historyTorrent,
               downloaderId: history.downloaderId,
               addTorrentOptions: (history.addTorrentOptions ?? {}) as CAddTorrentOptions,

--- a/src/entries/options/views/Overview/SearchEntity/ActionTd.vue
+++ b/src/entries/options/views/Overview/SearchEntity/ActionTd.vue
@@ -51,7 +51,9 @@ async function copyTorrentDownloadLink() {
 const localDlTorrentDownloadLinkBtnStatus = ref(false);
 async function localDlTorrentDownloadLink() {
   localDlTorrentDownloadLinkBtnStatus.value = true;
-  await Promise.allSettled(torrentItems.map((torrent) => sendMessage("downloadTorrentToLocalFile", { torrent })));
+  await Promise.allSettled(
+    torrentItems.map((torrent) => sendMessage("downloadTorrent", { torrent, downloaderId: "local" })),
+  );
   localDlTorrentDownloadLinkBtnStatus.value = false;
 }
 

--- a/src/entries/options/views/Settings/SetSite/Editor.vue
+++ b/src/entries/options/views/Settings/SetSite/Editor.vue
@@ -43,7 +43,7 @@ async function initSiteData(siteId: TSiteID, flush = false) {
   );
 
   // fix: customSiteUrl not show in Editor (#726)
-  if (!siteMetaData.value.urls.includes(siteUserConfig.value.url) ) {
+  if (!siteMetaData.value.urls.includes(siteUserConfig.value.url)) {
     customSiteUrl.value = siteUserConfig.value.url;
   }
 
@@ -239,8 +239,8 @@ const timeZone: Array<{ value: timezoneOffset; title: string }> = [
         <v-slider
           v-model="siteUserConfig.downloadInterval"
           :min="0"
-          :max="1800"
-          :step="30"
+          :max="(siteUserConfig.downloadInterval ?? 0) < 600 ? 600 : 1200"
+          :step="(siteUserConfig.downloadInterval ?? 0) <= 60 ? 1 : 10"
           hint="影响该站点的下载间隔时间（为了安全考虑，插件不会严格遵守该设置，实际间隔总是会略大于等于设置的间隔）"
           label="下载间隔"
           persistent-hint

--- a/src/entries/shared/types.ts
+++ b/src/entries/shared/types.ts
@@ -6,59 +6,13 @@ import type { TBackupFields } from "./types/storages/metadata.ts";
 
 // 代理转发所有 types 导出
 export * from "./types/extends.ts";
+export * from "./types/common/download.ts";
+export * from "./types/common/ptpp.ts";
 export * from "./types/storages/config.ts";
 export * from "./types/storages/indexdb.ts";
 export * from "./types/storages/metadata.ts";
 export * from "./types/storages/runtime.ts";
 export * from "./types/storages/other.ts";
-
-// https://github.com/pt-plugins/PT-Plugin-Plus/blob/70761980a72351397e19e188bead3289d36b4f83/src/interface/common.ts#L648-L726
-export interface IPtppUserInfo {
-  id: number | string; // 用户ID
-  name: string; // 用户名
-  uploaded?: number; // 上传量
-  uploads?: number; // 发布数
-  downloaded?: number; // 下载量
-  trueDownloaded?: string | number; // 真实下载量
-  totalTraffic?: string | number; // 总流量
-  snatches?: number; // 完成数
-  ratio?: number; // 分享率
-  seeding?: number; // 当前做种数
-  seedingSize?: number; // 做种量
-  seedingList?: string[]; // 做种列表
-  leeching?: number; // 当前下载数量
-  levelName?: string; // 等级名称
-  bonus?: number; // 魔力值/积分
-  seedingPoints?: number; // 保种积分
-  seedingTime?: number; // 做种时间要求
-  averageSeedtime?: number; // 平均保种时间
-  totalSeedtime?: number; // 总保种时间
-  bonusPerHour?: number; // 时魔值
-  bonusPage?: string; // 积分页面
-  unsatisfiedsPage?: string; // H&R未达标页面
-  joinTime?: number; // 入站时间
-  classPoints?: number; // 等级积分
-  unsatisfieds?: string | number; // H&R未达标
-  prewarn?: number; // H&R预警
-  lastUpdateTime?: number; // 最后更新时间
-  lastUpdateStatus?: "needLogin" | "notSupported" | "unknown" | "success"; // 最后更新状态  EUserDataRequestStatus
-  invites?: number; // 邀请数量
-  avatar?: string; // 头像
-  isLogged?: boolean; // 是否已登录
-  isLoading?: boolean; // 正在加载
-  lastErrorMsg?: string; // 最后错误信息
-  messageCount?: number; // 消息数量
-  uniqueGroups?: number; // 独特分组
-  perfectFLAC?: number; // “完美”FLAC
-  posts?: number; // 论坛发帖
-}
-
-export interface IPtppDumpUserInfo {
-  [key: string]: {
-    latest: IPtppUserInfo;
-    [key: `${string}-${string}-${string}`]: IPtppUserInfo;
-  };
-}
 
 export interface IRestoreOptions {
   fields?: TBackupFields[]; // 需要恢复的字段

--- a/src/entries/shared/types/common/download.ts
+++ b/src/entries/shared/types/common/download.ts
@@ -1,0 +1,55 @@
+import type { AxiosRequestConfig } from "axios";
+
+import type { ITorrent, TSiteID as TSiteKey } from "@ptd/site";
+import type { CAddTorrentOptions, CAddTorrentResult } from "@ptd/downloader";
+import type { TDownloaderKey } from "@/shared/types/storages/metadata.ts";
+
+export type TTorrentDownloadKey = number;
+export type TTorrentDownloadStatus = "pending" | "downloading" | "completed" | "failed";
+
+export const LocalDownloadMethod = [
+  "web", // 和PTPP一样打开对应种子下载的链接页面，然后由浏览器自动拉起下载过程，只有 method='get' 的种子才能支持，其他情况会回落到 extension
+  "browser", // （默认）由插件直接调用 chrome.downloads.download() 方法，支持 post, data, headers 参数（够用了），此时 filename 由浏览器自动猜测
+  "extension", // （回落）插件调用 axios.requests() 方法，获取并解析种子，生成 Blob 后交由 chrome.downloads.download ，此时 filename 由插件直接控制，可能会出现错误，同时支持 axios 的高级参数
+] as const;
+
+export type TLocalDownloadMethod = (typeof LocalDownloadMethod)[number];
+
+export interface IDownloadTorrentOption {
+  downloadId?: TTorrentDownloadKey;
+  torrent: Partial<ITorrent>;
+  downloaderId:
+    | string // 下载到对应id的下载器中
+    | "local"; // （默认）下载为本地文件
+
+  // 是否忽略种子对应站点的下载
+  ignoreSiteDownloadInterval?: boolean;
+
+  // 剩余等待时间(估算)
+  leftInterval?: number;
+
+  // 当使用下载为本地文件时，可用下面配置项
+  localDownloadMethod?: TLocalDownloadMethod; // 不存在时回落到 configStoreRaw?.download?.localDownloadMethod ?? "web"
+
+  // 当下载到对应id的下载器中时
+  addTorrentOptions?: CAddTorrentOptions;
+}
+
+export interface ITorrentDownloadMetadata extends Pick<ITorrent, "title" | "subTitle" | "url" | "link"> {
+  id?: TTorrentDownloadKey; // 每个下载任务生成的唯一id
+  siteId: TSiteKey; // 站点id
+  torrentId: ITorrent["id"]; // 种子id
+  downloaderId: TDownloaderKey | "local"; // 下载器id，注意 local 是一个特殊的关键词，表示本地下载
+  downloadAt: number; // 下载时间
+  downloadStatus: TTorrentDownloadStatus; // 下载状态
+  torrent: ITorrent; // 种子信息
+  addTorrentOptions: Partial<CAddTorrentOptions>;
+
+  downloadRequestConfig?: AxiosRequestConfig;
+  addTorrentResult?: CAddTorrentResult;
+}
+
+export interface IDownloadTorrentResult {
+  downloadId: TTorrentDownloadKey;
+  downloadStatus: TTorrentDownloadStatus;
+}

--- a/src/entries/shared/types/common/ptpp.ts
+++ b/src/entries/shared/types/common/ptpp.ts
@@ -1,0 +1,47 @@
+// https://github.com/pt-plugins/PT-Plugin-Plus/blob/70761980a72351397e19e188bead3289d36b4f83/src/interface/common.ts#L648-L726
+export interface IPtppUserInfo {
+  id: number | string; // 用户ID
+  name: string; // 用户名
+  uploaded?: number; // 上传量
+  uploads?: number; // 发布数
+  downloaded?: number; // 下载量
+  trueDownloaded?: string | number; // 真实下载量
+  totalTraffic?: string | number; // 总流量
+  snatches?: number; // 完成数
+  ratio?: number; // 分享率
+  seeding?: number; // 当前做种数
+  seedingSize?: number; // 做种量
+  seedingList?: string[]; // 做种列表
+  leeching?: number; // 当前下载数量
+  levelName?: string; // 等级名称
+  bonus?: number; // 魔力值/积分
+  seedingPoints?: number; // 保种积分
+  seedingTime?: number; // 做种时间要求
+  averageSeedtime?: number; // 平均保种时间
+  totalSeedtime?: number; // 总保种时间
+  bonusPerHour?: number; // 时魔值
+  bonusPage?: string; // 积分页面
+  unsatisfiedsPage?: string; // H&R未达标页面
+  joinTime?: number; // 入站时间
+  classPoints?: number; // 等级积分
+  unsatisfieds?: string | number; // H&R未达标
+  prewarn?: number; // H&R预警
+  lastUpdateTime?: number; // 最后更新时间
+  lastUpdateStatus?: "needLogin" | "notSupported" | "unknown" | "success"; // 最后更新状态  EUserDataRequestStatus
+  invites?: number; // 邀请数量
+  avatar?: string; // 头像
+  isLogged?: boolean; // 是否已登录
+  isLoading?: boolean; // 正在加载
+  lastErrorMsg?: string; // 最后错误信息
+  messageCount?: number; // 消息数量
+  uniqueGroups?: number; // 独特分组
+  perfectFLAC?: number; // “完美”FLAC
+  posts?: number; // 论坛发帖
+}
+
+export interface IPtppDumpUserInfo {
+  [key: string]: {
+    latest: IPtppUserInfo;
+    [key: `${string}-${string}-${string}`]: IPtppUserInfo;
+  };
+}

--- a/src/entries/shared/types/extends.ts
+++ b/src/entries/shared/types/extends.ts
@@ -1,1 +1,2 @@
 export type Writeable<T> = { -readonly [P in keyof T]: T[P] };
+export type AugmentedRequired<T extends object, K extends keyof T = keyof T> = Omit<T, K> & Required<Pick<T, K>>;

--- a/src/entries/shared/types/storages/config.ts
+++ b/src/entries/shared/types/storages/config.ts
@@ -4,6 +4,8 @@ import type { IFetchSocialSiteInformationConfig } from "@ptd/social";
 import type { TLangCode } from "@/options/plugins/i18n.ts";
 import type { ITimelineUserInfoField } from "@/options/views/Overview/MyData/UserDataTimeline/utils.ts";
 
+import type { TLocalDownloadMethod } from "../common/download.ts";
+
 export const supportTheme = ["auto", "light", "dark"] as const;
 export type supportThemeType = (typeof supportTheme)[number];
 type UiTableBehaviorKey = "SetSite" | "SearchEntity" | "MyData" | "DownloadHistory" | string;
@@ -12,14 +14,6 @@ interface UiTableBehaviorItem<T = string> {
   columns?: T[];
   sortBy?: { key: T; order: "asc" | "desc" }[];
 }
-
-export const LocalDownloadMethod = [
-  "web", // 和PTPP一样打开对应种子下载的链接页面，然后由浏览器自动拉起下载过程，只有 method='get' 的种子才能支持，其他情况会回落到 extension
-  "browser", // （默认）由插件直接调用 chrome.downloads.download() 方法，支持 post, data, headers 参数（够用了），此时 filename 由浏览器自动猜测
-  "extension", // （回落）插件调用 axios.requests() 方法，获取并解析种子，生成 Blob 后交由 chrome.downloads.download ，此时 filename 由插件直接控制，可能会出现错误，同时支持 axios 的高级参数
-] as const;
-
-export type TLocalDownloadMethod = (typeof LocalDownloadMethod)[number];
 
 export interface IConfigPiniaStorageSchema {
   version: string; // 插件版本，格式为 v0.0.5.1147+23f758f7 ，如果为空则表示第一次安装

--- a/src/entries/shared/types/storages/indexdb.ts
+++ b/src/entries/shared/types/storages/indexdb.ts
@@ -5,31 +5,10 @@
  */
 
 import type { DBSchema } from "idb";
-import type { AxiosRequestConfig } from "axios";
 import type { ISocialInformation } from "@ptd/social";
-import type { ITorrent, TSiteID as TSiteKey } from "@ptd/site";
-import type { CAddTorrentOptions, CAddTorrentResult } from "@ptd/downloader";
+import type { TSiteID as TSiteKey } from "@ptd/site";
 
-import type { TDownloaderKey } from "./metadata.ts";
-import type { ISearchResultTorrent } from "./runtime.ts";
-
-export type TTorrentDownloadKey = number;
-
-export type TTorrentDownloadStatus = "pending" | "downloading" | "completed" | "failed";
-
-export interface ITorrentDownloadMetadata extends Pick<ITorrent, "title" | "subTitle" | "url" | "link"> {
-  id?: TTorrentDownloadKey; // 每个下载任务生成的唯一id
-  siteId: TSiteKey; // 站点id
-  torrentId: ITorrent["id"]; // 种子id
-  downloaderId: TDownloaderKey | "local"; // 下载器id，注意 local 是一个特殊的关键词，表示本地下载
-  downloadAt: number; // 下载时间
-  downloadStatus: TTorrentDownloadStatus; // 下载状态
-  torrent: ISearchResultTorrent; // 种子信息
-  addTorrentOptions: Partial<CAddTorrentOptions>;
-
-  downloadRequestConfig?: AxiosRequestConfig;
-  addTorrentResult?: CAddTorrentResult;
-}
+import type { ITorrentDownloadMetadata, TTorrentDownloadKey } from "../common/download.ts";
 
 export interface IPtdDBSchemaV1 extends DBSchema {
   social_information: {

--- a/src/entries/shared/types/storages/runtime.ts
+++ b/src/entries/shared/types/storages/runtime.ts
@@ -1,3 +1,6 @@
+/**
+ * 此文件用于描述 sessionStorage['__ptd_runtime_store'] 中字段格式
+ */
 import type { VNodeProps } from "vue";
 import type { VSnackbar } from "vuetify/components";
 import type { EResultParseStatus, ITorrent, TSiteID } from "@ptd/site";


### PR DESCRIPTION
1. 拆分、合并download相关types到 shared/types/common/download 中
2. 合并 downloadTorrentToLocalFile 和 downloadTorrentToDownloader 对外通讯为统一的 downloadTorrent 方法，仅依靠 downloaderId: string | "local" 区分实际使用方法
3. 允许设置 < 30s 的站点下载间隔，此时使用 sleep 进行等待，不然仍使用原有的 chrome.alarms 进行队列等待

## Summary by Sourcery

Unify torrent download handling into a single configurable flow and centralize shared download/PTPP types.

New Features:
- Introduce a unified downloadTorrent API that routes to local file download or remote downloader based on downloaderId.
- Allow per-site download intervals below 30 seconds by performing short waits directly in the service worker.

Bug Fixes:
- Fix potential crashes when reading nested download configuration by guarding against missing config objects.

Enhancements:
- Refactor download-related type definitions into shared/common modules for reuse across entries.
- Consolidate local and remote torrent download logic to share history tracking, site interval handling, and configuration behavior.
- Adjust site download interval settings UI to support finer-grained control and dynamic slider ranges.
- Make torrent title component more generic by accepting partial ITorrent items and optional social info display.