### PR TITLE
fix(pkg/downloader/uTorrent): adjust parameter order in torrent-add

### DIFF
--- a/src/packages/downloader/entity/uTorrent.ts
+++ b/src/packages/downloader/entity/uTorrent.ts
@@ -194,8 +194,10 @@ export default class UTorrent extends AbstractBittorrentClient<TorrentClientConf
 
     let formData: FormData | null = new FormData();
     const params: { [key: string]: any } = {
-      download_dir: 0,
+      // 注意： uTorrent 对参数顺序有要求，必须要按照下面顺序，否则会报 invalid request 错误
       token: _sid,
+      action: "", // 空白占位，后面会覆写的
+      download_dir: 0,
       path: options.savePath ? options.savePath : "",
     };
 
@@ -218,7 +220,7 @@ export default class UTorrent extends AbstractBittorrentClient<TorrentClientConf
       formData.append("torrent_file", torrent.metadata.blob(), torrent.name);
     }
 
-    await axios.post(this.address, formData, {
+    await axios.post<{ build: number }>(this.address, formData, {
       params: params,
       auth: {
         username: this.config.username,


### PR DESCRIPTION
closed: #996

## Summary by Sourcery

Adjust uTorrent torrent-add request parameter order to satisfy client requirements and ensure compatibility with the uTorrent API.

Bug Fixes:
- Fix uTorrent torrent-add requests failing with 'invalid request' errors by ordering parameters as expected by the uTorrent API.

Enhancements:
- Specify the expected response type for the uTorrent torrent-add axios POST request.