### PR TITLE
fix(pkg/site): 更新一些 U3D 站点选择器

### DIFF
--- a/src/packages/site/definitions/fearnopeer.ts
+++ b/src/packages/site/definitions/fearnopeer.ts
@@ -8,6 +8,7 @@ export const siteMetadata: ISiteMetadata = {
   version: 1,
   name: "FearNoPeer",
   aka: ["FNP"],
+  description: "FearNoPear is a Private Torrent Tracker for MOVIES / TV / GENERAL",
   tags: ["综合"],
   timezoneOffset: "-0500",
   collaborator: ["hyuan280"],
@@ -183,6 +184,17 @@ export const siteMetadata: ISiteMetadata = {
       cross: { mode: "brackets" },
     },
   ],
+
+  userInfo: {
+    ...SchemaMetadata.userInfo!,
+    selectors: {
+      ...SchemaMetadata.userInfo!.selectors!,
+      joinTime: {
+        ...SchemaMetadata.userInfo!.selectors!.joinTime!,
+        selector: "span.profile-hero__meta-item:contains('Registration date')",
+      },
+    },
+  },
 
   levelRequirements: [
     {

--- a/src/packages/site/definitions/lst.ts
+++ b/src/packages/site/definitions/lst.ts
@@ -158,12 +158,16 @@ export const siteMetadata: ISiteMetadata = {
     ...SchemaMetadata.userInfo!,
     selectors: {
       ...SchemaMetadata.userInfo!.selectors!,
+      joinTime: {
+        ...SchemaMetadata.userInfo!.selectors!.joinTime!,
+        selector: "span.profile-hero__meta-item:contains('Registration date')",
+      },
       seedingSize: {
-        selector: "span.sidebar-stat__label:contains('Seeding size') ~ span",
+        selector: "div.profile-mini-stat__label:contains('Seeding size') + div",
         filters: [{ name: "parseSize" }],
       },
       averageSeedingTime: {
-        selector: "span.sidebar-stat__label:contains('Average seedtime') ~ span",
+        selector: "div.profile-mini-stat__label:contains('Average seedtime') + div",
         filters: [{ name: "parseDuration" }],
       },
     },


### PR DESCRIPTION
## Summary by Sourcery

Update U3D tracker site metadata and profile selectors for FearNoPeer and LST.

New Features:
- Add a textual description to the FearNoPeer site metadata.

Bug Fixes:
- Adjust FearNoPeer and LST user profile selectors to correctly capture registration date, seeding size, and average seeding time on updated layouts.