### PR TITLE
feat(pkg/site): ilolicon reopening

### DIFF
--- a/src/packages/site/definitions/ilolicon.ts
+++ b/src/packages/site/definitions/ilolicon.ts
@@ -5,6 +5,7 @@ import NexusPHP, {
   CategorySpstate,
   SchemaMetadata,
 } from "../schemas/NexusPHP";
+import { rot13 } from "../utils";
 
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,
@@ -23,6 +24,7 @@ export const siteMetadata: ISiteMetadata = {
   collaborator: ["haowenwu", "anonymous"],
 
   urls: ["uggcf://zhn.kybyv.pp/"],
+  formerHosts: [rot13("funer.vybyvpba.pbz")],
 
   category: [
     {


### PR DESCRIPTION
## Summary by Sourcery

Reopen and re-enable the ilolicon NexusPHP site definition with the current shared schema metadata and updated tracker URL.

New Features:
- Restore the ilolicon site implementation by reactivating its NexusPHP-based definition and request handler.

Bug Fixes:
- Update the ilolicon tracker URL to the new domain to point to the active site instead of the previously dead address.