### PR TITLE
refactor(pkg/site/myanonamouse): MAM 减少用户信息获取的请求数

### DIFF
--- a/src/packages/site/definitions/cathoderaytube.ts
+++ b/src/packages/site/definitions/cathoderaytube.ts
@@ -1,5 +1,6 @@
 import { type ISiteMetadata } from "../types";
 import { SchemaMetadata } from "../schemas/Luminance";
+import { buildCategoryOptionsFromDict } from "../utils";
 
 const categoryMap: Record<number, string> = {
   13: "Games",
@@ -28,7 +29,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       name: "类别",
       key: "filter_cat",
-      options: Object.entries(categoryMap).map(([value, name]) => ({ name, value })),
+      options: buildCategoryOptionsFromDict(categoryMap),
       cross: { mode: "appendQuote" },
     },
     {

--- a/src/packages/site/definitions/cgpeers.ts
+++ b/src/packages/site/definitions/cgpeers.ts
@@ -1,5 +1,6 @@
 import { type ISiteMetadata, ETorrentStatus } from "../types";
 import { SchemaMetadata } from "../schemas/Luminance";
+import { buildCategoryOptionsFromDict, buildCategoryOptionsFromList } from "../utils";
 
 const categoryMap: Record<number, string> = {
   1: "Applications",
@@ -33,7 +34,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       name: "类别",
       key: "filter_cat",
-      options: Object.entries(categoryMap).map(([value, name]) => ({ name, value })),
+      options: buildCategoryOptionsFromDict(categoryMap),
       cross: { mode: "appendQuote" },
     },
     {

--- a/src/packages/site/definitions/digitalcore.ts
+++ b/src/packages/site/definitions/digitalcore.ts
@@ -1,6 +1,6 @@
 import type { ISiteMetadata } from "../types";
 import { get } from "es-toolkit/compat";
-import { GB } from "../utils";
+import { buildCategoryOptionsFromDict, GB } from "../utils";
 
 const commonDocumentSelectors = {
   rows: { selector: "torrents-table[torrents] > table > tbody > tr" },
@@ -100,7 +100,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       name: "类别",
       key: "categories",
-      options: Object.entries(categoryMap).map(([value, name]) => ({ name, value })),
+      options: buildCategoryOptionsFromDict(categoryMap),
       cross: { mode: "brackets" },
     },
     {

--- a/src/packages/site/definitions/gazellegames.ts
+++ b/src/packages/site/definitions/gazellegames.ts
@@ -1,6 +1,11 @@
 import type { ISiteMetadata, ISearchInput, ITorrent, IUserInfo } from "../types.ts";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
-import { parseValidTimeString, extractContent, buildCategoryOptionsFromList } from "../utils.ts";
+import {
+  parseValidTimeString,
+  extractContent,
+  buildCategoryOptionsFromList,
+  buildCategoryOptionsFromDict,
+} from "../utils.ts";
 import urlJoin from "url-join";
 import GazelleJSONAPI from "../schemas/GazelleJSONAPI.ts";
 import { SchemaMetadata, jsonResponse, infoJsonResponse, userJsonResponse } from "../schemas/GazelleJSONAPI.ts";
@@ -84,7 +89,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       name: "类别",
       key: "filter_cat",
-      options: Object.entries(categoryMap).map(([value, name]) => ({ name, value })),
+      options: buildCategoryOptionsFromDict(categoryMap),
       cross: { mode: "appendQuote" },
     },
     {

--- a/src/packages/site/definitions/hdspace.ts
+++ b/src/packages/site/definitions/hdspace.ts
@@ -3,6 +3,7 @@
  */
 import type { ISiteMetadata } from "../types.ts";
 import { set } from "es-toolkit/compat";
+import { buildCategoryOptionsFromDict } from "../utils.ts";
 
 const categoryMap: Record<number, string> = {
   15: "Movie / Blu-ray",
@@ -53,7 +54,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       name: "类别",
       key: "category",
-      options: Object.entries(categoryMap).map(([value, name]) => ({ name, value })),
+      options: buildCategoryOptionsFromDict(categoryMap),
       cross: { mode: "custom" },
       generateRequestConfig: (selectedOptions) => {
         const params = { category: "" };

--- a/src/packages/site/definitions/hdtorrents.ts
+++ b/src/packages/site/definitions/hdtorrents.ts
@@ -3,7 +3,7 @@
  * @JackettIssue https://github.com/Jackett/Jackett/issues/16002
  */
 import type { ISiteMetadata } from "../types.ts";
-import { definedFilters } from "../utils.ts";
+import { definedFilters, buildCategoryOptionsFromDict } from "../utils.ts";
 import urlJoin from "url-join";
 
 const categoryMap: Record<number, string> = {
@@ -65,7 +65,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       name: "类别",
       key: "category",
-      options: Object.entries(categoryMap).map(([value, name]) => ({ name, value })),
+      options: buildCategoryOptionsFromDict(categoryMap),
       cross: { mode: "brackets" },
     },
     {

--- a/src/packages/site/definitions/pixelcove.ts
+++ b/src/packages/site/definitions/pixelcove.ts
@@ -1,5 +1,6 @@
 import { type ISiteMetadata } from "../types";
 import { SchemaMetadata } from "../schemas/Luminance";
+import { buildCategoryOptionsFromDict } from "../utils";
 
 const categoryMap: Record<number, string> = {
   10: "Windows",
@@ -61,7 +62,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       name: "类别",
       key: "filter_cat",
-      options: Object.entries(categoryMap).map(([value, name]) => ({ name, value })),
+      options: buildCategoryOptionsFromDict(categoryMap),
       cross: { mode: "appendQuote" },
     },
     {

--- a/src/packages/site/definitions/redacted.ts
+++ b/src/packages/site/definitions/redacted.ts
@@ -84,6 +84,10 @@ export const siteMetadata: ISiteMetadata = {
   levelRequirements: [
     {
       id: 1,
+      name: "User",
+    },
+    {
+      id: 2,
       name: "Member",
       interval: "P1W",
       uploaded: "10GB",
@@ -91,7 +95,7 @@ export const siteMetadata: ISiteMetadata = {
       privilege: "",
     },
     {
-      id: 2,
+      id: 3,
       name: "Power User",
       interval: "P2W",
       uploads: 5,
@@ -100,7 +104,7 @@ export const siteMetadata: ISiteMetadata = {
       privilege: "Invites forums; Immunity from inactivity disabling",
     },
     {
-      id: 3,
+      id: 4,
       name: "Elite",
       interval: "P4W",
       uploads: 50,
@@ -109,7 +113,7 @@ export const siteMetadata: ISiteMetadata = {
       privilege: "",
     },
     {
-      id: 4,
+      id: 5,
       name: "Torrent Master",
       interval: "P8W",
       uploads: 500,
@@ -118,7 +122,7 @@ export const siteMetadata: ISiteMetadata = {
       privilege: "Unlimited invites",
     },
     {
-      id: 5,
+      id: 6,
       name: "Power TM",
       interval: "P8W",
       uniqueGroups: 500,
@@ -127,7 +131,7 @@ export const siteMetadata: ISiteMetadata = {
       privilege: "",
     },
     {
-      id: 6,
+      id: 7,
       name: "Elite TM",
       interval: "P8W",
       perfectFlacs: 500,

--- a/src/packages/site/definitions/speedapp.ts
+++ b/src/packages/site/definitions/speedapp.ts
@@ -1,5 +1,6 @@
 import type { ISiteMetadata, ISearchEntryRequestConfig, ISearchResult } from "../types.ts";
 import PrivateSite from "../schemas/AbstractPrivateSite.ts";
+import { buildCategoryOptionsFromDict } from "../utils.ts";
 
 const categoryMapXXX: Record<number, string> = {
   15: "XXX Movies",
@@ -72,13 +73,13 @@ export const siteMetadata: ISiteMetadata = {
     {
       name: "Categories",
       key: "categories_normal",
-      options: Object.entries(categoryMapNormal).map(([value, name]) => ({ name, value })),
+      options: buildCategoryOptionsFromDict(categoryMapNormal),
       cross: { key: "categories", mode: "brackets" },
     },
     {
       name: "Categories (Adult)",
       key: "categories_xxx",
-      options: Object.entries(categoryMapXXX).map(([value, name]) => ({ name, value })),
+      options: buildCategoryOptionsFromDict(categoryMapXXX),
       cross: { mode: "custom" },
       generateRequestConfig: (selectedOptions) => {
         const params: Record<string, any> = { categories: [] };

--- a/src/packages/site/definitions/sportscult.ts
+++ b/src/packages/site/definitions/sportscult.ts
@@ -4,7 +4,7 @@
  */
 import type { ISiteMetadata, IUserInfo } from "../types.ts";
 import PrivateSite from "../schemas/AbstractPrivateSite.ts";
-import { parseSizeString } from "../utils.ts";
+import { parseSizeString, buildCategoryOptionsFromDict } from "../utils.ts";
 import Sizzle from "sizzle";
 
 const categoryMap: Record<number, string> = {
@@ -125,7 +125,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       name: "类别",
       key: "category",
-      options: Object.entries(categoryMap).map(([value, name]) => ({ name, value })),
+      options: buildCategoryOptionsFromDict(categoryMap),
     },
     {
       name: "种子状态",

--- a/src/packages/site/definitions/thegeeks.ts
+++ b/src/packages/site/definitions/thegeeks.ts
@@ -4,7 +4,7 @@
  */
 import type { ISiteMetadata } from "../types.ts";
 import { SchemaMetadata } from "../schemas/TCG.ts";
-import { definedFilters } from "../utils.ts";
+import { definedFilters, buildCategoryOptionsFromDict } from "../utils.ts";
 
 const categoryMap: Record<number, string> = {
   212: "AudioBook : Fiction",
@@ -111,7 +111,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       name: "类别",
       key: "category",
-      options: Object.entries(categoryMap).map(([value, name]) => ({ name, value })),
+      options: buildCategoryOptionsFromDict(categoryMap),
       cross: { mode: "append", key: "c" },
     },
     {

--- a/src/packages/site/definitions/thevault.ts
+++ b/src/packages/site/definitions/thevault.ts
@@ -4,7 +4,7 @@
  */
 import type { ISiteMetadata } from "../types.ts";
 import { SchemaMetadata } from "../schemas/TCG.ts";
-import { definedFilters } from "../utils.ts";
+import { definedFilters, buildCategoryOptionsFromDict } from "../utils.ts";
 
 const categoryMap: Record<number, string> = {
   200: "ABCs / Basics",
@@ -77,7 +77,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       name: "类别",
       key: "category",
-      options: Object.entries(categoryMap).map(([value, name]) => ({ name, value })),
+      options: buildCategoryOptionsFromDict(categoryMap),
       cross: { mode: "append", key: "c" },
     },
     {


### PR DESCRIPTION
## Summary by Sourcery

Refine multiple site definitions to reduce MyAnonamouse user info requests, compute additional stats from a single JSON endpoint, and standardize category option construction across several trackers.

New Features:
- Derive MyAnonamouse seeding, seeding size, uploads, message count, and last access time directly from the jsonLoad API response.
- Add an explicit base User level to Redacted level requirements metadata.

Bug Fixes:
- Correct Redacted user class IDs after inserting the base User level entry.

Enhancements:
- Simplify MyAnonamouse integration by inlining user info parsing into site metadata and removing the dedicated PrivateSite subclass.
- Switch several trackers to use shared helper utilities for building category options and URL/number/size parsing filters for more consistent behavior and reuse.