### PR TITLE
fix(pkg/site/mteam): 在全局优惠时正确显示标签

### DIFF
--- a/src/packages/site/definitions/mteam.ts
+++ b/src/packages/site/definitions/mteam.ts
@@ -648,6 +648,19 @@ export default class MTeam extends PrivateSite {
     return super.fixLink(uri, { ...requestConfig, baseURL: this.url }); // 将 baseURL 重新指向回 web 页面
   }
 
+  private mapDiscountToTag(discount?: string | null): ITorrentTag | undefined {
+    switch (discount) {
+      case "FREE":
+        return { name: "Free", color: "blue" };
+      case "PERCENT_70":
+        return { name: "30%", color: "indigo" };
+      case "PERCENT_50":
+        return { name: "50%", color: "orange" };
+      default:
+        return undefined;
+    }
+  }
+
   protected override parseTorrentRowForTags(
     torrent: Partial<ITorrent>,
     row: IMTeamRawTorrent,
@@ -655,23 +668,10 @@ export default class MTeam extends PrivateSite {
   ): Partial<ITorrent> {
     const tags: ITorrentTag[] = [];
 
-    const mapDiscountToTag = (discount?: string | null): ITorrentTag | undefined => {
-      switch (discount) {
-        case "FREE":
-          return { name: "Free", color: "blue" };
-        case "PERCENT_70":
-          return { name: "30%", color: "indigo" };
-        case "PERCENT_50":
-          return { name: "50%", color: "orange" };
-        default:
-          return undefined;
-      }
-    };
-
     // 优先处理全站促销规则
     if (row.status?.promotionRule) {
       const globalDiscount = row.status.promotionRule.discount ?? "NORMAL";
-      const tag = mapDiscountToTag(globalDiscount);
+      const tag = this.mapDiscountToTag(globalDiscount);
       if (tag) tags.push(tag);
     } else {
       // 处理 成人区限时free
@@ -680,7 +680,7 @@ export default class MTeam extends PrivateSite {
       } else {
         // 其他促销状态 从 status.discount 中获取
         const discount = row.status?.discount ?? "NORMAL";
-        const tag = mapDiscountToTag(discount);
+        const tag = this.mapDiscountToTag(discount);
         if (tag) tags.push(tag);
       }
     }


### PR DESCRIPTION
优先解析 row 中的 promotionRule

## Summary by Sourcery

Adjust torrent tag generation on MTeam to prioritize global promotion rules and avoid duplicate labels.

Bug Fixes:
- Ensure global promotion rules on MTeam torrents correctly determine the displayed discount tag instead of being overridden by other status fields.

Enhancements:
- Refactor discount-to-tag mapping into a reusable helper for consistent tag generation across promotion sources.
- Deduplicate label-based tags when mapping labelsNew to torrent tags to prevent repeated labels.