### PR TITLE
fix(pkg/site/Unit3D): 更新一些选择器

### DIFF
--- a/src/packages/site/definitions/fearnopeer.ts
+++ b/src/packages/site/definitions/fearnopeer.ts
@@ -185,17 +185,6 @@ export const siteMetadata: ISiteMetadata = {
     },
   ],
 
-  userInfo: {
-    ...SchemaMetadata.userInfo!,
-    selectors: {
-      ...SchemaMetadata.userInfo!.selectors!,
-      joinTime: {
-        ...SchemaMetadata.userInfo!.selectors!.joinTime!,
-        selector: "span.profile-hero__meta-item:contains('Registration date')",
-      },
-    },
-  },
-
   levelRequirements: [
     {
       id: 1,

--- a/src/packages/site/definitions/lst.ts
+++ b/src/packages/site/definitions/lst.ts
@@ -158,6 +158,10 @@ export const siteMetadata: ISiteMetadata = {
     ...SchemaMetadata.userInfo!,
     selectors: {
       ...SchemaMetadata.userInfo!.selectors!,
+      uploads: {
+        selector: "div.profile-mini-stat__label:contains('Total uploads') + div",
+        filters: [{ name: "parseNumber" }],
+      },
       joinTime: {
         ...SchemaMetadata.userInfo!.selectors!.joinTime!,
         selector: "span.profile-hero__meta-item:contains('Registration date')",

--- a/src/packages/site/schemas/Unit3D.ts
+++ b/src/packages/site/schemas/Unit3D.ts
@@ -294,7 +294,7 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
             }
           }
 
-          // 如果还是没有，那么我们尽力了，返回underfined
+          // 如果还是没有，那么我们尽力了，返回undefined
           return undefined;
         },
       },
@@ -411,8 +411,20 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
         elementProcess: () => 11, // 并不能直接知道还有多少个消息未读，所以置为11，会直接出线红点而不是具体数字
       },
       uploads: {
-        selector: [".badge-user .fa-upload + span", "li:has(i.fas.fa-upload) a[href*='/uploads']"],
-        filters: [{ name: "parseNumber" }],
+        selector: ["dl.key-value:has(a[href*='/uploads'])", ".badge-user .fa-upload + span"],
+        elementProcess: (el: Element) => {
+          if (!el.matches("dl.key-value:has(a[href*='/uploads'])")) {
+            return undefined;
+          }
+          let count = 0;
+          el.querySelectorAll("dt:has(a[href*='/uploads']) + dd").forEach((e) => {
+            count += Number(e.textContent.trim());
+          });
+          return count;
+        },
+        switchFilters: {
+          ".badge-user .fa-upload + span": [{ name: "parseNumber" }],
+        },
       },
       joinTime: {
         selector: ["time.profile__registration", ...joinTimeTrans.map((x) => `div.content h4:contains('${x}')`)],


### PR DESCRIPTION
## Summary by Sourcery

Update user info upload selectors and cleanup site-specific overrides for Unit3D-based schemas.

Bug Fixes:
- Correct the uploads counter selector logic to support the new key-value layout and ensure numeric parsing for legacy markup.

Enhancements:
- Remove a custom fearnopeer userInfo joinTime override to rely on the shared Unit3D schema implementation.
- Add a dedicated uploads selector for lst profiles to extract total uploads from the mini stats section.
- Fix a typo in an inline comment in the Unit3D schema metadata.