### PR TITLE
fix(pkg/site): 更新一些选择器信息

### DIFF
--- a/src/packages/site/definitions/anthelion.ts
+++ b/src/packages/site/definitions/anthelion.ts
@@ -268,17 +268,6 @@ export const siteMetadata: ISiteMetadata = {
     ],
     selectors: {
       ...SchemaMetadata!.userInfo!.selectors!,
-      id: { selector: "#nav_user a.username", attr: "href", filters: [{ name: "querystring", args: ["id"] }] },
-      name: { selector: "#nav_user a.username" },
-      messageCount: {
-        selector: "span.noty-notification",
-        filters: [
-          (query: string) => {
-            const match = query.match(/have (\d+|a) new/);
-            return match && match.length > 1 ? (match[1] == "a" ? 1 : parseInt(match[1])) : 0;
-          },
-        ],
-      },
       bonusPerHour: {
         selector: "h3.float_right",
         filters: [
@@ -288,10 +277,7 @@ export const siteMetadata: ISiteMetadata = {
           },
         ],
       },
-      uploaded: { selector: "li.tooltip:contains('Uploaded: ')", filters: [{ name: "parseSize" }] },
-      downloaded: { selector: "li.tooltip:contains('Downloaded: ')", filters: [{ name: "parseSize" }] },
       adoptions: { selector: "li:contains('Adopted: ') span" },
-      ratio: { selector: "li:contains('Ratio: ') span.tooltip", attr: "title", filters: [{ name: "parseNumber" }] },
       joinTime: {
         selector: "ul.stats li:contains('Joined:') span",
         attr: "title",

--- a/src/packages/site/definitions/cgpeers.ts
+++ b/src/packages/site/definitions/cgpeers.ts
@@ -52,7 +52,6 @@ export const siteMetadata: ISiteMetadata = {
     },
     selectors: {
       ...SchemaMetadata.search!.selectors,
-      rows: { selector: "table#torrent_table > tbody > tr:has(a[href*='action=download'])" },
       category: {
         selector: "td.cats_col > div[title] > a",
         attr: "href",
@@ -64,11 +63,7 @@ export const siteMetadata: ISiteMetadata = {
           },
         ],
       },
-      size: { selector: ["td:nth-child(7)"], filters: [{ name: "parseSize" }] },
-      author: undefined,
-      seeders: { selector: ["td:nth-child(9)"], filters: [{ name: "parseNumber" }] },
-      leechers: { selector: ["td:nth-child(10)"], filters: [{ name: "parseNumber" }] },
-      completed: { selector: ["td:nth-child(8)"], filters: [{ name: "parseNumber" }] },
+      author: { text: "N/A" },
       status: {
         selector: ["a[href*='torrents.php?action=download'] > i"],
         text: ETorrentStatus.unknown,
@@ -104,9 +99,9 @@ export const siteMetadata: ISiteMetadata = {
     ...SchemaMetadata.userInfo!,
     selectors: {
       ...SchemaMetadata.userInfo!.selectors,
-      name: { selector: ["a.username-link"] },
+      name: { selector: ["a#userDropdownTrigger"] },
       id: {
-        selector: ["a.username-link"],
+        selector: ["a[href^='/user.php?id=']"],
         attr: "href",
         filters: [{ name: "querystring", args: ["id"] }],
       },

--- a/src/packages/site/definitions/filelist.ts
+++ b/src/packages/site/definitions/filelist.ts
@@ -276,6 +276,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       id: 4,
       name: "VIP",
+      groupType: "vip",
       privilege:
         "This class always has a minimum ratio equal to 2, regardless of the downloads made, and is exempt from hit&run rules. They can set their own Custom Title.",
     },

--- a/src/packages/site/definitions/jpopsuki.ts
+++ b/src/packages/site/definitions/jpopsuki.ts
@@ -169,15 +169,6 @@ export const siteMetadata: ISiteMetadata = {
         attr: "title",
         filters: [{ name: "parseTime", args: ["MMMM dd yyyy, HH:mm"] }],
       },
-      messageCount: {
-        selector: ["#alerts > .alertbar > a[href='notice.php']", "div.alertbar > a[href*='inbox.php']"],
-        filters: [
-          (query: string) => {
-            const queryMatch = query.match(/(\d+)/);
-            return queryMatch && queryMatch.length >= 2 ? parseInt(queryMatch[1]) : 0;
-          },
-        ],
-      },
       uploads: {
         selector: genUserInfoSelector("community", "uploaded"),
         filters: [{ name: "parseNumber" }],

--- a/src/packages/site/definitions/lst.ts
+++ b/src/packages/site/definitions/lst.ts
@@ -103,10 +103,7 @@ export const siteMetadata: ISiteMetadata = {
     skipNonLatinCharacters: true,
     selectors: {
       ...SchemaMetadata.search!.selectors,
-      category: {
-        selector: "span.torrent-search--list__uploader > div:nth-child(1)",
-        filters: [{ name: "trim" }],
-      },
+      category: { selector: "span.torrent-search--list__uploader > div:nth-child(1)" },
       tags: [
         {
           name: "Free",

--- a/src/packages/site/definitions/nebulance.ts
+++ b/src/packages/site/definitions/nebulance.ts
@@ -90,14 +90,6 @@ export const siteMetadata: ISiteMetadata = {
           return "Other";
         },
       },
-      time: {
-        selector: "span.time[title]",
-        attr: "title",
-        filters: [{ name: "parseTime", args: ["MMM d yyyy, HH:mm"] }],
-      },
-      seeders: { selector: "> td:nth-child(6)" },
-      leechers: { selector: "> td:nth-child(7)" },
-      completed: { selector: "> td:nth-child(5)" },
       progress: {
         selector: ".Seeding",
         filters: [(query: any) => (query ? 100 : 0)],
@@ -136,6 +128,19 @@ export const siteMetadata: ISiteMetadata = {
     {
       urlPattern: ["/torrents.php"],
       excludeUrlPattern: [/\/torrents\.php\?(?:.*&)?(id|torrentid|showid)=\d+/],
+      selectors: {
+        time: {
+          selector: "span.time",
+          filters: [
+            { name: "parseTTL" },
+            (ts: number) => {
+              const offsetMinutes = new Date().getTimezoneOffset();
+              const offsetMs = offsetMinutes * 60 * 1000;
+              return ts + offsetMs + nblTimezoneOffset * 3600000;
+            },
+          ],
+        },
+      },
     },
   ],
 
@@ -184,10 +189,6 @@ export const siteMetadata: ISiteMetadata = {
         selector: "li:contains('Joined') > span.time",
         attr: "title",
         filters: [{ name: "parseTime", args: ["MMM d yyyy, HH:mm"] }],
-      },
-      messageCount: {
-        selector: "div.alertbar a[href*='inbox.php']",
-        filters: [{ name: "parseNumber" }],
       },
       levelName: {
         ...SchemaMetadata!.userInfo!.selectors!.levelName!,

--- a/src/packages/site/schemas/Gazelle.ts
+++ b/src/packages/site/schemas/Gazelle.ts
@@ -7,7 +7,7 @@ import { ETorrentStatus, type ISiteMetadata, type ITorrent, type ISearchInput, t
 
 const commonTagKeywords = ["Freeleech", "Neutral", "Seeding", "Snatched", "Reported"];
 
-export const extractSubTitle = (tags: string, tagKeywords?: string[]) => {
+export function extractSubTitle(tags: string, tagKeywords?: string[]): string {
   const tagParts = tags.split(" / ");
   if (tagParts.length < 1) return "";
 
@@ -17,7 +17,21 @@ export const extractSubTitle = (tags: string, tagKeywords?: string[]) => {
     if (!(tagKeywords || commonTagKeywords).some((keyword) => tag.includes(keyword))) filteredParts.push(tag);
   });
   return filteredParts.join(" / ");
-};
+}
+
+function genStatBoxSelector(section: string | string[], itemSel: string | string[], suffixSel?: string): string[] {
+  const sections = Array.isArray(section) ? section : [section];
+  const itemSels = Array.isArray(itemSel) ? itemSel : [itemSel];
+  return sections.flatMap((s) =>
+    itemSels.map(
+      (iSel) => `div:contains('${s}') + ul.stats > li:contains('${iSel}')${suffixSel ? ` ${suffixSel}` : ""}`,
+    ),
+  );
+}
+
+const statsBoxName = ["Stats", "Statistics"];
+const personalBoxName = ["Personal"];
+const communityBoxName = ["Community"];
 
 export const SchemaMetadata: Partial<ISiteMetadata> = {
   version: 0,
@@ -37,33 +51,36 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
       },
       title: { selector: "a[href*='torrents.php?id=']" },
       url: { selector: "a[href*='torrents.php?id=']", attr: "href" },
-      link: {
-        selector: "a[href*='torrents.php?action=download'][title='Download']:first",
-        attr: "href",
-      },
+      link: { selector: "a[href*='torrents.php?action=download']:first", attr: "href" },
       // TODO category: {}
       time: {
+        text: 0,
         elementProcess: (element: HTMLElement) => {
-          const AccurateTimeAnother = element.querySelector("span[title], time[title]");
-          if (AccurateTimeAnother) {
-            return AccurateTimeAnother.getAttribute("title")! + ":00";
-          } else if (element.getAttribute("title")) {
-            return element.getAttribute("title")! + ":00";
-          } else {
-            return element.innerText.trim() + ":00";
-          }
+          let time: number | string = 0;
+          try {
+            const AccurateTimeAnother = element.querySelector("span[title], time[title]");
+            if (AccurateTimeAnother) {
+              time = AccurateTimeAnother.getAttribute("title")!;
+            } else if (element.getAttribute("title")) {
+              time = element.getAttribute("title")!;
+            } else {
+              time = element.innerText.trim();
+            }
+            time = parseValidTimeString(time);
+          } catch (e) {}
+          return time;
         },
       },
-
       progress: { text: 0 },
       status: { text: ETorrentStatus.unknown },
     },
   },
   userInfo: {
+    pickLast: ["id"],
     process: [
       {
         requestConfig: { url: "/index.php", responseType: "document" },
-        fields: ["id", "name", "messageCount"],
+        fields: ["id"],
       },
       {
         requestConfig: {
@@ -75,6 +92,8 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
         },
         assertion: { id: "params.id" },
         fields: [
+          "name",
+          "messageCount",
           "uploaded",
           "downloaded",
           "ratio",
@@ -98,74 +117,67 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
         selector: ["a.username[href*='user.php']:first"],
       },
       messageCount: {
-        selector: ["div.alert-bar > a[href*='inbox.php']", "div.alertbar > a[href*='inbox.php']"],
-        filters: [
-          (query: string) => {
-            const queryMatch = query.match(/(\d+)/);
-            return queryMatch && queryMatch.length >= 2 ? parseInt(queryMatch[1]) : 0;
-          },
-        ],
-      },
+        selector: ":self",
+        elementProcess: (doc: Document) => {
+          const notifRegex = /have (\d+|a) new/;
+          let messages = 0;
 
-      // "page": "/user.php?id=$user.id$",
-      uploaded: {
-        selector: "div:contains('Stats') + ul.stats > li:contains('Uploaded')",
-        filters: [
-          (query: string) => {
-            const queryMatch = query.replace(/,/g, "").match(/Upload.+?([\d.]+ ?[ZEPTGMK]?i?B)/);
-            return queryMatch && queryMatch.length >= 2 ? parseSizeString(queryMatch[1]) : 0;
-          },
-        ],
-      },
-      downloaded: {
-        selector: "div:contains('Stats') + ul.stats > li:contains('Downloaded')",
-        filters: [
-          (query: string) => {
-            const queryMatch = query.replace(/,/g, "").match(/Download.+?([\d.]+ ?[ZEPTGMK]?i?B)/);
-            return queryMatch && queryMatch.length >= 2 ? parseSizeString(queryMatch[1]) : 0;
-          },
-        ],
-      },
-      ratio: {
-        selector: "div:contains('Stats') + ul.stats > li:contains('Ratio:')",
-        filters: [
-          (query: string) => {
-            const queryMatch = query.replace(/,/g, "").match(/Ratio.+?([\d.]+)/);
-            return queryMatch && queryMatch.length >= 2 ? parseFloat(queryMatch[1]) : 0;
-          },
-        ],
-      },
-      levelName: {
-        selector: "div:contains('Personal') + ul.stats > li:contains('Class:')",
-        filters: [
-          (query: string) => {
-            const queryMatch = query.match(/Class:.+?(.+)/);
-            return queryMatch && queryMatch.length >= 2 ? queryMatch[1] : "";
-          },
-        ],
-      },
-      bonus: {
-        selector: [
-          "div:contains('Stats') + ul.stats > li:contains('Bonus Points:')",
-          "div:contains('Stats') + ul.stats > li:contains('SeedBonus:')",
-        ],
-        filters: [
-          (query: string) => {
-            query = query.replace(/,/g, "");
-            const queryMatch = query.match(/Bonus Points.+?([\d.]+)/) || query.match(/SeedBonus.+?([\d.]+)/);
-            return queryMatch && queryMatch.length >= 2 ? parseFloat(queryMatch[1]) : 0;
-          },
-        ],
-      },
-      joinTime: {
-        selector: ["div:contains('Stats') + ul.stats > li:contains('Joined:') > span"],
-        elementProcess: (element: HTMLElement) => {
-          const query = (element.getAttribute("title") || element.innerText).trim();
-          return parseValidTimeString(query, ["yyyy-MM-dd HH:mm:ss"]);
+          const pargeMessage = (el: Element) => {
+            const match = el.textContent.match(notifRegex);
+            messages += match ? (match[1] === "a" ? 1 : parseInt(match[1])) : 0;
+          };
+
+          // 1. Traditional
+          const alert = doc.querySelector("div#alert");
+          if (alert) {
+            const alerts = alert.querySelectorAll("a[href*='inbox.php'], a[href*='staffpm.php']");
+            alerts.forEach(pargeMessage);
+          }
+
+          // 2. Pop-Up
+          if (!alert || !messages) {
+            const notifSpans = doc.querySelectorAll(
+              ".noty-notification[data-noty-url*='inbox.php'], .noty-notification[data-noty-url*='staffpm.php']",
+            );
+            notifSpans.forEach(pargeMessage);
+          }
+
+          return messages;
         },
       },
+      // "page": "/user.php?id=$user.id$",
+      uploaded: {
+        selector: genStatBoxSelector(statsBoxName, "Uploaded"),
+        filters: [{ name: "parseSize" }],
+      },
+      downloaded: {
+        selector: genStatBoxSelector(statsBoxName, "Downloaded"),
+        filters: [{ name: "parseSize" }],
+      },
+      ratio: {
+        selector: genStatBoxSelector(statsBoxName, "Ratio:"),
+        filters: [{ name: "parseNumber" }],
+      },
+      levelName: {
+        selector: genStatBoxSelector(personalBoxName, "Class:"),
+        filters: [{ name: "split", args: [":", 1] }],
+      },
+      bonus: {
+        selector: genStatBoxSelector(statsBoxName, "Bonus Points:"),
+        filters: [{ name: "parseNumber" }],
+      },
+      joinTime: {
+        selector: genStatBoxSelector(statsBoxName, "Joined:", "> span"),
+        attr: "title",
+        filters: [{ name: "parseTime" }],
+      },
+      lastAccessAt: {
+        selector: genStatBoxSelector(statsBoxName, ["Last seen", "Last Seen"], "> span"),
+        attr: "title",
+        filters: [{ name: "parseTime" }],
+      },
       uploads: {
-        selector: ["div:contains('Community') + ul.stats > li:contains('Uploaded')"],
+        selector: genStatBoxSelector(communityBoxName, "Uploaded"),
         filters: [{ name: "parseNumber" }],
       },
     },

--- a/src/packages/site/schemas/Luminance.ts
+++ b/src/packages/site/schemas/Luminance.ts
@@ -5,6 +5,7 @@ import {
   type ISiteMetadata,
   type IUserInfo,
   type ITorrent,
+  type ISearchInput,
   NeedLoginError,
 } from "../types";
 import { GazelleBase } from "./Gazelle";
@@ -23,7 +24,7 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
     },
     keywordPath: "params.title",
     selectors: {
-      rows: { selector: "tr.torrent" },
+      rows: { selector: "table#torrent_table:last tr:gt(0)" },
       id: {
         selector: ["a[href*='torrents.php?id=']"],
         attr: "href",
@@ -49,12 +50,6 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
       url: { selector: ["a[href*='torrents.php?id=']"], attr: "href" },
       link: { selector: ["a[href*='torrents.php?action=download']"], attr: "href" },
       time: { selector: ["span.time[title]"], attr: "title", filters: [{ name: "parseTime" }] },
-      size: { selector: ["td:nth-child(6)"], filters: [{ name: "parseSize" }] },
-      author: { selector: ["td:nth-child(10) > a"] },
-      seeders: { selector: ["td:nth-child(8)"], filters: [{ name: "parseNumber" }] },
-      leechers: { selector: ["td:nth-child(9)"], filters: [{ name: "parseNumber" }] },
-      completed: { selector: ["td:nth-child(7)"], filters: [{ name: "parseNumber" }] },
-      comments: { selector: ["td:nth-child(4)"], filters: [{ name: "parseNumber" }] },
       // category: {},
       status: {
         selector: ["a[href*='torrents.php?action=download'] span"],
@@ -118,7 +113,7 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
       levelName: {
         selector: ["span.rank", "ul.stats > li:contains('Class:')"],
         switchFilters: {
-          "ul.stats > li:contains('Class:')": [{ name: "trim" }, { name: "split", args: [":", 1] }],
+          "ul.stats > li:contains('Class:')": [{ name: "split", args: [":", 1] }],
         },
       },
       bonus: {
@@ -196,6 +191,67 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
 };
 
 export default class Luminance extends GazelleBase {
+  protected guessSearchFieldIndexConfig(): Record<string, string[]> {
+    return {
+      size: ["td:has(a[href*='order_by=size'])", "td:contains('Size')"], // 大小
+      seeders: ["td:has(a[href*='order_by=seeders'])"], // 种子数
+      leechers: ["td:has(a[href*='order_by=leechers'])"], // 下载数
+      completed: ["td:has(a[href*='order_by=snatched'])"], // 完成数
+      comments: ["td:contains('Comm')", "td:has(i.fa-comment)"], // 评论数
+      author: ["td:contains('Uploader')"], // 上传者
+    } as Record<keyof ITorrent, string[]>;
+  }
+
+  public override async transformSearchPage(
+    doc: Document | object | any,
+    searchConfig: ISearchInput,
+  ): Promise<ITorrent[]> {
+    const { keywords, searchEntry, requestConfig } = searchConfig;
+
+    // 返回是 Document 的情况才自动生成选择器
+    if (doc instanceof Document) {
+      // 如果配置文件没有传入 search 的选择器，则我们自己生成
+      const legacyTableSelector = "table#torrent_table:last";
+
+      // 生成 rows的
+      if (!searchEntry!.selectors?.rows) {
+        searchEntry!.selectors!.rows = {
+          selector: `${legacyTableSelector} tr:gt(0)`,
+        };
+      }
+
+      // 对于 Luminance，一般来说，表的第一行应该是标题行，即 ` > tr:nth-child(1)`
+      const headSelector = `${legacyTableSelector} tr:first > td`;
+      const headAnother = Sizzle(headSelector, doc) as HTMLElement[];
+      headAnother.forEach((element, elementIndex) => {
+        // 比较好处理的一些元素，都是可以直接获取的
+        let updateSelectorField;
+        for (const [dectField, dectSelector] of Object.entries(this.guessSearchFieldIndexConfig())) {
+          for (const dectFieldElement of dectSelector) {
+            if (Sizzle.matchesSelector(element, dectFieldElement)) {
+              updateSelectorField = dectField;
+              break;
+            }
+          }
+        }
+
+        if (updateSelectorField) {
+          // @ts-ignore
+          searchEntry.selectors[updateSelectorField] = toMerged(
+            {
+              selector: [`> td:eq(${elementIndex})`],
+            },
+            // @ts-ignore
+            searchEntry.selectors[updateSelectorField] || {},
+          );
+        }
+      });
+    }
+
+    // !!! 其他一些比较难处理的，我们把他 hack 到 parseWholeTorrentFromRow 中 !!!
+    return await super.transformSearchPage(doc, { keywords, searchEntry, requestConfig });
+  }
+
   public override async getUserInfoResult(lastUserInfo: Partial<IUserInfo> = {}): Promise<IUserInfo> {
     let flushUserInfo: IUserInfo = {
       status: EResultParseStatus.unknownError,


### PR DESCRIPTION
## Summary by Sourcery

Update multiple Gazelle-based site schemas to improve selector robustness, unify user info parsing, and better handle dynamic search/result tables.

New Features:
- Automatically infer Luminance torrent table column selectors at runtime based on header content.
- Support parsing last access time for Gazelle-based user stats boxes.

Bug Fixes:
- Fix torrent time extraction in Gazelle schemas by using generic time parsing and avoiding hardcoded format concatenation.
- Correct Luminance search row selector to target the main torrents table and avoid relying on fixed column indexes.
- Adjust Nebulance browse time parsing to work with relative time displays and correct for timezone offsets.
- Fix CGPeers user info selectors to match the current navigation structure and user dropdown.
- Improve message count parsing across Gazelle-like sites by handling both alert bars and popup notifications.

Enhancements:
- Refactor Gazelle stats box selectors into reusable helpers and switch to common filter utilities for sizes, numbers, and times.
- Simplify several site schemas by delegating user stats fields (id, name, traffic, ratio) to shared Gazelle metadata where possible.
- Relax or remove over-specific search table selectors for certain sites in favor of dynamic parsing.
- Add groupType metadata for FileList VIP class to better describe its role in the class hierarchy.