### PR TITLE
fix(ui) 为部分缺少文本提示的 V-Btn 添加 title 属性

### DIFF
--- a/src/entries/content-script/app/components/AdvanceListModuleDialog.vue
+++ b/src/entries/content-script/app/components/AdvanceListModuleDialog.vue
@@ -103,7 +103,7 @@ function enterDialog() {
         <v-toolbar color="blue-grey-darken-2">
           <v-toolbar-title> 为 {{ torrentItems.length }} 个种子自定义批量操作行为 </v-toolbar-title>
           <template #append>
-            <v-btn icon="mdi-close" @click="showDialog = false" />
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
           </template>
         </v-toolbar>
       </v-card-title>

--- a/src/entries/content-script/app/components/SocialSiteParseResultsDialog.vue
+++ b/src/entries/content-script/app/components/SocialSiteParseResultsDialog.vue
@@ -16,7 +16,7 @@ const ptdData = inject<IPtdData>("ptd_data", {});
         <v-toolbar color="blue-grey-darken-2">
           <v-toolbar-title> 快速搜索 </v-toolbar-title>
           <template #append>
-            <v-btn icon="mdi-close" @click="showDialog = false" />
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
           </template>
         </v-toolbar>
       </v-card-title>

--- a/src/entries/options/components/SentToDownloaderDialog.vue
+++ b/src/entries/options/components/SentToDownloaderDialog.vue
@@ -236,7 +236,7 @@ function dialogLeave() {
         <v-toolbar color="blue-grey-darken-2">
           <v-toolbar-title> 为 {{ torrentItems.length }} 个种子选择下载器 </v-toolbar-title>
           <template #append>
-            <v-btn icon="mdi-close" @click="showDialog = false" />
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
           </template>
         </v-toolbar>
       </v-card-title>
@@ -369,7 +369,7 @@ function dialogLeave() {
       </v-card-text>
       <v-divider />
       <v-card-actions>
-        <v-btn icon="mdi-cards" @click="quickSendToClient = !quickSendToClient" />
+        <v-btn title="更多选项" icon="mdi-cards" @click="quickSendToClient = !quickSendToClient" />
 
         <v-spacer />
         <v-btn

--- a/src/entries/options/views/About/Logger.vue
+++ b/src/entries/options/views/About/Logger.vue
@@ -58,6 +58,7 @@ onMounted(() => {
     <template #item.action="{ item }">
       <v-btn-group class="table-action" density="compact" variant="plain">
         <v-btn
+          :title="t('Logger.action.details')"
           :disabled="typeof item.data === 'undefined'"
           color="info"
           size="small"

--- a/src/entries/options/views/Layout/Topbar.vue
+++ b/src/entries/options/views/Layout/Topbar.vue
@@ -100,7 +100,12 @@ watch(
     >
       <template #append>
         <!-- 搜索按键 -->
-        <v-btn :disabled="runtimeStore.search.isSearching" icon="mdi-magnify" @click="startSearchEntity" />
+        <v-btn
+          :disabled="runtimeStore.search.isSearching"
+          icon="mdi-magnify"
+          :title="t('common.search')"
+          @click="startSearchEntity"
+        />
       </template>
 
       <template #prepend-inner>
@@ -214,7 +219,12 @@ watch(
         <!-- 处于小屏幕，只显示点，btn以menu列表形式展示 -->
         <v-menu bottom left offset-y>
           <template #activator="{ props }">
-            <v-btn v-bind="props" icon="mdi-dots-vertical" variant="text" />
+            <v-btn
+              :title="t('layout.header.expand')"
+              v-bind="props"
+              icon="mdi-dots-vertical"
+              variant="text"
+            />
           </template>
 
           <v-list>

--- a/src/entries/options/views/Overview/DownloadHistory/AdvanceFilterGenerateDialog.vue
+++ b/src/entries/options/views/Overview/DownloadHistory/AdvanceFilterGenerateDialog.vue
@@ -32,7 +32,7 @@ function updateTableFilter() {
         <v-toolbar color="blue-grey-darken-2">
           <v-toolbar-title> 生成高级过滤词 </v-toolbar-title>
           <template #append>
-            <v-btn icon="mdi-close" @click="showDialog = false" />
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
           </template>
         </v-toolbar>
       </v-card-title>

--- a/src/entries/options/views/Overview/DownloadHistory/Index.vue
+++ b/src/entries/options/views/Overview/DownloadHistory/Index.vue
@@ -191,6 +191,7 @@ onMounted(() => {
         <template #item.action="{ item }">
           <v-btn-group class="table-action" density="compact" variant="plain">
             <v-btn
+              :title="t('DownloadHistory.reDownload')"
               color="primary"
               icon="mdi-tray-arrow-down"
               size="small"

--- a/src/entries/options/views/Overview/DownloadHistory/ReDownloadSelectDialog.vue
+++ b/src/entries/options/views/Overview/DownloadHistory/ReDownloadSelectDialog.vue
@@ -89,7 +89,7 @@ function dialogEnter() {
         <v-toolbar color="primary">
           <v-toolbar-title>重新下载 {{ torrentItems.length }} 条记录</v-toolbar-title>
           <template #append>
-            <v-btn icon="mdi-close" @click="showDialog = false" />
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
           </template>
         </v-toolbar>
       </v-card-title>

--- a/src/entries/options/views/Overview/MediaServerEntity/ItemInformationDialog.vue
+++ b/src/entries/options/views/Overview/MediaServerEntity/ItemInformationDialog.vue
@@ -60,7 +60,7 @@ function secondsToISO8601(seconds: number) {
         <v-toolbar color="blue-grey-darken-2">
           <v-toolbar-title> 媒体详情 </v-toolbar-title>
           <template #append>
-            <v-btn icon="mdi-close" @click="showDialog = false" />
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
           </template>
         </v-toolbar>
       </v-card-title>

--- a/src/entries/options/views/Overview/MyData/HistoryDataViewDialog.vue
+++ b/src/entries/options/views/Overview/MyData/HistoryDataViewDialog.vue
@@ -93,7 +93,7 @@ function exportSiteHistoryData() {
             {{ t("MyData.HistoryDataView.title") }} @ <SiteName :site-id="props.siteId!" class="" tag="span" />
           </v-toolbar-title>
           <template #append>
-            <v-btn icon="mdi-close" @click="showDialog = false" />
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
           </template>
         </v-toolbar>
       </v-card-title>

--- a/src/entries/options/views/Overview/SearchEntity/ActionTd.vue
+++ b/src/entries/options/views/Overview/SearchEntity/ActionTd.vue
@@ -70,6 +70,7 @@ function sendToDownloader() {
       :disabled="torrentItems.length == 0"
       :size="btnSize"
       icon="mdi-cloud-download"
+      title="下载到服务器"
       @click="() => sendToDownloader()"
     />
     <!-- 复制下载链接 -->

--- a/src/entries/options/views/Overview/SearchEntity/AdvanceFilterGenerateDialog.vue
+++ b/src/entries/options/views/Overview/SearchEntity/AdvanceFilterGenerateDialog.vue
@@ -51,7 +51,7 @@ function updateTableFilter() {
         <v-toolbar color="blue-grey-darken-2">
           <v-toolbar-title> 生成高级过滤词 </v-toolbar-title>
           <template #append>
-            <v-btn icon="mdi-close" @click="showDialog = false" />
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
           </template>
         </v-toolbar>
       </v-card-title>

--- a/src/entries/options/views/Overview/SearchEntity/Index.vue
+++ b/src/entries/options/views/Overview/SearchEntity/Index.vue
@@ -286,7 +286,7 @@ function cancelSearchQueue() {
         <v-menu>
           <template v-slot:activator="{ props }">
             <v-btn-group size="small" variant="text">
-              <v-btn color="blue" icon="mdi-cog" v-bind="props" />
+              <v-btn :title= "t('SearchEntity.index.action.displayPreferences')"color="blue" icon="mdi-cog" v-bind="props" />
             </v-btn-group>
           </template>
           <v-list>

--- a/src/entries/options/views/Overview/SearchEntity/SaveSnapshotDialog.vue
+++ b/src/entries/options/views/Overview/SearchEntity/SaveSnapshotDialog.vue
@@ -34,7 +34,7 @@ function saveSearchSnapshotData() {
         <v-toolbar color="cyan-darken-2">
           <v-toolbar-title>保存搜索快照</v-toolbar-title>
           <template #append>
-            <v-btn icon="mdi-close" @click="showDialog = false" />
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
           </template>
         </v-toolbar>
         <v-spacer />

--- a/src/entries/options/views/Overview/SearchEntity/SearchStatusDialog.vue
+++ b/src/entries/options/views/Overview/SearchEntity/SearchStatusDialog.vue
@@ -39,7 +39,7 @@ function getSearchSolution(planKey: string, entryName: string) {
           </v-toolbar-title>
 
           <template #append>
-            <v-btn icon="mdi-close" @click="showDialog = false" />
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
           </template>
         </v-toolbar>
       </v-card-title>
@@ -107,6 +107,7 @@ function getSearchSolution(planKey: string, entryName: string) {
                 <!-- 上移队列 -->
                 <v-btn
                   v-if="searchPlan.status === EResultParseStatus.waiting"
+                  :title="t('SearchEntity.SearchStatusDialog.moveUp')"
                   color="warning"
                   icon="mdi-arrow-collapse-up"
                   @click="() => raiseSearchPriority(solutionKey)"
@@ -115,6 +116,7 @@ function getSearchSolution(planKey: string, entryName: string) {
                 <!-- 重新搜索 -->
                 <v-btn
                   v-else
+                  :title="t('SearchEntity.SearchStatusDialog.searchAgain')"
                   :loading="searchPlan.status === EResultParseStatus.working"
                   color="red"
                   icon="mdi-cached"

--- a/src/entries/options/views/Overview/SearchResultSnapshot/EditNameDialog.vue
+++ b/src/entries/options/views/Overview/SearchResultSnapshot/EditNameDialog.vue
@@ -35,7 +35,7 @@ function dialogEnter() {
         <v-toolbar color="cyan-darken-2">
           <v-toolbar-title>搜索快照重命名</v-toolbar-title>
           <template #append>
-            <v-btn icon="mdi-close" @click="showDialog = false" />
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
           </template>
         </v-toolbar>
       </v-card-title>

--- a/src/entries/options/views/Settings/SetBackup/AddDialog.vue
+++ b/src/entries/options/views/Settings/SetBackup/AddDialog.vue
@@ -66,6 +66,7 @@ function resetDialog() {
           <v-toolbar-title> 添加备份服务器 </v-toolbar-title>
           <v-spacer />
           <v-btn
+            :title="t('layout.header.wiki')"
             :href="`${REPO_URL}/wiki/config-backup-server`"
             color="success"
             icon="mdi-help-circle"

--- a/src/entries/options/views/Settings/SetBackup/EditDialog.vue
+++ b/src/entries/options/views/Settings/SetBackup/EditDialog.vue
@@ -35,7 +35,7 @@ function editClientConfig() {
         <v-toolbar color="blue-grey-darken-2">
           <v-toolbar-title>{{ t("SetDownloader.edit.title") }}</v-toolbar-title>
           <template #append>
-            <v-btn icon="mdi-close" @click="showDialog = false" />
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
           </template>
         </v-toolbar>
       </v-card-title>

--- a/src/entries/options/views/Settings/SetBackup/HistoryDialog.vue
+++ b/src/entries/options/views/Settings/SetBackup/HistoryDialog.vue
@@ -89,7 +89,7 @@ async function dialogLeave() {
             {{ metadataStore.backupServers[backupServerId].name ?? backupServerId }} 的历史备份
           </v-toolbar-title>
           <template #append>
-            <v-btn icon="mdi-close" @click="showDialog = false" />
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
           </template>
         </v-toolbar>
       </v-card-title>
@@ -125,7 +125,13 @@ async function dialogLeave() {
 
           <template #item.action="{ item }">
             <v-btn-group class="table-action" density="compact" variant="plain">
-              <v-btn color="blue" icon="mdi-cloud-download" size="small" @click="restoreBackup(item.path)" />
+              <v-btn
+                title="恢复备份"
+                color="blue"
+                icon="mdi-cloud-download"
+                size="small"
+                @click="restoreBackup(item.path)"
+              />
 
               <v-btn
                 :title="t('common.remove')"

--- a/src/entries/options/views/Settings/SetBackup/Index.vue
+++ b/src/entries/options/views/Settings/SetBackup/Index.vue
@@ -157,14 +157,19 @@ async function confirmDeleteBackupServer(id: TBackupServerKey) {
       <template #item.action="{ item }">
         <v-btn-group class="table-action" density="compact" variant="plain">
           <v-btn
+            :title="t('SetBackup.table.action.backupNow')"
             :loading="doBackupStatus[item.id]"
             color="green"
             icon="mdi-cloud-upload"
             size="small"
             @click="doBackup(item.id)"
           />
-
-          <v-btn icon="mdi-view-list" size="small" @click="showHistory(item.id)" />
+          <v-btn
+            :title="t('SetBackup.table.action.viewHistoryBackup')"
+            icon="mdi-view-list"
+            size="small"
+            @click="showHistory(item.id)"
+          />
 
           <v-btn
             :title="t('common.edit')"

--- a/src/entries/options/views/Settings/SetBase/RestorePtppUserDataDialog.vue
+++ b/src/entries/options/views/Settings/SetBase/RestorePtppUserDataDialog.vue
@@ -246,7 +246,7 @@ async function entryDialog() {
         <v-toolbar color="blue-grey-darken-2">
           <v-toolbar-title>恢复 PT-Plugin-Plus 的用户历史数据信息</v-toolbar-title>
           <template #append>
-            <v-btn icon="mdi-close" @click="showDialog = false" />
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
           </template>
         </v-toolbar>
       </v-card-title>

--- a/src/entries/options/views/Settings/SetBase/UserInfoWindow.vue
+++ b/src/entries/options/views/Settings/SetBase/UserInfoWindow.vue
@@ -120,6 +120,7 @@ onMounted(async () => {
             {{ t("userInfo.autoRefresh.nextFlushTime") }}
             {{ nextFlushUserInfoAt != 0 ? formatDate(nextFlushUserInfoAt) : "-" }}
             <v-btn
+              :title="t('userInfo.autoRefresh.getNextFlushTime')"
               class="ml-1"
               density="compact"
               icon="mdi-refresh"

--- a/src/entries/options/views/Settings/SetDownloader/AddDialog.vue
+++ b/src/entries/options/views/Settings/SetDownloader/AddDialog.vue
@@ -69,6 +69,7 @@ async function saveStoredDownloaderConfig() {
           <v-toolbar-title>{{ t("SetDownloader.add.title") }}</v-toolbar-title>
           <v-spacer />
           <v-btn
+            :title="t('layout.header.wiki')"
             :href="`${REPO_URL}/wiki/config-download-client`"
             color="success"
             icon="mdi-help-circle"

--- a/src/entries/options/views/Settings/SetDownloader/EditDialog.vue
+++ b/src/entries/options/views/Settings/SetDownloader/EditDialog.vue
@@ -35,7 +35,7 @@ function editClientConfig() {
         <v-toolbar color="blue-grey-darken-2">
           <v-toolbar-title>{{ t("SetDownloader.edit.title") }}</v-toolbar-title>
           <template #append>
-            <v-btn icon="mdi-close" @click="showDialog = false" />
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
           </template>
         </v-toolbar>
       </v-card-title>

--- a/src/entries/options/views/Settings/SetDownloader/Index.vue
+++ b/src/entries/options/views/Settings/SetDownloader/Index.vue
@@ -228,8 +228,7 @@ async function confirmDeleteDownloader(downloaderId: TDownloaderKey) {
 
       <template #item.action="{ item }">
         <v-btn-group class="table-action" density="compact" variant="plain">
-          <!-- TODO 查看该下载服务器现状 -->
-          <v-btn :disabled="true" icon="mdi-information-outline" size="small" />
+          <v-btn :disabled="true" :title="t('SetDownloader.index.table.action.status')" icon="mdi-information-outline" size="small" />
 
           <v-btn
             :title="t('common.edit')"

--- a/src/entries/options/views/Settings/SetDownloader/PathAndTagSuggestDialog.vue
+++ b/src/entries/options/views/Settings/SetDownloader/PathAndTagSuggestDialog.vue
@@ -115,7 +115,7 @@ function saveClientConfig() {
           color="blue-grey-darken-2"
         >
           <template #append>
-            <v-btn icon="mdi-close" @click="showDialog = false" />
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
           </template>
         </v-toolbar>
       </v-card-title>
@@ -151,7 +151,13 @@ function saveClientConfig() {
                       variant="text"
                       @click="loadClientFolders"
                     />
-                    <v-btn color="red" icon="$clear" variant="text" @click="suggestFolderInput = ''" />
+                    <v-btn
+                      :title="t('SetDownloader.PathAndTag.downloadPath.clear')"
+                      color="red"
+                      icon="$clear"
+                      variant="text"
+                      @click="suggestFolderInput = ''"
+                    />
                   </div>
                 </template>
                 <template #details>
@@ -191,7 +197,13 @@ function saveClientConfig() {
                       variant="text"
                       @click="loadClientLabels"
                     />
-                    <v-btn color="red" icon="$clear" variant="text" @click="suggestTagInput = ''" />
+                    <v-btn
+                      :title="t('SetDownloader.PathAndTag.tags.clear')"
+                      color="red"
+                      icon="$clear"
+                      variant="text"
+                      @click="suggestTagInput = ''"
+                    />
                   </div>
                 </template>
                 <template #details>

--- a/src/entries/options/views/Settings/SetMediaServer/AddDialog.vue
+++ b/src/entries/options/views/Settings/SetMediaServer/AddDialog.vue
@@ -71,7 +71,7 @@ async function saveStoredMediaServerConfig() {
         <v-toolbar color="blue-grey-darken-2">
           <v-toolbar-title>添加媒体服务器</v-toolbar-title>
           <template #append>
-            <v-btn icon="mdi-close" @click="showDialog = false" />
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
           </template>
         </v-toolbar>
       </v-card-title>

--- a/src/entries/options/views/Settings/SetMediaServer/EditDialog.vue
+++ b/src/entries/options/views/Settings/SetMediaServer/EditDialog.vue
@@ -35,7 +35,7 @@ function editClientConfig() {
         <v-toolbar color="blue-grey-darken-2">
           <v-toolbar-title>{{ t("SetDownloader.edit.title") }}</v-toolbar-title>
           <template #append>
-            <v-btn icon="mdi-close" @click="showDialog = false" />
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
           </template>
         </v-toolbar>
       </v-card-title>

--- a/src/entries/options/views/Settings/SetSearchSolution/CustomSolutionDialog.vue
+++ b/src/entries/options/views/Settings/SetSearchSolution/CustomSolutionDialog.vue
@@ -93,7 +93,7 @@ function doSubmit() {
         <v-toolbar color="primary">
           <v-toolbar-title> 自定义搜索方案 [<SiteName :site-id="siteId" tag="span" class="" />] </v-toolbar-title>
           <template #append>
-            <v-btn icon="mdi-close" @click="showDialog = false" />
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
           </template>
         </v-toolbar>
       </v-card-title>

--- a/src/entries/options/views/Settings/SetSearchSolution/EditDialog.vue
+++ b/src/entries/options/views/Settings/SetSearchSolution/EditDialog.vue
@@ -120,7 +120,7 @@ function dialogLeave() {
       <v-card-title class="pa-0">
         <v-toolbar :title="t('SetSearchSolution.edit.title')" color="blue-grey-darken-2">
           <template #append>
-            <v-btn icon="mdi-close" @click="showDialog = false" />
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
           </template>
         </v-toolbar>
       </v-card-title>

--- a/src/entries/options/views/Settings/SetSearchSolution/SiteCategoryPanel.vue
+++ b/src/entries/options/views/Settings/SetSearchSolution/SiteCategoryPanel.vue
@@ -159,10 +159,17 @@ onMounted(async () => {
       </v-col>
       <v-col align-self="center">
         <v-row justify="end">
-          <v-btn color="red" icon="mdi-cached" variant="text" @click="() => resetSelectCategory()" />
+          <v-btn
+            :title="t('SetSearchSolution.spDialog.action.resetSelected')"
+            color="red"
+            icon="mdi-cached"
+            variant="text"
+            @click="() => resetSelectCategory()"
+          />
         </v-row>
         <v-row justify="end">
           <v-btn
+            :title="t('SetSearchSolution.spDialog.action.addCustom')"
             color="indigo"
             icon="mdi-pencil-plus"
             variant="text"
@@ -170,7 +177,13 @@ onMounted(async () => {
           ></v-btn>
         </v-row>
         <v-row justify="end">
-          <v-btn color="blue" icon="mdi-arrow-right-bold" variant="text" @click="() => generateSolution()" />
+          <v-btn
+            :title="t('SetSearchSolution.spDialog.action.saveSelected')"
+            color="blue"
+            icon="mdi-arrow-right-bold"
+            variant="text"
+            @click="() => generateSolution()"
+          />
         </v-row>
       </v-col>
     </v-row>

--- a/src/entries/options/views/Settings/SetSite/AddDialog.vue
+++ b/src/entries/options/views/Settings/SetSite/AddDialog.vue
@@ -55,6 +55,7 @@ async function saveSite() {
           <v-toolbar-title>{{ t("SetSite.add.title") }}</v-toolbar-title>
           <v-spacer />
           <v-btn
+            :title="t('layout.header.wiki')"
             :href="`${REPO_URL}/wiki/config-site`"
             color="success"
             icon="mdi-help-circle"

--- a/src/entries/options/views/Settings/SetSite/EditDialog.vue
+++ b/src/entries/options/views/Settings/SetSite/EditDialog.vue
@@ -41,7 +41,7 @@ function dialogEnter() {
         <v-toolbar color="blue-grey-darken-2">
           <v-toolbar-title>{{ t("SetSite.edit.title") }}</v-toolbar-title>
           <template #append>
-            <v-btn icon="mdi-close" @click="showDialog = false" />
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
           </template>
         </v-toolbar>
       </v-card-title>

--- a/src/entries/options/views/Settings/SetSite/Editor.vue
+++ b/src/entries/options/views/Settings/SetSite/Editor.vue
@@ -159,6 +159,7 @@ const timeZone: Array<{ value: timezoneOffset; title: string }> = [
                 {{ url }}
                 <v-spacer />
                 <v-btn
+                  :title="t('SetSite.common.open')"
                   :href="url"
                   color="info"
                   icon="mdi-arrow-top-right-bold-box-outline"

--- a/src/entries/options/views/Settings/SetSite/Index.vue
+++ b/src/entries/options/views/Settings/SetSite/Index.vue
@@ -305,7 +305,12 @@ async function flushSiteFavicon(siteId: TSiteID | TSiteID[]) {
           />
 
           <!-- 默认站点搜索入口编辑（只有配置了 siteMetadata.searchEntry 的站点才支持该设置） -->
-          <v-btn :disabled="item.metadata.isDead || !item.metadata.searchEntry" class="v-btn--icon" size="small">
+          <v-btn
+            :title="('SetSite.index.table.searchEntries')"
+            :disabled="item.metadata.isDead || !item.metadata.searchEntry"
+            class="v-btn--icon"
+            size="small"
+          >
             <v-icon icon="mdi-magnify"></v-icon>
             <v-menu :close-on-content-click="false" activator="parent">
               <EditSearchEntryList :item="item" />

--- a/src/entries/options/views/Settings/SetSite/OneClickImportDialog.vue
+++ b/src/entries/options/views/Settings/SetSite/OneClickImportDialog.vue
@@ -154,7 +154,12 @@ async function dialogEnter() {
         <v-toolbar color="blue-grey-darken-2">
           <v-toolbar-title>{{ t("SetSite.oneClickImportDialog.title") }}</v-toolbar-title>
           <template #append>
-            <v-btn icon="mdi-close" @click="showDialog = false" :disabled="importStatus.isWorking" />
+            <v-btn
+              icon="mdi-close"
+              :title="t('common.dialog.close')"
+              @click="showDialog = false"
+              :disabled="importStatus.isWorking"
+            />
           </template>
         </v-toolbar>
       </v-card-title>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -30,7 +30,8 @@
       "title": {
         "confirmAction": "Confirm Action"
       },
-      "deleteText": "Are you sure to delete these {0} item?"
+      "deleteText": "Are you sure to delete these {0} item?",
+      "close": "Close"
     },
     "edit": "Edit",
     "language": "Language",
@@ -59,7 +60,8 @@
       },
       "searchTip": "Input keyword, IMDb numbers to search",
       "wiki": "Wiki",
-      "wrongPixelRatioNotice": "Your page display may be affected by zooming. It is recommended to zoom at 100% to ensure your browsing experience~"
+      "wrongPixelRatioNotice": "Your page display may be affected by zooming. It is recommended to zoom at 100% to ensure your browsing experience~",
+      "expand": "Expand More"
     },
     "init": "Please wait patiently for the page to load....."
   },
@@ -166,6 +168,11 @@
     "needLogin": "Login Required!",
     "noResults": "No Results!",
     "unknown": "Unknown Status!"
+  },
+  "Logger": {
+    "action": {
+      "details": "Details"
+    }
   },
   "SpecialThank": {
     "contributor": "Contributors",
@@ -344,7 +351,8 @@
         "cancel": "Cancel current waiting search",
         "retry": "Retry Search",
         "retryFailed": "Retry the failed search plans (such as @:resultParseStatus.unknownError, @:resultParseStatus.parseError, @:resultParseStatus.CFBlocked, @:resultParseStatus.needLogin)",
-        "saveSnapshot": "Save Search Snapshot"
+        "saveSnapshot": "Save Search Snapshot",
+        "displayPreferences": "Search Results Display Preferences"
       },
       "filterLabel": "Filter search results",
       "selectedTorrents": "Selected {0} torrents",
@@ -379,7 +387,9 @@
         "noEmptyKeywords": "Empty keywords not supported",
         "noNonLatin": "Non-Latin characters not supported",
         "noAdvanceParams": "Advance parameter not supported"
-      }
+      },
+      "moveUp": "Move Up in the Queue",
+      "searchAgain": "Search Again"
     }
   },
   "SearchResultSnapshot": {
@@ -496,6 +506,7 @@
         "enabled": "Enabled ?",
         "autodl": "Auto DL ?",
         "action": {
+          "status": "Status",
           "setPathAndTag": "Set Suggest Download Path and Tags",
           "deleteDownloader": "Delete this downloader server",
           "setDefault": "Set this downloader server as Default Downloader."
@@ -510,14 +521,16 @@
         "addTitle": "Added @:SetDownloader.PathAndTag.downloadPath.title @:SetDownloader.PathAndTag.supportDragNote",
         "addInputLabel": "Added @:SetDownloader.PathAndTag.downloadPath.title",
         "autoImport": "One-click to import of existing @:SetDownloader.PathAndTag.downloadPath.title from the downloader",
-        "autoImportFail": "@:SetDownloader.PathAndTag.downloadPath.autoImport failed, please add manually."
+        "autoImportFail": "@:SetDownloader.PathAndTag.downloadPath.autoImport failed, please add manually.",
+        "clear": "Clear @:SetDownloader.PathAndTag.downloadPath.title"
       },
       "tags": {
         "title": "Tags",
         "addTitle": "Added @:SetDownloader.PathAndTag.tags.title @:SetDownloader.PathAndTag.supportDragNote",
         "addInputLabel": "Added @:SetDownloader.PathAndTag.tags.title",
         "autoImport": "One-click to import of existing @:SetDownloader.PathAndTag.tags.title from the downloader",
-        "autoImportFail": "@:SetDownloader.PathAndTag.tags.autoImport failed, please add manually."
+        "autoImportFail": "@:SetDownloader.PathAndTag.tags.autoImport failed, please add manually.",
+        "clear": "Clear @:SetDownloader.PathAndTag.tags.title"
       },
       "note": {
         "title": "Note",
@@ -564,7 +577,12 @@
       "noDefNotice": "This site does not define any search categories, please go to help!",
       "notice": "It is not recommended to set it here, and it is recommended to configure your user CP in site or use search solution",
       "selectAllNotice": "(Notice: In most cases, you don't need to select all search terms! )",
-      "title": "Set default search params for Site {name}"
+      "title": "Set default search params for Site {name}",
+      "action": {
+        "resetSelected": "Reset this @:SetSearchSolution.title",
+        "addCustom": "Add a custom @:SetSearchSolution.title and save it",
+        "saveSelected": "Save this @:SetSearchSolution.title"
+      }
     }
   },
   "SetSite": {
@@ -583,7 +601,8 @@
       "type": "Type",
       "url": "URL",
       "groups": "Site Groups",
-      "allowContentScript": "Load Content Script"
+      "allowContentScript": "Load Content Script",
+      "open": "Open"
     },
     "delete": {
       "text": "Are you sure to delete these {0} Site?"
@@ -604,6 +623,7 @@
     "index": {
       "flushFaviconFinish": "The selected site favicon has been refreshed successfully!",
       "table": {
+        "searchEntries": "Search Entries",
         "flushFavicon": "Refresh Site Favicon"
       },
       "settingNote": [
@@ -634,7 +654,11 @@
       "backupFields": "Backup Content",
       "lastBackupAt": "Last Backup Time",
       "notBackup": "Not Backed Up",
-      "enabled": "Enabled"
+      "enabled": "Enabled",
+      "action": {
+        "backupNow": "Backup Now",
+        "viewHistoryBackup": "View History Backups"
+      }
     },
     "localExport": "Local Export",
     "localImport": "Local Import",
@@ -655,7 +679,8 @@
       "times": "times, with an interval of",
       "minutes": "minutes.",
       "lastFlushTime": "Last refresh time:",
-      "nextFlushTime": "Next refresh check time:"
+      "nextFlushTime": "Next refresh check time:",
+      "getNextFlushTime": "Get Next Refresh Check Time"
     },
     "alwaysPickLastUserInfo": "",
     "showDeadSite": "Show sites marked as dead (isDead) in the overview",

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -30,7 +30,8 @@
       "title": {
         "confirmAction": "确认操作"
       },
-      "deleteText": "确认删除这 {0} 条记录吗？"
+      "deleteText": "确认删除这 {0} 条记录吗？",
+      "close": "关闭"
     },
     "edit": "编辑",
     "language": "语言",
@@ -59,7 +60,8 @@
       },
       "searchTip": "输入种子关键字、IMDb编号进行搜索",
       "wiki": "帮助",
-      "wrongPixelRatioNotice": "检测到您的页面展示可能受到缩放影响，建议您将当前页面缩放调整为100%，以保障您的浏览体验～"
+      "wrongPixelRatioNotice": "检测到您的页面展示可能受到缩放影响，建议您将当前页面缩放调整为100%，以保障您的浏览体验～",
+      "expand": "展开更多"
     },
     "init": "请耐心等待页面加载....."
   },
@@ -166,6 +168,11 @@
     "needLogin": "需要登录！",
     "noResults": "无结果！",
     "unknown": "未知状态！"
+  },
+  "Logger": {
+    "action": {
+      "details": "详细信息"
+    }
   },
   "SpecialThank": {
     "contributor": "协作者",
@@ -344,7 +351,8 @@
         "cancel": "取消当前等待的搜索",
         "retry": "重新搜索",
         "retryFailed": "重新搜索失败的方案（如 @:resultParseStatus.unknownError , @:resultParseStatus.parseError , @:resultParseStatus.CFBlocked , @:resultParseStatus.needLogin ）",
-        "saveSnapshot": "保存搜索快照"
+        "saveSnapshot": "保存搜索快照",
+        "displayPreferences": "搜索结果展示偏好"
       },
       "filterLabel": "过滤搜索结果",
       "selectedTorrents": "已选择 {0} 个种子",
@@ -379,7 +387,9 @@
         "noEmptyKeywords": "不支持空关键词",
         "noNonLatin": "不支持非拉丁字符",
         "noAdvanceParams": "不支持高级搜索参数"
-      }
+      },
+      "moveUp": "在队列中上移",
+      "searchAgain": "重新搜索"
     }
   },
   "SearchResultSnapshot": {
@@ -496,6 +506,7 @@
         "enabled": "启用？",
         "autodl": "自动下载？",
         "action": {
+          "status": "状态",
           "setPathAndTag": "设置预设的下载路径和标签",
           "deleteDownloader": "删除该下载服务器",
           "setDefault": "设置为默认下载服务器"
@@ -510,14 +521,16 @@
         "addTitle": "已添加的@:SetDownloader.PathAndTag.downloadPath.title@:SetDownloader.PathAndTag.supportDragNote",
         "addInputLabel": "添加@:SetDownloader.PathAndTag.downloadPath.title",
         "autoImport": "一键导入下载器中已有的@:SetDownloader.PathAndTag.downloadPath.title",
-        "autoImportFail": "@:SetDownloader.PathAndTag.downloadPath.autoImport 失败，请手动添加。"
+        "autoImportFail": "@:SetDownloader.PathAndTag.downloadPath.autoImport 失败，请手动添加。",
+        "clear": "清空@:SetDownloader.PathAndTag.downloadPath.title"
       },
       "tags": {
         "title": "标签",
         "addTitle": "已添加的@:SetDownloader.PathAndTag.tags.title@:SetDownloader.PathAndTag.supportDragNote",
         "addInputLabel": "添加@:SetDownloader.PathAndTag.tags.title",
         "autoImport": "一键导入下载器中已有的@:SetDownloader.PathAndTag.tags.title",
-        "autoImportFail": "@:SetDownloader.PathAndTag.tags.autoImport 失败，请手动添加。"
+        "autoImportFail": "@:SetDownloader.PathAndTag.tags.autoImport 失败，请手动添加。",
+        "clear": "清空@:SetDownloader.PathAndTag.tags.title"
       },
       "note": {
         "title": "说明",
@@ -565,7 +578,12 @@
       "noDefNotice": "该站点未定义搜索模块，请到项目仓库提供帮助！",
       "notice": "不推荐在此处进行设置，更建议在对应站点的个人设置中配置或使用插件提供的搜索方案功能！",
       "selectAllNotice": "（注意：在大多数情况下，你并不需要全选所有搜索项！）",
-      "title": "配置站点默认搜索模式 - {name}"
+      "title": "配置站点默认搜索模式 - {name}",
+      "action": {
+        "resetSelected": "重置此@:SetSearchSolution.title",
+        "addCustom": "添加并保存自定义@:SetSearchSolution.title",
+        "saveSelected": "保存此@:SetSearchSolution.title"
+      }
     }
   },
   "SetSite": {
@@ -584,7 +602,8 @@
       "type": "类型",
       "url": "网站链接",
       "groups": "站点分类",
-      "allowContentScript": "加载侧边栏"
+      "allowContentScript": "加载侧边栏",
+      "open": "打开"
     },
     "delete": {
       "text": "确认删除这 {0} 个站点吗？"
@@ -605,6 +624,7 @@
     "index": {
       "flushFaviconFinish": "所选站点的图标已成功刷新！",
       "table": {
+        "searchEntries": "搜索入口",
         "flushFavicon": "刷新站点图标"
       },
       "settingNote": ["只有配置过的站点才会显示插件图标及相应的功能；", "已离线的站点不再参与搜索和信息获取；"],
@@ -632,7 +652,11 @@
       "backupFields": "备份内容",
       "lastBackupAt": "最近一次备份时间",
       "notBackup": "未备份",
-      "enabled": "启用"
+      "enabled": "启用",
+      "action": {
+        "backupNow": "立即备份",
+        "viewHistoryBackup": "查看历史备份"
+      }
     },
     "localExport": "本地导出",
     "localImport": "本地导入",
@@ -653,7 +677,8 @@
       "times": "次，每次间隔",
       "minutes": "分钟。",
       "lastFlushTime": "最近一次刷新时间:",
-      "nextFlushTime": "下一次检查时间:"
+      "nextFlushTime": "下一次检查时间:",
+      "getNextFlushTime": "获取下一次检查时间"
     },
     "alwaysPickLastUserInfo": "刷新用户数据时尽可能使用已有的历史信息",
     "showDeadSite": "在概览中展示已被标记为死亡 （isDead） 的站点",


### PR DESCRIPTION
有些 V-Btn 缺少 title 属性，同时标签内部也没有文本内容，仅有图标表示按钮的含义，有些不便。因此，添加 title 属性方便使用者知晓按钮含义。
大部分修改采用了 i18n。有部分组件内其他 V-Btn 未采用 i18n 的，修改过的 V-Btn 也未使用 i18n。

## Summary by Sourcery

Add descriptive title attributes to icon-only buttons across dialogs, toolbars, and tables to improve usability and accessibility.

Enhancements:
- Use i18n-based titles for many icon-only V-Btn components so users can understand button purpose via tooltips.
- Standardize dialog close buttons to share a common localized title text.
- Improve clarity of various action buttons (search, reset, save, download, history, more options, details, re-download, open link, etc.) by adding contextual titles.