### PR TITLE
feat(pkg/site/gazellegames): 支持用组名搜索

### DIFF
--- a/src/packages/site/definitions/pter.ts
+++ b/src/packages/site/definitions/pter.ts
@@ -231,12 +231,10 @@ export const siteMetadata: ISiteMetadata = {
         // TODO,
         rows: {
           selector: ".rowfollow",
-          filter: <T>(rows: T): T => {
+          filter: (rows: HTMLElement[] | null): HTMLElement[] | null => {
             // 只保留游戏种子
             if (Array.isArray(rows)) {
-              return Array.from(rows).filter(
-                (row) => !!(row as HTMLElement).querySelector("a[title='点击查看此种子详细资料']"),
-              ) as unknown as T;
+              return Array.from(rows).filter((row) => !!row.querySelector("a[title='点击查看此种子详细资料']"));
             }
             return rows;
           },
@@ -277,7 +275,8 @@ export const siteMetadata: ISiteMetadata = {
           selector: "div > span + span + span + span",
         },
         time: {
-          selector: "div[id^='ktorrent'] > #hidefl ~ span",
+          text: 0,
+          selector: ["div[id^='ktorrent'] > #hidefl ~ span[title]", "div[id^='ktorrent'] > span > span[title]"],
           attr: "title",
         },
       },


### PR DESCRIPTION
## Summary by Sourcery

Add an option to search GazelleGames by group name and adjust related search and torrent handling, while refining Pter game row filtering and time extraction.

New Features:
- Introduce a GazelleGames search option to use group name for more precise search results.

Enhancements:
- Override GazelleGames search handling to map the new group-name option into the underlying request parameters.
- Rename and encapsulate the GazelleGames torrent transformation helper for clearer intent and scoping.
- Tighten Pter search row filtering to explicitly operate on HTML elements representing game torrents.
- Improve Pter torrent time parsing by supporting multiple possible DOM locations for the timestamp.