### PR TITLE
feat(pkg/site/alpharatio): 完善 AR 元数据

### DIFF
--- a/src/packages/site/definitions/alpharatio.ts
+++ b/src/packages/site/definitions/alpharatio.ts
@@ -1,14 +1,17 @@
 /**
  * @JackettDefinitions https://github.com/Jackett/Jackett/blob/master/src/Jackett.Common/Indexers/Definitions/AlphaRatio.cs
  */
-import type { ISiteMetadata } from "../types";
-import { SchemaMetadata } from "../schemas/GazelleJSONAPI";
+import type { ISiteMetadata, ITorrent, IUserInfo } from "../types";
+import GazelleJSONAPI, { SchemaMetadata, torrentBrowseResult } from "../schemas/GazelleJSONAPI";
+import { set, unset } from "es-toolkit/compat";
+import { toMerged } from "es-toolkit";
 
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,
   version: 1,
   id: "alpharatio",
   name: "AlphaRatio",
+  aka: ["AR"],
   description: "AlphaRatio (AR) is a Private Torrent Tracker for 0DAY / GENERAL",
   tags: ["综合", "0day"],
   timezoneOffset: "+0000",
@@ -63,7 +66,179 @@ export const siteMetadata: ISiteMetadata = {
   search: {
     ...SchemaMetadata.search!,
     advanceKeywordParams: {
-      imdb: false,
+      imdb: {
+        requestConfigTransformer: ({ keywords, requestConfig }) => {
+          if (keywords) {
+            unset(requestConfig!, SchemaMetadata.search!.keywordPath!);
+            set(requestConfig!, "params.taglist", keywords);
+          }
+          return requestConfig!;
+        },
+      },
     },
   },
+
+  userInfo: {
+    ...SchemaMetadata.userInfo!,
+    selectors: {
+      ...SchemaMetadata.userInfo!.selectors!,
+      donation: { selector: "li:contains('Donated:')", filters: [{ name: "parseNumber" }] },
+      seedingBonus: { selector: "li:contains('SeedBonus:')", filters: [{ name: "parseNumber" }] },
+    },
+  },
+
+  levelRequirements: [
+    {
+      id: 1,
+      name: "Mortal",
+    },
+    {
+      id: 2,
+      name: "Philosopher",
+      interval: "P4W",
+      uploaded: "80GB",
+      seedingBonus: 60000,
+      // 普通用户无法查看 H&R 信息
+      // hnrUnsatisfied: 0,
+      privilege: "Mortal privileges plus can invite users, upload torrents, and submit requests.",
+    },
+    {
+      id: 3,
+      name: "Gladiator",
+      interval: "P8W",
+      uploaded: "260GB",
+      seedingBonus: 120000,
+      // hnrUnsatisfied: 0,
+      privilege: "Philosopher privileges plus can use bookmarks and view top ten user/torrent stats.",
+    },
+    {
+      id: 4,
+      name: "Giant",
+      interval: "P12W",
+      uploaded: "600GB",
+      seedingBonus: 360000,
+      // hnrUnsatisfied: 0,
+      privilege: "Gladiator privileges plus can create polls in the forum.",
+    },
+    {
+      id: 5,
+      name: "Centaur",
+      interval: "P18W",
+      uploaded: "1.6TB",
+      seedingBonus: 720000,
+      // hnrUnsatisfied: 0,
+      privilege: "Giant privileges.",
+    },
+    {
+      id: 6,
+      name: "Sphinx",
+      interval: "P26W",
+      uploaded: "3.2TB",
+      seedingBonus: 1440000,
+      // hnrUnsatisfied: 0,
+      privilege: "Centaur privileges plus access to the Invite Forum.",
+    },
+    {
+      id: 7,
+      name: "Harpy",
+      interval: "P38W",
+      uploaded: "6TB",
+      seedingBonus: 1920000,
+      // hnrUnsatisfied: 0,
+      privilege: "Sphinx privileges.",
+    },
+    {
+      id: 8,
+      name: "Satyr",
+      interval: "P60W",
+      uploaded: "12TB",
+      seedingBonus: 2400000,
+      // hnrUnsatisfied: 0,
+      privilege: "Harpy privileges plus exemption from hit and runs and can see other users' active torrents.",
+    },
+    {
+      id: 9,
+      name: "Adonis",
+      interval: "P60W",
+      uploaded: "12TB",
+      seedingBonus: 2000000,
+      // hnrUnsatisfied: 0,
+      donation: 50,
+      privilege: "Harpy privileges plus exemption from hit and runs and can see other users' active torrents.",
+    },
+    {
+      id: 10,
+      name: "Cyclops",
+      interval: "P90W",
+      uploaded: "18TB",
+      seedingBonus: 4800000,
+      // hnrUnsatisfied: 0,
+      privilege: "Satyr privileges.",
+    },
+    {
+      id: 11,
+      name: "Chimera",
+      interval: "P90W",
+      uploaded: "18TB",
+      seedingBonus: 4000000,
+      // hnrUnsatisfied: 0,
+      donation: 200,
+      privilege: "Satyr privileges.",
+    },
+    {
+      id: 12,
+      name: "Deity",
+      groupType: "vip",
+      privilege:
+        "Given by Staff at their discretion. Same as Satyr privileges plus can send invites even when invites are closed.",
+    },
+    {
+      id: 13,
+      name: "Spartan",
+      groupType: "vip",
+      interval: "P120W",
+      uploaded: "10TB",
+      seedingBonus: 6200000,
+      // hnrUnsatisfied: 0,
+      donation: 400,
+      privilege: "Same as Deity privileges.",
+    },
+  ],
 };
