### PR TITLE
fix(pkg/site/ubit): subtitle selector in search result

### DIFF
--- a/src/packages/site/definitions/ubits.ts
+++ b/src/packages/site/definitions/ubits.ts
@@ -183,6 +183,20 @@ export const siteMetadata: ISiteMetadata = {
   ],
   search: {
     ...SchemaMetadata.search,
+    selectors: {
+      ...SchemaMetadata.search!.selectors,
+      subTitle: {
+        selector: ["td.embedded:first"],
+        elementProcess: (element: HTMLElement) => {
+          const br1 = element.querySelector("br");
+          const nextNode = br1?.nextSibling;
+          if (nextNode && nextNode.nodeType === Node.TEXT_NODE) {
+            return nextNode.textContent?.trim() || "";
+          }
+          return "";
+        },
+      },
+    },
   },
   levelRequirements: [
     {


### PR DESCRIPTION
fix: #660

## Summary by Sourcery

Bug Fixes:
- Fix subtitle extraction in ubit search results by updating the DOM selector and processing logic.