### PR TITLE
perf(pkg/site/exttorrents): EXT 简化磁力链接获取

### DIFF
--- a/src/packages/site/definitions/exttorrents.ts
+++ b/src/packages/site/definitions/exttorrents.ts
@@ -7,10 +7,16 @@ import { parseTimeToLive, parseValidTimeString } from "../utils";
 
 const extCategories = [
   { uri: "/anime/", cat: 7, value: "Anime" },
-  { uri: "/anime/audio-lossless/", cat: 7, subCat: 61, value: "Anime Audio Lossless" },
   { uri: "/anime/english-translated/", cat: 7, subCat: 7, value: "Anime English Translated" },
-  { uri: "/anime/raw/", cat: 7, subCat: 60, value: "Anime Raw" },
+  { uri: "/anime/music-video/", cat: 7, subCat: 58, value: "Anime Music Video" },
   { uri: "/anime/subs/", cat: 7, subCat: 59, value: "Anime Subs" },
+  { uri: "/anime/raw/", cat: 7, subCat: 60, value: "Anime Raw" },
+  { uri: "/anime/audio-lossless/", cat: 7, subCat: 61, value: "Anime Audio Lossless" },
+  { uri: "/anime/audio-lossy/", cat: 7, subCat: 62, value: "Anime Audio Lossy" },
+  { uri: "/anime/live-action-english/", cat: 7, subCat: 65, value: "Anime Live Action English" },
+  { uri: "/anime/live-action-non-english/", cat: 7, subCat: 67, value: "Anime Live Action Non-English" },
+  { uri: "/anime/live-action-raw/", cat: 7, subCat: 66, value: "Anime Live Action Raw" },
+  { uri: "/anime/pictures/", cat: 7, subCat: 68, value: "Anime Pictures" },
   { uri: "/applications/", cat: 5, value: "Apps" },
   { uri: "/applications/android/", cat: 5, subCat: 25, value: "Apps Android" },
   { uri: "/applications/ios/", cat: 5, subCat: 24, value: "Apps iOS" },
@@ -19,40 +25,49 @@ const extCategories = [
   { uri: "/applications/other-applications/", cat: 5, subCat: 51, value: "Apps Other" },
   { uri: "/applications/windows/", cat: 5, subCat: 5, value: "Apps Windows" },
   { uri: "/books/", cat: 6, value: "Books" },
-  { uri: "/books/audio-books/", cat: 6, subCat: 20, value: "Books Audiobooks" },
-  { uri: "/books/comics/", cat: 6, subCat: 19, value: "Books Comics" },
   { uri: "/books/ebooks/", cat: 6, subCat: 6, value: "Books Ebooks" },
+  { uri: "/books/comics/", cat: 6, subCat: 19, value: "Books Comics" },
+  { uri: "/books/magazines/", cat: 6, subCat: 75, value: "Books Magazines" },
+  { uri: "/books/audio-books/", cat: 6, subCat: 20, value: "Books Audiobooks" },
+  { uri: "/books/manga-english/", cat: 6, subCat: 63, value: "Books Manga English" },
+  { uri: "/books/manga-raw/", cat: 6, subCat: 64, value: "Books Manga Raw" },
   { uri: "/games/", cat: 4, value: "Games" },
-  { uri: "/games/mac/", cat: 4, subCat: 52, value: "Games Mac" },
-  { uri: "/games/nds/", cat: 4, subCat: 33, value: "Games NDS" },
-  { uri: "/games/other-games/", cat: 4, subCat: 32, value: "Games Other" },
   { uri: "/games/pc-games/", cat: 4, subCat: 31, value: "Games PC" },
-  { uri: "/games/ps3/", cat: 4, subCat: 30, value: "Games PS3" },
-  { uri: "/games/ps4/", cat: 4, subCat: 29, value: "Games PS4" },
-  { uri: "/games/psp/", cat: 4, subCat: 28, value: "Games PSP" },
-  { uri: "/games/switch/", cat: 4, subCat: 41, value: "Games Switch" },
-  { uri: "/games/wii/", cat: 4, subCat: 27, value: "Games Wii" },
   { uri: "/games/xbox360/", cat: 4, subCat: 26, value: "Games Xbox360" },
+  { uri: "/games/ps4/", cat: 4, subCat: 29, value: "Games PS4" },
+  { uri: "/games/ps3/", cat: 4, subCat: 30, value: "Games PS3" },
+  { uri: "/games/wii/", cat: 4, subCat: 27, value: "Games Wii" },
+  { uri: "/games/psp/", cat: 4, subCat: 28, value: "Games PSP" },
+  { uri: "/games/nds/", cat: 4, subCat: 33, value: "Games NDS" },
+  { uri: "/games/switch/", cat: 4, subCat: 41, value: "Games Switch" },
+  { uri: "/games/mac/", cat: 4, subCat: 52, value: "Games Mac" },
+  { uri: "/games/other-games/", cat: 4, subCat: 32, value: "Games Other" },
   { uri: "/movies/", cat: 1, value: "Movies" },
   { uri: "/movies/3d-movies/", cat: 1, subCat: 1, value: "Movies 3D" },
+  { uri: "/movies/dubbed-movies/", cat: 1, subCat: 39, value: "Movies Dubbed" },
+  { uri: "/movies/mp4/", cat: 1, subCat: 9, value: "Movies MP4" },
+  { uri: "/movies/highres-movies/", cat: 1, subCat: 11, value: "Movies Highres" },
+  { uri: "/movies/ultrahd/", cat: 1, subCat: 12, value: "Movies UltraHD" },
   { uri: "/movies/bollywood/", cat: 1, subCat: 13, value: "Movies Bollywood" },
   { uri: "/movies/documentary/", cat: 1, subCat: 40, value: "Movies Documentary" },
-  { uri: "/movies/dubbed-movies/", cat: 1, subCat: 39, value: "Movies Dubbed" },
   { uri: "/movies/dvd/", cat: 1, subCat: 42, value: "Movies DVD" },
-  { uri: "/movies/highres-movies/", cat: 1, subCat: 11, value: "Movies Highres" },
-  { uri: "/movies/movie-clips/", cat: 1, subCat: 49, value: "Movies Movie clips" },
-  { uri: "/movies/mp4/", cat: 1, subCat: 9, value: "Movies MP4" },
   { uri: "/movies/music-videos/", cat: 1, subCat: 48, value: "Movies Music videos" },
+  { uri: "/movies/movie-clips/", cat: 1, subCat: 49, value: "Movies Movie clips" },
   { uri: "/movies/other-movies/", cat: 1, subCat: 50, value: "Movies Other Movies" },
-  { uri: "/movies/ultrahd/", cat: 1, subCat: 12, value: "Movies UltraHD" },
   { uri: "/music/", cat: 3, value: "Music" },
-  { uri: "/music/aac/", cat: 3, subCat: 38, value: "Music AAC" },
-  { uri: "/music/lossless/", cat: 3, subCat: 37, value: "Music Lossless" },
   { uri: "/music/mp3/", cat: 3, subCat: 36, value: "Music MP3" },
-  { uri: "/music/other-music/", cat: 3, subCat: 35, value: "Music Other" },
+  { uri: "/music/aac/", cat: 3, subCat: 38, value: "Music AAC" },
   { uri: "/music/radio-shows/", cat: 3, subCat: 34, value: "Music Radio Shows" },
+  { uri: "/music/lossless/", cat: 3, subCat: 37, value: "Music Lossless" },
+  { uri: "/music/other-music/", cat: 3, subCat: 35, value: "Music Other" },
   { uri: "/other/", cat: 8, value: "Other" },
   { uri: "/tv/", cat: 2, value: "TV" },
+  { uri: "/tv/episodes-sd/", cat: 2, subCat: 69, value: "TV Episodes SD" },
+  { uri: "/tv/episodes-hd/", cat: 2, subCat: 70, value: "TV Episodes HD" },
+  { uri: "/tv/episodes-4k-uhd/", cat: 2, subCat: 71, value: "TV Episodes 4K UHD" },
+  { uri: "/tv/season-packs/", cat: 2, subCat: 72, value: "TV Season Packs" },
+  { uri: "/tv/big-season-packs/", cat: 2, subCat: 73, value: "TV Big Season Packs" },
+  { uri: "/tv/sports/", cat: 2, subCat: 74, value: "TV Sports" },
   { uri: "/xxx/", cat: 10, value: "XXX" },
   { uri: "/xxx/games/", cat: 10, subCat: 43, value: "XXX Games" },
   { uri: "/xxx/hentai/", cat: 10, subCat: 44, value: "XXX Hentai" },
@@ -148,6 +163,14 @@ export const siteMetadata: ISiteMetadata = {
       },
       title: { selector: "td:nth-child(1) div a" },
       url: { selector: "td:nth-child(1) div a", attr: "href" },
+      link: {
+        selector: "a.search-magnet-btn",
+        elementProcess: (el: HTMLElement) => {
+          const infoHash = el.dataset.hash;
+          const title = encodeURIComponent(el.dataset.name || "");
+          return `magnet:?xt=urn:btih:${infoHash}&dn=${title}`;
+        },
+      },
       size: { selector: "span:contains('Size') + span", filters: [{ name: "parseSize" }] },
       time: {
         selector: "span:contains('Age') + span",
@@ -183,19 +206,11 @@ export default class ExtTorrents extends BittorrentSite {
   public override async transformDetailPage(doc: Document): Promise<ITorrent> {
     const torrent = await super.transformDetailPage(doc);
     torrent.id = parseId(torrent.url!);
-    return torrent;
-  }
 
-  public override async getTorrentDownloadLink(torrent: ITorrent): Promise<string> {
-    const detailPage = await this.request<Document>({ url: torrent.url!, responseType: "document" });
+    const injectScriptSelector = "script:not([defer])[src]:last + script";
 
-    const injectScriptSelector = "script[src]:last + script";
-
-    const pageToken = this.extractWindowVar(Sizzle(injectScriptSelector, detailPage.data)[0], "pageToken");
-    const csrfToken = this.extractWindowVar(
-      Sizzle(`${injectScriptSelector} + script`, detailPage.data)[0],
-      "csrfToken",
-    );
+    const pageToken = this.extractWindowVar(Sizzle(injectScriptSelector, doc)[0], "pageToken");
+    const csrfToken = this.extractWindowVar(Sizzle(`${injectScriptSelector} + script`, doc)[0], "csrfToken");
 
     const timestamp = Math.floor(Date.now() / 1000);
     const hmacToken = this.computeHMAC(torrent.id as number, timestamp, pageToken!);
@@ -215,9 +230,10 @@ export default class ExtTorrents extends BittorrentSite {
     });
 
     if (getMagnetResp.data.success) {
-      return getMagnetResp.data.magnet!;
+      torrent.link = getMagnetResp.data.magnet!;
     }
-    return super.getTorrentDownloadLink(torrent);
+
+    return torrent;
   }
 
   private extractWindowVar(scriptEl: Element, varName: string): string | null {


### PR DESCRIPTION
最近站点搜索页提供了 hash 信息，可以用来生成磁力链接。详情页仍旧需要自行请求获取

## Summary by Sourcery

Simplify and optimize magnet link retrieval for ExtTorrents by leveraging search page hash data and reusing the detail document while expanding supported category mappings.

New Features:
- Support direct magnet link generation on the ExtTorrents search page using embedded hash and name metadata.
- Add category mappings for new ExtTorrents sections such as additional anime, books, games, movies, music, and TV subcategories.

Enhancements:
- Reuse the already-fetched detail page document to derive tokens for magnet retrieval instead of issuing a separate request, and attach the resulting magnet link to the torrent metadata.