### PR TITLE
feat(pkg/site): 增加一些 tag 信息

### DIFF
--- a/src/packages/site/definitions/anthelion.ts
+++ b/src/packages/site/definitions/anthelion.ts
@@ -3,7 +3,7 @@ import Gazelle, { SchemaMetadata, extractSubTitle } from "../schemas/Gazelle.ts"
 import { ISiteMetadata, ITorrent, ISearchInput, ETorrentStatus } from "../types";
 import { definedFilters, buildCategoryOptionsFromList } from "../utils.ts";
 
-const tagKeywords = ["Freeleech", "Neutral", "Seeding", "Snatched", "Pollen", "Reported"];
+const tagKeywords = ["Freeleech", "Neutral", "Seeding", "Snatched", "Internal", "Pollen", "Reported"];
 
 const antCategories = [
   { name: "Feature Film", class: "featurefilm", value: 1 },
@@ -190,6 +190,10 @@ export const siteMetadata: ISiteMetadata = {
         {
           name: "Free",
           selector: "strong:contains('Freeleech')",
+        },
+        {
+          name: "Internal",
+          selector: "strong:contains('Internal')",
         },
       ],
       progress: {

--- a/src/packages/site/definitions/morethantv.ts
+++ b/src/packages/site/definitions/morethantv.ts
@@ -50,6 +50,8 @@ export const siteMetadata: ISiteMetadata = {
     },
   ],
 
+  officialGroupPattern: [/-(TEPES|E\.N\.D|SMURF|hallowed|WDYM|PiRAMiDHEAD|VaLTiEL)/i],
+
   search: {
     skipNonLatinCharacters: true,
     keywordPath: "params.q",

--- a/src/packages/site/definitions/opencd.ts
+++ b/src/packages/site/definitions/opencd.ts
@@ -232,6 +232,8 @@ export const siteMetadata: ISiteMetadata = {
     },
   ],
 
+  officialGroupPattern: ["OpenCD", "LLM", "TSxD", "KHQ"],
+
   search: {
     ...SchemaMetadata.search,
     advanceKeywordParams: {

--- a/src/packages/site/utils/tags.ts
+++ b/src/packages/site/utils/tags.ts
@@ -14,7 +14,6 @@ export const preDefinedTorrentTagMap: IPreDefinedTorrentTag[] = [
   // 优惠类
   { name: "NL.", color: "deep-purple", aka: ["Neutral"] }, // 中性种子（0xUP & 0xDL）
   { name: "Freeload", color: "red", aka: [] }, // Freeload
-  { name: "Free", color: "blue", aka: [] }, // 免费下载
   { name: "2xFree", color: "green", aka: [] }, // 免费下载 + 2x 上传
   { name: "2xUp", color: "lime", aka: [] }, // 2x 上传
   { name: "2x50%", color: "light-green", aka: [] }, // 2x 上传 + 50% 下载
@@ -24,9 +23,11 @@ export const preDefinedTorrentTagMap: IPreDefinedTorrentTag[] = [
   { name: "50%", color: "orange", aka: [] }, // 50% 下载
   { name: "70%", color: "blue-grey", aka: [] }, // 70% 下载
   { name: "75%", color: "lime-darken-3", aka: [] }, // 75% 下载
+  { name: "Free", color: "blue", aka: [] }, // 免费下载
+  { name: "可退款", color: "gray", aka: ["Refund"] }, // 定期退还下载量
 
   // 站点属性类
-  { name: "官方", color: "blue-darken-2", aka: ["官组", "官种"] },
+  { name: "官方", color: "blue-darken-2", aka: ["官组", "官种", "Internal"] },
   { name: "Hot", color: "yellow-lighten-1", aka: ["热门", "熱門"] },
   { name: "H&R", color: "red", aka: ["HnR"] }, // 需要 H&R
   { name: "Excl.", color: "deep-orange-darken-1", aka: ["独家", "限转", "禁转"] }, // 禁止转载


### PR DESCRIPTION
## Summary by Sourcery

Add and update torrent tag metadata and official group patterns for several sites.

New Features:
- Recognize the "Internal" tag on Anthelion torrents and include it in tag parsing.
- Add recognition of official release groups for MoreThanTV and OpenCD using configurable patterns.
- Introduce a predefined tag for refundable downloads mapped from the "Refund" label.

Enhancements:
- Adjust predefined torrent tag ordering and alias mappings, including mapping the "Internal" label to the existing official tag.