### PR TITLE
fix(pkg/site): 更新 FNP 选择器 & SC 新分类

### DIFF
--- a/src/packages/site/definitions/fearnopeer.ts
+++ b/src/packages/site/definitions/fearnopeer.ts
@@ -185,6 +185,25 @@ export const siteMetadata: ISiteMetadata = {
     },
   ],
 
+  userInfo: {
+    ...SchemaMetadata.userInfo!,
+    selectors: {
+      ...SchemaMetadata.userInfo!.selectors!,
+      uploads: {
+        ...SchemaMetadata.userInfo!.selectors!.uploads!,
+        selector: "dl.profile-stats-list-2026:has(a[href*='/uploads'])",
+      },
+      joinTime: {
+        ...SchemaMetadata.userInfo!.selectors!.joinTime!,
+        selector: "span.profile-hero-2026__meta-item:contains('Registration date')",
+      },
+      invites: {
+        selector: "span.profile-hero-2026__info-label:contains('Invites') + span",
+        filters: [{ name: "parseNumber" }],
+      },
+    },
+  },
+
   levelRequirements: [
     {
       id: 1,

--- a/src/packages/site/definitions/sportscult.ts
+++ b/src/packages/site/definitions/sportscult.ts
@@ -1,5 +1,5 @@
 /**
- * @JackettDefinitions https://github.com/Jackett/Jackett/blob/master/src/Jackett.Common/Definitions/hdtorrents.yml
+ * @JackettDefinitions https://github.com/Jackett/Jackett/blob/master/src/Jackett.Common/Definitions/sportscult.yml
  * @JackettIssue https://github.com/Jackett/Jackett/issues/1330
  */
 import type { ISiteMetadata, IUserInfo } from "../types.ts";
@@ -97,7 +97,11 @@ const categoryMap: Record<number, string> = {
   99: "Darts",
   100: "ESport",
   6: "European Soccer",
+  101: "EuroCup",
+  102: "Ultimate Diskk",
+  104: "WinterOlympicGames",
   52: "Field Hockey",
+  103: "Basketball Champions",
   58: "UFC",
   57: "NRL",
 };

--- a/src/packages/site/schemas/Unit3D.ts
+++ b/src/packages/site/schemas/Unit3D.ts
@@ -415,7 +415,7 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
       uploads: {
         selector: ["dl.key-value:has(a[href*='/uploads'])", ".badge-user .fa-upload + span"],
         elementProcess: (el: Element) => {
-          if (!el.matches("dl.key-value:has(a[href*='/uploads'])")) {
+          if (!el.querySelector("a[href*='/uploads']")) {
             return undefined;
           }
           let count = 0;


### PR DESCRIPTION
## Summary by Sourcery

Update site metadata and category mappings for specific trackers and adjust a user uploads selector for the Unit3D schema.

New Features:
- Add user info selectors for uploads, registration date, and invites to the FearNoPeer site definition.
- Extend SportsCult category mappings with new sports and competition categories.

Bug Fixes:
- Fix the Unit3D user uploads selector to correctly detect links to uploads in the key-value list.