### PR TITLE
fix(pkg/site/anthelion): ANT 魔力值解析有误

### DIFF
--- a/src/packages/site/definitions/anthelion.ts
+++ b/src/packages/site/definitions/anthelion.ts
@@ -300,7 +300,7 @@ export const siteMetadata: ISiteMetadata = {
         filters: [{ name: "parseTime", args: ["MMM d yyyy, HH:mm 'UTC'"] }],
       },
       seedingSize: { selector: "li:contains('Seeding Size: ') span", filters: [{ name: "parseSize" }] },
-      bonus: { selector: "a[href*='store.php']", filters: [{ name: "replace", args: [",", ""] }] },
+      bonus: { selector: "a[href*='store.php']", filters: [{ name: "replace", args: [/,/g, ""] }] },
       seeding: { selector: "#search_results", filters: [{ name: "parseNumber" }] },
     },
   },


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix ANT bonus value parsing by replacing all comma characters instead of only the first occurrence.