### PR TITLE
feat(pkg/site/Gazelle): 添加通用拖拽下载方式

### DIFF
--- a/src/packages/site/definitions/morethantv.ts
+++ b/src/packages/site/definitions/morethantv.ts
@@ -1,5 +1,5 @@
-import { ISearchCategoryOptions, type ISiteMetadata } from "../types";
-import { SchemaMetadata } from "../schemas/Luminance";
+import { ISearchCategoryOptions, type ISiteMetadata, type ITorrent } from "../types";
+import Luminance, { SchemaMetadata } from "../schemas/Luminance";
 
 const categories: ISearchCategoryOptions[] = [
   // Torznab Movie Categories
@@ -221,3 +221,10 @@ export const siteMetadata: ISiteMetadata = {
     { id: 211, name: "Tagger", groupType: "manager" },
   ],
 };
+
+export default class MoreThanTV extends Luminance {
+  public override async getTorrentDownloadLink(torrent: ITorrent): Promise<string> {
+    // 种子链接格式是 torrent.php?torrentid=123（有种子组）
+    return this.getTorrentDownloadLinkFactory("torrentid")(torrent);
+  }
+}

--- a/src/packages/site/definitions/nebulance.ts
+++ b/src/packages/site/definitions/nebulance.ts
@@ -371,4 +371,9 @@ export default class Nebulance extends Gazelle {
 
     return torrents;
   }
+
+  public override async getTorrentDownloadLink(torrent: ITorrent): Promise<string> {
+    // 种子链接格式是 torrent.php?id=123（无种子组）
+    return this.getTorrentDownloadLinkFactory("id")(torrent);
+  }
 }

--- a/src/packages/site/schemas/GazelleJSONAPI.ts
+++ b/src/packages/site/schemas/GazelleJSONAPI.ts
@@ -415,6 +415,11 @@ export default class GazelleJSONAPI extends GazelleBase {
     return torrents;
   }
 
+  public override async getTorrentDownloadLink(torrent: ITorrent): Promise<string> {
+    // 种子链接格式是 torrent.php?torrentid=123
+    return this.getTorrentDownloadLinkFactory("torrentid")(torrent);
+  }
+
   public override async getUserInfoResult(lastUserInfo: Partial<IUserInfo> = {}): Promise<IUserInfo> {
     let flushUserInfo: IUserInfo = {
       status: EResultParseStatus.unknownError,

--- a/src/packages/site/schemas/Luminance.ts
+++ b/src/packages/site/schemas/Luminance.ts
@@ -252,6 +252,11 @@ export default class Luminance extends GazelleBase {
     return await super.transformSearchPage(doc, { keywords, searchEntry, requestConfig });
   }
 
+  public override async getTorrentDownloadLink(torrent: ITorrent): Promise<string> {
+    // 种子链接格式是 torrent.php?id=123
+    return this.getTorrentDownloadLinkFactory("id")(torrent);
+  }
+
   public override async getUserInfoResult(lastUserInfo: Partial<IUserInfo> = {}): Promise<IUserInfo> {
     let flushUserInfo: IUserInfo = {
       status: EResultParseStatus.unknownError,
@@ -337,18 +342,5 @@ export default class Luminance extends GazelleBase {
       this.metadata.userInfo?.selectors!,
       Object.keys(omit(this.metadata.userInfo?.selectors!, ["id"])),
     ) as Partial<IUserInfo>;
-  }
-
-  public override async getTorrentDownloadLink(torrent: ITorrent): Promise<string> {
-    const downloadLink = await super.getTorrentDownloadLink(torrent);
-    if (downloadLink && !downloadLink.includes("action=download")) {
-      const { data: detailDocument } = await this.request<Document>({
-        url: downloadLink,
-        responseType: "document",
-      });
-      return this.getFieldData(detailDocument, this.metadata.search?.selectors?.link!);
-    }
-
-    return downloadLink;
   }
 }


### PR DESCRIPTION
## Summary by Sourcery

Unify Gazelle-based torrent download link handling with a shared helper and apply it across Gazelle-derived site schemas.

Enhancements:
- Add a reusable download-link factory in GazelleBase to normalize dragged torrent links into direct download URLs for Gazelle-based sites.
- Update Gazelle, Luminance, GazelleJSONAPI, MoreThanTV, and Nebulance schemas to use the shared download-link factory instead of site-specific implementations.