### PR TITLE
fix(pkg/site/digitalcore): DCC 下载链接未添加 passkey

### DIFF
--- a/src/packages/site/definitions/milkie.ts
+++ b/src/packages/site/definitions/milkie.ts
@@ -137,7 +137,7 @@ export default class Milkie extends PrivateSite {
     return super.request<T>(axiosConfig, checkLogin);
   }
 
-  protected parseTorrentRowForLink(torrent: Partial<ITorrent>, row: object | any): Partial<ITorrent> {
+  protected parseTorrentRowForLink(torrent: Partial<ITorrent>, row: { id: number }): Partial<ITorrent> {
     torrent.link = `/api/v1/torrents/${row.id}/torrent?key=${encodeURIComponent(this.userConfig.inputSetting!.token)}`;
     return torrent;
   }


### PR DESCRIPTION
## Summary by Sourcery

Fix DigitalCore torrent download links to include user-specific passkeys and align torrent link parsing types with Milkie.

Bug Fixes:
- Ensure DigitalCore torrent download links include the required passkey fetched from the site status API.
- Correct the DigitalCore implementation to derive torrent download links dynamically instead of using static metadata mappings.
- Tighten the Milkie torrent row link parser to use a typed row object with an explicit id field.

Enhancements:
- Extract and reuse a shared status request configuration for DigitalCore across user-related requests.