### PR TITLE
feat(pkg/site) 支持获取部分 NexusPHP 站点 "download.php?downhash=" 格式的下载链接

### DIFF
--- a/src/packages/site/schemas/NexusPHP.ts
+++ b/src/packages/site/schemas/NexusPHP.ts
@@ -314,7 +314,8 @@ export const SchemaMetadata: Pick<
         selector: [
           'a[href*="download.php?id="][href*="&downhash="]',
           'a[href*="download.php?id="][href*="&passkey="]',
-          // 如果上面两个都没拿到，则尝试使用nphp默认的下载链接selector
+          'a[href*="download.php?downhash="]',
+          // 如果上面三个都没拿到，则尝试使用nphp默认的下载链接selector
           'a[href*="download.php?id="]',
         ],
         attr: "href",


### PR DESCRIPTION
部分 NexusPHP 站点，如 UBits, SoulVoice, PTSBao, HDTime, DiscFan 等，下载链接格式为 download.php?downhash= ，在 NexusPHP 的 `SchemaMetadata.detail.selectors.link.selector` 增加一个选择器 `a[href*="download.php?downhash="]` ，以适配这些站点

## Summary by Sourcery

New Features:
- Add support for NexusPHP sites that expose torrent downloads via `download.php?downhash=` URLs in link selection metadata.