### PR TITLE
fix(pkg/site/retroflix): 修复时间格式解析

### DIFF
--- a/src/packages/site/definitions/btetree.ts
+++ b/src/packages/site/definitions/btetree.ts
@@ -26,6 +26,7 @@ const torrentYearMap = [
   [2023, 617776],
   [2024, 621061],
   [2025, 623102],
+  [2026, 625197],
 ];
 
 export const siteMetadata: ISiteMetadata = {
@@ -33,6 +34,8 @@ export const siteMetadata: ISiteMetadata = {
   id: "btetree",
   name: "BT.etree",
   description: "BT.etree is a Public Tracker dedicated to Bootleg FLAC MUSIC",
+  tags: ["音乐"],
+  timezoneOffset: "-0500",
 
   type: "public",
   urls: ["https://bt.etree.org/"],
@@ -46,7 +49,7 @@ export const siteMetadata: ISiteMetadata = {
       imdb: false,
     },
     selectors: {
-      rows: { selector: 'table[bgcolor="#CCCCCC"] tbody tr:gt(1)' }, // 不要第一行
+      rows: { selector: 'table[bgcolor="#CCCCCC"] tbody tr:gt(0)' }, // 不要第一行
       id: {
         selector: "td:nth-child(2) a.details_link",
         attr: "href",

--- a/src/packages/site/definitions/retroflix.ts
+++ b/src/packages/site/definitions/retroflix.ts
@@ -178,9 +178,19 @@ export const siteMetadata: ISiteMetadata = {
     selectors: {
       ...SchemaMetadata.userInfo!.selectors!,
       seedingBonus: undefined,
+      joinTime: {
+        ...SchemaMetadata.userInfo!.selectors!.joinTime!,
+        filters: [
+          { name: "split", args: ["(", 0] },
+          { name: "parseTime", args: ["dd-MM-yyyy HH:mm:ss"] },
+        ],
+      },
       lastAccessAt: {
-        ...SchemaMetadata.userInfo!.selectors!.lastAccessAt!,
         selector: "td.rowhead:contains('Last'):contains('seen') + td",
+        filters: [
+          { name: "split", args: ["(", 0] },
+          { name: "parseTime", args: ["dd-MM-yyyy HH:mm:ss"] },
+        ],
       },
       averageSeedingTime: { selector: "td.rowhead:contains('Seed avg.') + td", filters: [{ name: "parseDuration" }] },
       hnrUnsatisfied: {


### PR DESCRIPTION
## Summary by Sourcery

Update site metadata for Retroflix and BT.etree to correctly parse user time fields and extend tracker configuration.

Bug Fixes:
- Fix Retroflix user join and last access time parsing by normalizing the displayed datetime format before processing.

Enhancements:
- Extend BT.etree configuration with 2026 torrent year mapping, music tag, timezone offset, and improved row selection for torrent listings.