### PR TITLE
feat(pkg/site/speedapp): SpeedApp 增加成人搜索入口

### DIFF
--- a/src/packages/site/definitions/bakabt.ts
+++ b/src/packages/site/definitions/bakabt.ts
@@ -41,10 +41,14 @@ export const siteMetadata: ISiteMetadata = {
     {
       name: "成人内容",
       key: "hentai",
+      notes: "请先在站点设置中启用 Browse -> Show adult content",
       options: [
         { name: "显示", value: 1 },
         { name: "不显示", value: 0 },
       ],
+      generateRequestConfig: (selectedOption) => ({
+        requestConfig: { params: { hentai: selectedOption, reorder: 1 } },
+      }),
     },
   ],
 
@@ -55,7 +59,6 @@ export const siteMetadata: ISiteMetadata = {
       responseType: "document",
       params: {
         only: 0,
-        reorder: 1,
         incomplete: 1,
         lossless: 1,
         hd: 1,

--- a/src/packages/site/definitions/hdspace.ts
+++ b/src/packages/site/definitions/hdspace.ts
@@ -40,7 +40,7 @@ export const siteMetadata: ISiteMetadata = {
   version: 1,
   id: "hdspace",
   name: "HD-Space",
-  aka: ["HDS"],
+  aka: ["HD-S"],
   description: "HD-Space (HDS) is a Private Torrent Tracker for HD MOVIES / TV",
   tags: ["影视"],
   timezoneOffset: "+0000",

--- a/src/packages/site/definitions/speedapp.ts
+++ b/src/packages/site/definitions/speedapp.ts
@@ -71,23 +71,26 @@ export const siteMetadata: ISiteMetadata = {
   // 这里除了 categories 其它均为自定义 key，需要在自定义站点方法中统一处理
   category: [
     {
+      name: "搜索入口",
+      key: "#url",
+      options: [
+        { name: "综合", value: "/browse" },
+        { name: "成人", value: "/adult" },
+      ],
+    },
+    {
       name: "Categories",
       key: "categories_normal",
+      notes: "请先设置分类入口为“综合”！请勿与 成人 区类别同时选择！",
       options: buildCategoryOptionsFromDict(categoryMapNormal),
       cross: { key: "categories", mode: "brackets" },
     },
     {
       name: "Categories (Adult)",
       key: "categories_xxx",
+      notes: "请先设置分类入口为“成人”！请勿与 综合 区类别同时选择！",
       options: buildCategoryOptionsFromDict(categoryMapXXX),
-      cross: { mode: "custom" },
-      generateRequestConfig: (selectedOptions) => {
-        const params: Record<string, any> = { categories: [] };
-        (selectedOptions as number[]).forEach((value) => {
-          params.categories.push(value);
-        });
-        return { requestConfig: { url: "/adult", params } };
-      },
+      cross: { key: "categories", mode: "brackets" },
     },
     {
       name: "Resolution",
@@ -290,7 +293,7 @@ export const siteMetadata: ISiteMetadata = {
       url: { selector: "div:nth-child(2) > a[href^='/browse/']:first-child", attr: "href" },
       link: { selector: "a.btn[href^='/torrents/']", attr: "href" },
       category: {
-        selector: "a[href^='/browse?categories']",
+        selector: "a[href*='?categories']",
         attr: "href",
         filters: [{ name: "split", args: ["=", 1] }, (catID: number) => categoryMap[catID]],
       },
@@ -316,6 +319,11 @@ export const siteMetadata: ISiteMetadata = {
         },
       ],
     },
+  },
+
+  searchEntry: {
+    area_normal: { name: "综合", requestConfig: { url: "/browse" } },
+    area_adult: { name: "成人", enabled: false, requestConfig: { url: "/adult" } },
   },
 
   list: [


### PR DESCRIPTION
## Summary by Sourcery

Add configurable adult search entry support for SpeedApp and adjust related category handling and selectors, update BakaBT adult content search parameters, and correct HD-Space alternate naming.

New Features:
- Introduce a selectable search entry configuration for SpeedApp with normal and adult areas.
- Add an adult content toggle in BakaBT that drives search request parameters.

Enhancements:
- Unify SpeedApp normal and adult category handling via a shared categories parameter and more flexible category link selector.
- Clarify configuration notes for SpeedApp and BakaBT regarding adult content settings.
- Correct the displayed AKA name for the HD-Space tracker.