### PR TITLE
fix(pkg/site): 更新一些站点的高级搜索信息

### DIFF
--- a/src/packages/site/definitions/desigaane.ts
+++ b/src/packages/site/definitions/desigaane.ts
@@ -18,6 +18,13 @@ export const siteMetadata: ISiteMetadata = {
 
   urls: ["https://desigaane.rocks/"],
 
+  search: {
+    ...SchemaMetadata.search!,
+    advanceKeywordParams: {
+      imdb: false,
+    },
+  },
+
   levelRequirements: [
     {
       id: 1,

--- a/src/packages/site/definitions/orpheus.ts
+++ b/src/packages/site/definitions/orpheus.ts
@@ -58,6 +58,13 @@ export const siteMetadata: ISiteMetadata = {
     },
   ],
 
+  search: {
+    ...SchemaMetadata.search!,
+    advanceKeywordParams: {
+      imdb: false,
+    },
+  },
+
   userInfo: {
     ...SchemaMetadata.userInfo!,
     selectors: {

--- a/src/packages/site/definitions/redacted.ts
+++ b/src/packages/site/definitions/redacted.ts
@@ -63,6 +63,13 @@ export const siteMetadata: ISiteMetadata = {
     },
   ],
 
+  search: {
+    ...SchemaMetadata.search!,
+    advanceKeywordParams: {
+      imdb: false,
+    },
+  },
+
   userInfo: {
     ...SchemaMetadata.userInfo!,
     selectors: {

--- a/src/packages/site/definitions/secretcinema.ts
+++ b/src/packages/site/definitions/secretcinema.ts
@@ -15,8 +15,9 @@ import GazelleJSONAPI, {
   browseJsonResponse,
 } from "../schemas/GazelleJSONAPI";
 import BittorrentSite from "../schemas/AbstractBittorrentSite";
+import { unset, set } from "es-toolkit/compat";
 
-const movieCats = ["SD", "720p", "1080p", "4k", "DVD-R", "BDMV"];
+const movieCats = ["SD", "720p", "1080p", "2160p", "4k", "DVD-R", "BDMV"];
 const musicCats = ["CD", "DVD", "WEB", "Vinyl"];
 
 const mediaCategorySets = {
@@ -57,6 +58,21 @@ export const siteMetadata: ISiteMetadata = {
       options: buildCategoryOptionsFromList([movieCats, musicCats]),
     },
   ],
+
+  search: {
+    ...SchemaMetadata.search!,
+    advanceKeywordParams: {
+      imdb: {
+        requestConfigTransformer: ({ keywords, requestConfig }) => {
+          if (keywords) {
+            unset(requestConfig!, SchemaMetadata.search!.keywordPath!);
+            set(requestConfig!, "params.cataloguenumber", keywords);
+          }
+          return requestConfig!;
+        },
+      },
+    },
+  },
 
   list: [
     {

--- a/src/packages/site/definitions/sugoimusic.ts
+++ b/src/packages/site/definitions/sugoimusic.ts
@@ -19,6 +19,13 @@ export const siteMetadata: ISiteMetadata = {
 
   urls: ["https://sugoimusic.me/"],
 
+  search: {
+    ...SchemaMetadata.search!,
+    advanceKeywordParams: {
+      imdb: false,
+    },
+  },
+
   levelRequirements: [
     {
       id: 1,


### PR DESCRIPTION
## Summary by Sourcery

Update advanced search configuration for several torrent sites and adjust movie category definitions.

New Features:
- Add per-site advanced search configuration for SecretCinema, mapping IMDb keyword searches to a catalogue number parameter.
- Enable explicit advanced search configuration stubs for DesiGaane, Orpheus, Redacted, and SugoiMusic with IMDb search disabled.

Enhancements:
- Extend SecretCinema movie category list to distinguish 2160p resolutions separately from 4K.