### PR TITLE
fix(i18n): update flush terminology to refresh in en.json

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -214,8 +214,8 @@
   },
   "MyData": {
     "index": {
-      "flushSelectSite": "Flush selected",
-      "flushCancel": "Flush canceled",
+      "flushSelectSite": "Refresh selected",
+      "flushCancel": "Refresh canceled",
       "joinTimeFormat": "Display join time",
       "joinTimeFormatOptions": {
         "alive": "Relative Time",
@@ -261,7 +261,7 @@
       "updateAt": "Updated At",
       "action": {
         "viewHistoryData": "View History Data",
-        "flushData": "Flush Data"
+        "flushData": "Refresh Data"
       }
     },
     "HistoryDataView": {
@@ -586,9 +586,9 @@
       "uploadSpeedLimitHint": "Set upload speed limit (MB/s) when pushing torrents to downloader, 0 or empty means unlimited"
     },
     "index": {
-      "flushFaviconFinish": "The selected site favicon has been flushed successfully!",
+      "flushFaviconFinish": "The selected site favicon has been refreshed successfully!",
       "table": {
-        "flushFavicon": "Flush Site Favicon"
+        "flushFavicon": "Refresh Site Favicon"
       },
       "settingNote": [
         "Only the configured site will display the plugin icon and the corresponding function;",


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Replace occurrences of the term 'flush' with 'refresh' in the English locale strings to align wording with current terminology.