### PR TITLE
fix(i18n) 完善SetSearchSolution相关i18n内容

### DIFF
--- a/src/entries/options/views/Settings/SetSearchSolution/SiteCategoryPanel.vue
+++ b/src/entries/options/views/Settings/SetSearchSolution/SiteCategoryPanel.vue
@@ -160,7 +160,7 @@ onMounted(async () => {
       <v-col align-self="center">
         <v-row justify="end">
           <v-btn
-            :title="t('SetSearchSolution.spDialog.action.resetSelected')"
+            :title="t('SetSearchSolution.spDialog.action.reset')"
             color="red"
             icon="mdi-cached"
             variant="text"
@@ -169,7 +169,7 @@ onMounted(async () => {
         </v-row>
         <v-row justify="end">
           <v-btn
-            :title="t('SetSearchSolution.spDialog.action.addCustom')"
+            :title="t('SetSearchSolution.spDialog.action.create')"
             color="indigo"
             icon="mdi-pencil-plus"
             variant="text"
@@ -178,7 +178,7 @@ onMounted(async () => {
         </v-row>
         <v-row justify="end">
           <v-btn
-            :title="t('SetSearchSolution.spDialog.action.saveSelected')"
+            :title="t('SetSearchSolution.spDialog.action.add')"
             color="blue"
             icon="mdi-arrow-right-bold"
             variant="text"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -557,6 +557,7 @@
   },
   "SetSearchSolution": {
     "solution": "Search Solution",
+    "copy": "Duplicate",
     "import": "Import",
     "export": "Export",
     "table": {
@@ -579,9 +580,9 @@
       "selectAllNotice": "(Notice: In most cases, you don't need to select all search terms! )",
       "title": "Set default search params for Site {name}",
       "action": {
-        "resetSelected": "Reset this @:SetSearchSolution.title",
-        "addCustom": "Add a custom @:SetSearchSolution.title and save it",
-        "saveSelected": "Save this @:SetSearchSolution.title"
+        "reset": "Reset this @:SetSearchSolution.solution",
+        "create": "Create a custom @:SetSearchSolution.solution based on this",
+        "add": "Add this @:SetSearchSolution.solution"
       }
     }
   },

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -557,7 +557,7 @@
   },
   "SetSearchSolution": {
     "solution": "搜索方案",
-    "copy": "基于此搜索方案复制",
+    "copy": "创建副本",
     "import": "导入",
     "export": "导出",
     "table": {
@@ -580,9 +580,9 @@
       "selectAllNotice": "（注意：在大多数情况下，你并不需要全选所有搜索项！）",
       "title": "配置站点默认搜索模式 - {name}",
       "action": {
-        "resetSelected": "重置此@:SetSearchSolution.title",
-        "addCustom": "添加并保存自定义@:SetSearchSolution.title",
-        "saveSelected": "保存此@:SetSearchSolution.title"
+        "reset": "重置此@:SetSearchSolution.solution",
+        "create": "基于此创建自定义@:SetSearchSolution.solution",
+        "add": "添加此@:SetSearchSolution.solution"
       }
     }
   },


### PR DESCRIPTION
简化了`SetSearchSolution.spDialog.action`的字段名；
修改了`SetSearchSolution.spDialog.action`部分文本，更贴切相应功能描述；
修复了错误引用`SetSearchSolution.solution`为`SetSearchSolution.title`；
添加了en语言缺失的`SetSearchSolution.copy`字段；
更改zh-CN语言`SetSearchSolution.copy`文本，使其更简洁。

## Summary by Sourcery

Improve internationalization texts and key usage for SetSearchSolution and related dialog actions.

New Features:
- Add the missing SetSearchSolution.copy i18n entry for the English locale.

Bug Fixes:
- Correct the i18n key reference from SetSearchSolution.solution to SetSearchSolution.title.

Enhancements:
- Simplify and rename SetSearchSolution.spDialog.action i18n keys and associated button tooltips to better match their actions.