### PR TITLE
fix: 修复#899引入的错误：未导入useI18n就使用了 t()

### DIFF
--- a/src/entries/content-script/app/components/AdvanceListModuleDialog.vue
+++ b/src/entries/content-script/app/components/AdvanceListModuleDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, inject } from "vue";
+import { useI18n } from "vue-i18n";
 import { useWindowSize } from "@vueuse/core";
 import { ETorrentStatus, ITorrent } from "@ptd/site";
 import type { DataTableHeader } from "vuetify/lib/components/VDataTable/types";
@@ -10,6 +11,8 @@ import { useRuntimeStore } from "@/options/stores/runtime.ts";
 
 import NavButton from "@/options/components/NavButton.vue";
 import TorrentTitleTd from "@/options/components/TorrentTitleTd.vue";
+
+const { t } = useI18n();
 
 const showDialog = defineModel<boolean>();
 

--- a/src/entries/content-script/app/components/SocialSiteParseResultsDialog.vue
+++ b/src/entries/content-script/app/components/SocialSiteParseResultsDialog.vue
@@ -2,6 +2,9 @@
 import { ISocialSitePageInformation } from "@ptd/social";
 import { doKeywordSearch, type IPtdData } from "../utils.ts";
 import { inject } from "vue";
+import { useI18n } from "vue-i18n";
+
+const { t } = useI18n();
 
 const showDialog = defineModel<boolean>();
 const { parseResults } = defineProps<{ parseResults: ISocialSitePageInformation[] }>();

--- a/src/entries/options/views/Overview/DownloadHistory/ReDownloadSelectDialog.vue
+++ b/src/entries/options/views/Overview/DownloadHistory/ReDownloadSelectDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, shallowRef } from "vue";
+import { useI18n } from "vue-i18n";
 import type { CAddTorrentOptions } from "@ptd/downloader";
 
 import { sendMessage } from "@/messages.ts";
@@ -7,6 +8,8 @@ import { useResetableRef } from "@/options/directives/useResetableRef.ts";
 import type { ITorrentDownloadMetadata } from "@/shared/types.ts";
 
 import SentToDownloaderDialog from "@/options/components/SentToDownloaderDialog.vue";
+
+const { t } = useI18n();
 
 const showDialog = defineModel<boolean>();
 const emit = defineEmits<{

--- a/src/entries/options/views/Overview/MediaServerEntity/ItemInformationDialog.vue
+++ b/src/entries/options/views/Overview/MediaServerEntity/ItemInformationDialog.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import { computed } from "vue";
+import { useI18n } from "vue-i18n";
 import { IMediaServerItem } from "@ptd/mediaServer";
 import { formatSize } from "@/options/utils.ts";
+
+const { t } = useI18n();
 
 const showDialog = defineModel<boolean>();
 const { item } = defineProps<{

--- a/src/entries/options/views/Overview/SearchEntity/SaveSnapshotDialog.vue
+++ b/src/entries/options/views/Overview/SearchEntity/SaveSnapshotDialog.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import { computed } from "vue";
+import { useI18n } from "vue-i18n";
 
 import { useMetadataStore } from "@/options/stores/metadata.ts";
 import { useRuntimeStore } from "@/options/stores/runtime.ts";
 import { formatDate } from "@/options/utils.ts";
+
+const { t } = useI18n();
 
 const showDialog = defineModel<boolean>();
 

--- a/src/entries/options/views/Overview/SearchResultSnapshot/EditNameDialog.vue
+++ b/src/entries/options/views/Overview/SearchResultSnapshot/EditNameDialog.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { ref } from "vue";
+import { useI18n } from "vue-i18n";
 
 import { useMetadataStore } from "@/options/stores/metadata.ts";
 import { type TSearchSnapshotKey } from "@/shared/types.ts";
+
+const { t } = useI18n();
 
 const showDialog = defineModel<boolean>();
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix runtime errors in several Vue dialog components by correctly importing and initializing useI18n before using t().