### PR TITLE
refactor(pkg/site/morethantv): MTV 复用 Luminance Schema

### DIFF
--- a/src/packages/site/definitions/cgpeers.ts
+++ b/src/packages/site/definitions/cgpeers.ts
@@ -1,8 +1,9 @@
 import { type ISiteMetadata, ETorrentStatus } from "../types";
 import { SchemaMetadata } from "../schemas/Luminance";
-import { buildCategoryOptionsFromDict, buildCategoryOptionsFromList } from "../utils";
+import { buildCategoryOptionsFromDict } from "../utils";
 
 const categoryMap: Record<number, string> = {
+  17: "3D Printing",
   1: "Applications",
   8: "Audio",
   7: "Game Development",
@@ -63,7 +64,6 @@ export const siteMetadata: ISiteMetadata = {
           },
         ],
       },
-      time: { selector: ["td:nth-child(6) > span"], attr: "title", filters: [{ name: "parseTime" }] },
       size: { selector: ["td:nth-child(7)"], filters: [{ name: "parseSize" }] },
       author: undefined,
       seeders: { selector: ["td:nth-child(9)"], filters: [{ name: "parseNumber" }] },

--- a/src/packages/site/definitions/morethantv.ts
+++ b/src/packages/site/definitions/morethantv.ts
@@ -1,4 +1,5 @@
 import { ISearchCategoryOptions, type ISiteMetadata } from "../types";
+import { SchemaMetadata } from "../schemas/Luminance";
 
 const categories: ISearchCategoryOptions[] = [
   // Torznab Movie Categories
@@ -24,12 +25,13 @@ const categories: ISearchCategoryOptions[] = [
 ];
 
 export const siteMetadata: ISiteMetadata = {
+  ...SchemaMetadata,
   id: "morethantv",
   version: 2,
   name: "MoreThanTV",
   aka: ["MTV"],
   description: "MoreThanTV is a Private Torrent Tracker for TV / MOVIES",
-  tags: ["电视剧", "剧集"],
+  tags: ["电视剧", "剧集", "电影"],
 
   collaborator: ["luckiestone", "Rhilip"],
 
@@ -117,87 +119,20 @@ export const siteMetadata: ISiteMetadata = {
       urlPattern: ["/torrents/browse"],
       mergeSearchSelectors: false,
       selectors: {
-        rows: { selector: "table#torrent_table tr.torrent" },
+        ...SchemaMetadata.search!.selectors!,
         id: {
           selector: "a.overlay_torrent[href]",
           attr: "href",
           filters: [{ name: "querystring", args: ["torrentid"] }],
         },
-        title: { selector: "a.overlay_torrent[href]" },
-        url: { selector: "a.overlay_torrent[href]", attr: "href" },
-        link: { selector: "a[href^='/torrents.php'][href*='action=download']", attr: "href" },
         seeders: { selector: "td:nth-child(7)" },
         leechers: { selector: "td:nth-child(8)" },
         completed: { selector: "td:nth-child(6)" },
         size: { selector: "td:nth-child(5)", filters: [{ name: "parseSize" }] },
-        time: {
-          selector: "span.time[title]",
-          attr: "title", // Jul 03 2025, 21:04
-          filters: [{ name: "parseTime", args: ["MMM dd yyyy, HH:mm"] }],
-        },
         keywords: { selector: "input#searchtext", elementProcess: (el) => el?.value ?? "" },
       },
     },
   ],
-
-  userInfo: {
-    pickLast: ["id", "joinTime"],
-    process: [
-      {
-        requestConfig: { url: "/index.php" },
-        selectors: {
-          id: {
-            selector: "a.username[href*='user.php']:first",
-            attr: "href",
-            filters: [{ name: "querystring", args: ["id"] }],
-          },
-          name: { selector: "a.username[href*='user.php']:first" },
-          messageCount: {
-            selector: ["div.alert-bar > a[href*='inbox.php']", "div.alertbar > a[href*='inbox.php']"],
-            filters: [{ name: "parseNumber" }],
-          },
-        },
-      },
-      {
-        requestConfig: { url: "/user.php" },
-        assertion: { id: "params.id" },
-        selectors: {
-          uploaded: { selector: "ul.stats > li:contains('Uploaded')", filters: [{ name: "parseSize" }] },
-          downloaded: { selector: "ul.stats > li:contains('Downloaded')", filters: [{ name: "parseSize" }] },
-          ratio: { selector: "ul.stats > li:contains('Ratio:')", filters: [{ name: "parseNumber" }] },
-          seeding: { selector: "ul.stats > li:contains('Seeding:')", filters: [{ name: "parseNumber" }] },
-          seedingSize: { selector: "ul.stats > li:contains('Seeding Size:')", filters: [{ name: "parseSize" }] },
-          levelName: { selector: "ul.stats > li:contains('Class:') a" },
-          bonus: { selector: "#stats_credits", filters: [{ name: "parseNumber" }] },
-          bonusPerHour: {
-            selector: "ul.stats > li:contains('Seeding:')",
-            filters: [
-              (query: string) => {
-                let ret = 0;
-                const queryMatch = query.replace(/,/g, "").match(/Seeding:.+?(\d+)/);
-                if (queryMatch && queryMatch.length >= 2) {
-                  const rawPerHour = parseFloat(queryMatch[1]);
-                  ret = rawPerHour >= 300 ? 100 : Math.round((Math.sqrt(rawPerHour * 0.4 + 1) - 1) * 10);
-                }
-                return ret;
-              },
-            ],
-          },
-          joinTime: {
-            selector: "ul.stats > li:contains('Joined:') > span",
-            attr: "title",
-            filters: [{ name: "parseTime", args: ["MMMM dd yyyy, HH:mm"] }],
-          },
-          lastAccessAt: {
-            selector: "ul.stats > li:contains('Last Seen:') > span",
-            attr: "title",
-            filters: [{ name: "parseTime", args: ["MMMM dd yyyy, HH:mm"] }],
-          },
-          posts: { selector: "ul.stats > li:contains('Forum Posts:')", filters: [{ name: "parseNumber" }] },
-        },
-      },
-    ],
-  },
 
   levelRequirements: [
     {


### PR DESCRIPTION
MTV 的时魔计算公式好像改了，保种数 60 时魔有 90 左右，因此改为通用获取方式（bonuslog 除以 24）

## Summary by Sourcery

Refactor MoreThanTV and related site definitions to reuse the shared Luminance schema for search and user info while aligning selectors with current site markup.

New Features:
- Add 3D Printing to the CGPeers category map and include movies in MoreThanTV tags.

Enhancements:
- Reuse Luminance SchemaMetadata in the MoreThanTV site definition for search configuration and user metadata.
- Align Luminance schema selectors and parsing logic with the latest user stats and torrent listing DOM structure, including time, stats fields, uploads, seeding size, and message count handling.
- Simplify CGPeers search configuration by relying on shared Luminance time parsing instead of a local override.