+
+export default class AlphaRatio extends GazelleJSONAPI {
+  protected override async transformUnGroupTorrent(group: torrentBrowseResult): Promise<ITorrent> {
+    const torrent = await super.transformUnGroupTorrent(group);
+    torrent.tags?.push({ name: "H&R" });
+
+    const imdbRe = /tt\d+/;
+    const imdbId = group.tags.find((tag) => imdbRe.test(tag))?.match(imdbRe)?.[0];
+    if (imdbId) {
+      torrent.ext_imdb = imdbId;
+    }
+
+    return torrent;
+  }
+
+  protected override async getUserExtendInfo(userId: number): Promise<Partial<IUserInfo>> {
+    const flushUserInfo = await super.getUserExtendInfo(userId);
+
+    await this.sleepAction(this.metadata.userInfo?.requestDelay);
+
+    const { data: userPage } = await this.request<Document>({
+      url: "/user.php",
+      params: {
+        id: userId,
+      },
+      responseType: "document",
+    });
+
+    return toMerged(
+      flushUserInfo,
+      this.getFieldsData(userPage, this.metadata.userInfo!.selectors!, [
+        "donation",
+        "seedingBonus",
+      ] as (keyof Partial<IUserInfo>)[]) as Partial<IUserInfo>,
+    );
+  }
+}

--- a/src/packages/site/definitions/brokenstones.ts
+++ b/src/packages/site/definitions/brokenstones.ts
@@ -179,6 +179,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       id: 6,
       name: "VIP",
+      groupType: "vip",
       privilege: "Custom title & Unlimited Invites",
     },
   ],

--- a/src/packages/site/definitions/hdspace.ts
+++ b/src/packages/site/definitions/hdspace.ts
@@ -279,18 +279,21 @@ export const siteMetadata: ISiteMetadata = {
     {
       id: 6,
       name: "VIP",
+      groupType: "vip",
       nameAka: ["V.I.P."],
       privilege: "Same access like HD Astronaut, immune to automatic demotion, automated HnR warnings and ratio watch.",
     },
     {
       id: 7,
       name: "Uploader",
+      groupType: "manager",
       uploads: 20,
       privilege: "Access to HD Spacer and HD Astronaut extras. May upload and download any torrents.",
     },
     {
       id: 8,
       name: "Elite Uploader",
+      groupType: "manager",
       uploaded: "20TB",
       ratio: 7,
       uploads: 100,

--- a/src/packages/site/definitions/myanonamouse.ts
+++ b/src/packages/site/definitions/myanonamouse.ts
@@ -370,6 +370,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       id: 4,
       name: "VIP",
+      groupType: "vip",
       privilege: "Receive 4 requests per month; Can have 150 unsatisfied torrents at maximum",
     },
   ],

--- a/src/packages/site/definitions/oldtoonsworld.ts
+++ b/src/packages/site/definitions/oldtoonsworld.ts
@@ -222,6 +222,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       id: 9,
       name: "VIP",
+      groupType: "vip",
       privilege: "无限下载槽 直接发布种子 站免 双倍上传 免疫HR 发送邀请",
     },
   ],

--- a/src/packages/site/definitions/speedapp.ts
+++ b/src/packages/site/definitions/speedapp.ts
@@ -448,6 +448,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       id: 8,
       name: "VIP",
+      groupType: "vip",
       privilege: "Same privileges as Elite User, immune to automated HnR warnings.",
     },
   ],

--- a/src/packages/site/definitions/sportscult.ts
+++ b/src/packages/site/definitions/sportscult.ts
@@ -286,6 +286,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       id: 4,
       name: "VIP",
+      groupType: "vip",
       privilege:
         "Fancy star, No ratio requirements (as long as you are vip) + Access to: Online Users, Tracker info, Live TV, Requests, Top 10, and Users",
     },


### PR DESCRIPTION
## Summary by Sourcery

Enhance tracker metadata, user rank definitions, and user info extraction for AlphaRatio and annotate VIP/manager rank types across several other site definitions.

New Features:
- Add detailed rank and promotion requirements for AlphaRatio, including donation, seeding bonus, and special VIP ranks.
- Extract extended AlphaRatio torrent metadata (H&R tag and IMDb ID) and additional user fields (donation and seeding bonus).
- Support IMDb keyword searches on AlphaRatio by mapping search keywords to the site’s tag-based search parameter.

Enhancements:
- Introduce an AlphaRatio-specific GazelleJSONAPI subclass to customize torrent transformation and user info enrichment while reusing shared schema metadata.
- Add alias and group type metadata (e.g., VIP, manager) to rank definitions for multiple trackers to better categorize user classes.