### PR TITLE
fix(pkg/site): 更新部分站点等级信息

### DIFF
--- a/src/packages/site/definitions/dicmusic.ts
+++ b/src/packages/site/definitions/dicmusic.ts
@@ -219,6 +219,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       id: 6,
       name: "Power Torrent Master",
+      nameAka: ["Power TM"],
       interval: "P8W",
       uploaded: "200GiB",
       ratio: 1.05,
@@ -228,6 +229,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       id: 7,
       name: "Elite Torrent Master",
+      nameAka: ["Elite TM"],
       interval: "P12W",
       uploaded: "600GiB",
       ratio: 1.05,

--- a/src/packages/site/definitions/empornium.ts
+++ b/src/packages/site/definitions/empornium.ts
@@ -149,6 +149,15 @@ export const siteMetadata: ISiteMetadata = {
     },
     {
       id: 4,
+      name: "Better Perv",
+      interval: "P5Y",
+      uploaded: "25TB",
+      ratio: 1.05,
+      privilege:
+        "can see staff list on Staff page; can send invites (if you have any); can create an additional personal collage (3 total); can set forum signature (up to 512 characters)",
+    },
+    {
+      id: 5,
       name: "Great Perv",
       interval: "P8W",
       uploaded: "100GB",
@@ -158,7 +167,7 @@ export const siteMetadata: ISiteMetadata = {
         "can see staff list on Staff page;  can access the Invite forum;  can send invites (if you have any);  can create an additional personal collage (3 total);  can set forum signature (up to 512 characters)",
     },
     {
-      id: 5,
+      id: 6,
       name: "Sextreme Perv",
       interval: "P13W",
       uploaded: "1TB",
@@ -168,7 +177,7 @@ export const siteMetadata: ISiteMetadata = {
         "can see staff list on Staff page; can create 2 additional personal collages (5 total); can set forum signature (up to 1024 characters)",
     },
     {
-      id: 6,
+      id: 7,
       name: "Smut Peddler",
       interval: "P26W",
       uploaded: "10TB",

--- a/src/packages/site/definitions/greatposterwall.ts
+++ b/src/packages/site/definitions/greatposterwall.ts
@@ -285,6 +285,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       id: 5,
       name: "Power Torrent Master",
+      nameAka: ["Power TM"],
       interval: "P12W",
       uploads: 250,
       trueDownloaded: "2TB",
@@ -294,6 +295,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       id: 6,
       name: "Elite Torrent Master",
+      nameAka: ["Elite TM"],
       interval: "P16W",
       uploads: 500,
       trueDownloaded: "5TB",


### PR DESCRIPTION
## Summary by Sourcery

Update tracker rank metadata for multiple sites to reflect current titles and aliases.

New Features:
- Add the Better Perv rank to the Empornium site definition with its associated requirements and privileges.
- Add short alias names for the Power Torrent Master and Elite Torrent Master ranks in the DicMusic and GreatPosterWall site definitions.

Enhancements:
- Adjust Empornium rank IDs to account for the newly inserted Better Perv rank so subsequent ranks maintain correct ordering.