### PR TITLE
fix(site): 修复 ptsbao 站点 URL 配置

### DIFF
--- a/src/packages/site/definitions/ptsbao.ts
+++ b/src/packages/site/definitions/ptsbao.ts
@@ -15,7 +15,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "NexusPHP",
 
-  urls: ["uggcf://cgfonb.pyho/"],
+  urls: ["https://ptsbao.club/"],
 
   category: [
     {


### PR DESCRIPTION
- 确保站点定义中的 URL 格式正确可用

Closes 973

## Summary by Sourcery

Bug Fixes:
- Fix incorrect URL scheme and domain configuration for the ptsbao site metadata entry.