### PR TITLE
fix(pkg/site/torrentleech): TL 修复用户 ID 获取

### DIFF
--- a/src/packages/site/definitions/torrentleech.ts
+++ b/src/packages/site/definitions/torrentleech.ts
@@ -218,7 +218,7 @@ export const siteMetadata: ISiteMetadata = {
         assertion: { name: "url" }, // 替换之前获取的用户名
         selectors: {
           id: {
-            selector: "div.has-support-msg script",
+            selector: "script:contains('userLogUserID')",
             filters: [(text: string) => text.match(/var userLogUserID = '(\d+)';/)?.[1] ?? ""],
           },
           levelName: { selector: "div.profile-details div.label-user-class" },


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix user ID extraction on TorrentLeech by targeting the script that defines `userLogUserID` instead of relying on a generic support message container.