### PR TITLE
fix(pkg/site/bakabt): 修复分类获取

### DIFF
--- a/src/packages/site/definitions/bakabt.ts
+++ b/src/packages/site/definitions/bakabt.ts
@@ -87,10 +87,9 @@ export const siteMetadata: ISiteMetadata = {
       subTitle: { selector: "span.tags" },
       url: { selector: ".peers a", attr: "href" },
       category: {
+        text: "stub", // torrent_alt 行没有类别信息，会在后续方法处理
         selector: "span.torrent_icon",
         attr: "title",
-        // torrent_alt 行没有类别信息，会在后续方法处理
-        filters: [(query: string) => query || "stub"],
       },
       time: {
         selector: ":self",


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure Bakabt torrent entries without category info receive a stub category value for downstream processing.