### PR TITLE
修复 #899 引入的代码错误

### DIFF
--- a/src/entries/options/views/Overview/SearchEntity/Index.vue
+++ b/src/entries/options/views/Overview/SearchEntity/Index.vue
@@ -286,7 +286,7 @@ function cancelSearchQueue() {
         <v-menu>
           <template v-slot:activator="{ props }">
             <v-btn-group size="small" variant="text">
-              <v-btn :title= "t('SearchEntity.index.action.displayPreferences')"color="blue" icon="mdi-cog" v-bind="props" />
+              <v-btn :title="t('SearchEntity.index.action.displayPreferences')" color="blue" icon="mdi-cog" v-bind="props" />
             </v-btn-group>
           </template>
           <v-list>

--- a/src/entries/options/views/Settings/SetSite/Index.vue
+++ b/src/entries/options/views/Settings/SetSite/Index.vue
@@ -306,7 +306,7 @@ async function flushSiteFavicon(siteId: TSiteID | TSiteID[]) {
 
           <!-- 默认站点搜索入口编辑（只有配置了 siteMetadata.searchEntry 的站点才支持该设置） -->
           <v-btn
-            :title="('SetSite.index.table.searchEntries')"
+            :title="t('SetSite.index.table.searchEntries')"
             :disabled="item.metadata.isDead || !item.metadata.searchEntry"
             class="v-btn--icon"
             size="small"


### PR DESCRIPTION
#899中，src/entries/options/views/Overview/SearchEntity/Index.vue 空格错位，src/entries/options/views/Settings/SetSite/Index.vue 缺少了`t()`

## Summary by Sourcery

Fix title bindings and spacing issues in options views.

Bug Fixes:
- Correct the spacing and attribute formatting for the SearchEntity display preferences button.
- Fix the SetSite search entries button title to use the localization helper instead of a raw string.