### PR TITLE
fix(pkg/site/jpopsuki): 搜索添加禁用分组参数

### DIFF
--- a/src/packages/site/definitions/jpopsuki.ts
+++ b/src/packages/site/definitions/jpopsuki.ts
@@ -65,7 +65,7 @@ function genUserInfoSelector(boxName: boxName, field: keyof IUserInfo): string[]
 
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,
-  version: 2,
+  version: 3,
   id: "jpopsuki",
   name: "JPopSuki",
   aka: ["JPS", "JPOP"],
@@ -96,9 +96,17 @@ export const siteMetadata: ISiteMetadata = {
     },
   ],
 
-  // FIXME 使用 disablegrouping: 1 参数，可以避免专辑行和单种行的分组
   search: {
     ...SchemaMetadata.search!,
+    keywordPath: "params.torrentname",
+    requestConfig: {
+      url: "/ajax.php",
+      params: {
+        section: "torrents",
+        action: "advanced",
+        disablegrouping: 1,
+      },
+    },
     advanceKeywordParams: {
       imdb: false,
     },
@@ -246,5 +254,18 @@ export default class Jpopsuki extends Gazelle {
 
     // 其他情况仍交给 super.transformListPage 处理
     return super.transformListPage(doc);
+  }
+
+  protected override async getUserTorrentList(
+    userId: number,
+    page: number = 1,
+    type: string = "seeding",
+  ): Promise<Document> {
+    const { data: TListDocument } = await this.request<Document>({
+      url: "/ajax.php",
+      params: { section: "torrents", userid: userId, page, type },
+      responseType: "document",
+    });
+    return TListDocument;
   }
 }


### PR DESCRIPTION
搜索 url 改为了 `/ajax.php?section=torrents`，返回的页面更轻量一点

![search](https://github.com/user-attachments/assets/0cb0260c-3056-4ce5-b8be-ed4ef5c6e7cf)

## Summary by Sourcery

Update JPopSuki search and user torrent listing to use the lightweight AJAX torrents endpoint and improve generic Gazelle row parsing for unclassified torrent rows.

New Features:
- Support searching JPopSuki torrents via the /ajax.php?section=torrents endpoint with keyword-based parameters and disabled grouping.
- Allow fetching a user's torrent list on JPopSuki through the AJAX torrents endpoint with pagination and type filters.

Enhancements:
- Improve Gazelle torrent list parsing by handling previously unmatched rows, validating links, and attempting a full-row parse with error handling.
- Bump JPopSuki site metadata version to reflect the updated search and torrent listing behaviour.