### PR TITLE
feat(pkg/site): 适配 Luminarr

### DIFF
--- a/src/packages/site/definitions/aither.ts
+++ b/src/packages/site/definitions/aither.ts
@@ -1,5 +1,12 @@
 import { type ISiteMetadata } from "../types";
-import { SchemaMetadata } from "../schemas/Unit3D.ts";
+import { CategoryFree, SchemaMetadata } from "../schemas/Unit3D.ts";
+import { buildCategoryOptionsFromDict } from "../utils.ts";
+
+const categoryMap: Record<number, string> = {
+  1: "Movie",
+  9: "Sport",
+  2: "TV",
+};
 
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,
@@ -95,11 +102,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       name: "类别",
       key: "categoryIds",
-      options: [
-        { name: "Movie", value: 1 },
-        { name: "Sport", value: 9 },
-        { name: "TV", value: 2 },
-      ],
+      options: buildCategoryOptionsFromDict(categoryMap),
       cross: { mode: "brackets" },
     },
     {
@@ -144,32 +147,7 @@ export const siteMetadata: ISiteMetadata = {
       ],
       cross: { mode: "brackets" },
     },
-    {
-      name: "Buff",
-      key: "free",
-      options: [
-        { name: "0% Freeleech", value: 0 },
-        { name: "25% Free", value: 25 },
-        { name: "50% Free", value: 50 },
-        { name: "75% Free", value: 75 },
-        { name: "100% Free", value: 100 },
-        { name: "双倍上传", value: "doubleup" },
-        { name: "精选", value: "featured" },
-        { name: "Refundable", value: "refundable" },
-      ],
-      cross: { mode: "custom" },
-      generateRequestConfig: (selectedOptions) => {
-        const params: Record<string, any> = { free: [] };
-        (selectedOptions as Array<number | string>).forEach((value) => {
-          if (value === "doubleup" || value === "featured" || value === "refundable") {
-            params[value] = 1;
-          } else {
-            params.free.push(value);
-          }
-        });
-        return { requestConfig: { params } };
-      },
-    },
+    CategoryFree,
   ],
 
   search: {
@@ -177,6 +155,11 @@ export const siteMetadata: ISiteMetadata = {
     skipNonLatinCharacters: true,
     selectors: {
       ...SchemaMetadata.search!.selectors,
+      category: {
+        selector: ":self",
+        data: "categoryId",
+        filters: [(query: string) => categoryMap[Number(query)]],
+      },
       tags: [
         ...SchemaMetadata.search!.selectors!.tags!,
         {

--- a/src/packages/site/definitions/blutopia.ts
+++ b/src/packages/site/definitions/blutopia.ts
@@ -1,5 +1,5 @@
 import { type ISiteMetadata } from "../types";
-import { SchemaMetadata } from "../schemas/Unit3D.ts";
+import { CategoryFree, SchemaMetadata } from "../schemas/Unit3D.ts";
 
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,
@@ -130,32 +130,7 @@ export const siteMetadata: ISiteMetadata = {
       ],
       cross: { mode: "brackets" },
     },
-    {
-      name: "Buff",
-      key: "free",
-      options: [
-        { name: "0% Freeleech", value: 0 },
-        { name: "25% Free", value: 25 },
-        { name: "50% Free", value: 50 },
-        { name: "75% Free", value: 75 },
-        { name: "100% Free", value: 100 },
-        { name: "双倍上传", value: "doubleup" },
-        { name: "精选", value: "featured" },
-        { name: "Refundable", value: "refundable" },
-      ],
-      cross: { mode: "custom" },
-      generateRequestConfig: (selectedOptions) => {
-        const params: Record<string, any> = { free: [] };
-        (selectedOptions as Array<number | string>).forEach((value) => {
-          if (value === "doubleup" || value === "featured" || value === "refundable") {
-            params[value] = 1;
-          } else {
-            params.free.push(value);
-          }
-        });
-        return { requestConfig: { params } };
-      },
-    },
+    CategoryFree,
   ],
 
   search: {

--- a/src/packages/site/definitions/cinematik.ts
+++ b/src/packages/site/definitions/cinematik.ts
@@ -1,5 +1,5 @@
 import { type ISiteMetadata } from "../types";
-import { SchemaMetadata } from "../schemas/Unit3D.ts";
+import { CategoryFree, SchemaMetadata } from "../schemas/Unit3D.ts";
 
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,
@@ -129,32 +129,7 @@ export const siteMetadata: ISiteMetadata = {
       ],
       cross: { mode: "brackets" },
     },
-    {
-      name: "Buff",
-      key: "free",
-      options: [
-        { name: "0% Freeleech", value: 0 },
-        { name: "25% Free", value: 25 },
-        { name: "50% Free", value: 50 },
-        { name: "75% Free", value: 75 },
-        { name: "100% Free", value: 100 },
-        { name: "双倍上传", value: "doubleup" },
-        { name: "精选", value: "featured" },
-        { name: "Refundable", value: "refundable" },
-      ],
-      cross: { mode: "custom" },
-      generateRequestConfig: (selectedOptions) => {
-        const params: Record<string, any> = { free: [] };
-        (selectedOptions as Array<number | string>).forEach((value) => {
-          if (value === "doubleup" || value === "featured" || value === "refundable") {
-            params[value] = 1;
-          } else {
-            params.free.push(value);
-          }
-        });
-        return { requestConfig: { params } };
-      },
-    },
+    CategoryFree,
   ],
 
   search: {

--- a/src/packages/site/definitions/fearnopeer.ts
+++ b/src/packages/site/definitions/fearnopeer.ts
@@ -1,6 +1,17 @@
 import { type ISiteMetadata } from "../types";
 import { SchemaMetadata } from "../schemas/Unit3D.ts";
-import { buildCategoryOptionsFromList } from "../utils";
+import { buildCategoryOptionsFromDict, buildCategoryOptionsFromList } from "../utils";
+
+const categoryMap: Record<number, string> = {
+  1: "Movie",
+  2: "TV",
+  3: "Music",
+  6: "Anime",
+  4: "Games",
+  5: "Apps",
+  9: "Sport",
+  11: "Assorted",
+};
 
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,
@@ -22,16 +33,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       name: "类别",
       key: "categoryIds",
-      options: [
-        { name: "Movie", value: 1 },
-        { name: "TV", value: 2 },
-        { name: "Music", value: 3 },
-        { name: "Anime", value: 6 },
-        { name: "Games", value: 4 },
-        { name: "Apps", value: 5 },
-        { name: "Sport", value: 9 },
-        { name: "Assorted", value: 11 },
-      ],
+      options: buildCategoryOptionsFromDict(categoryMap),
       cross: { mode: "brackets" },
     },
     {
@@ -184,6 +186,18 @@ export const siteMetadata: ISiteMetadata = {
       cross: { mode: "brackets" },
     },
   ],
+
+  search: {
+    ...SchemaMetadata.search,
+    selectors: {
+      ...SchemaMetadata.search!.selectors,
+      category: {
+        selector: ":self",
+        data: "categoryId",
+        filters: [(query: string) => categoryMap[Number(query)]],
+      },
+    },
+  },
 
   userInfo: {
     ...SchemaMetadata.userInfo!,

--- a/src/packages/site/definitions/lst.ts
+++ b/src/packages/site/definitions/lst.ts
@@ -1,5 +1,5 @@
 import { type ISiteMetadata } from "../types";
-import { SchemaMetadata } from "../schemas/Unit3D.ts";
+import { CategoryFree, SchemaMetadata } from "../schemas/Unit3D.ts";
 
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,
@@ -73,8 +73,7 @@ export const siteMetadata: ISiteMetadata = {
       cross: { mode: "brackets" },
     },
     {
-      name: "Buff",
-      key: "free",
+      ...CategoryFree,
       options: [
         // 25% - 75% 没有实际使用
         { name: "Normal", value: 0 },
@@ -83,18 +82,6 @@ export const siteMetadata: ISiteMetadata = {
         { name: "精选", value: "featured" },
         { name: "Refundable", value: "refundable" },
       ],
-      cross: { mode: "custom" },
-      generateRequestConfig: (selectedOptions) => {
-        const params: Record<string, any> = { free: [] };
-        (selectedOptions as Array<number | string>).forEach((value) => {
-          if (value === "doubleup" || value === "featured" || value === "refundable") {
-            params[value] = 1;
-          } else {
-            params.free.push(value);
-          }
-        });
-        return { requestConfig: { params } };
-      },
     },
   ],
 

--- a/src/packages/site/definitions/luminarr.ts
+++ b/src/packages/site/definitions/luminarr.ts
@@ -1,0 +1,186 @@
+import { type ISiteMetadata } from "../types";
+import { CategoryFree, SchemaMetadata } from "../schemas/Unit3D";
+import { buildCategoryOptionsFromDict } from "../utils";
+
+const categoryMap: Record<number, string> = {
+  1: "Movies",
+  2: "TV",
+};
+
+export const siteMetadata: ISiteMetadata = {
+  ...SchemaMetadata,
+
+  version: 1,
+  id: "luminarr",
+  name: "Luminarr",
+  aka: ["LUME"],
+  description: "Luminarr is a Private Torrent Tracker for MOVIES / TV",
+  tags: ["影视"],
+  timezoneOffset: "+0000",
+
+  type: "private",
+  schema: "Unit3D",
+
+  urls: ["uggcf://yhzvanee.zr/"],
+
+  category: [
+    {
+      name: "类别",
+      key: "categoryIds",
+      options: buildCategoryOptionsFromDict(categoryMap),
+      cross: { mode: "brackets" },
+    },
+    {
+      name: "规格",
+      key: "typeIds",
+      options: [
+        { name: "Full Disc", value: 1 },
+        { name: "Remux", value: 2 },
+        { name: "Encode", value: 3 },
+        { name: "WEB-DL", value: 4 },
+        { name: "WEBRip", value: 5 },
+        { name: "HDTV", value: 6 },
+        { name: "SDTV", value: 7 },
+      ],
+      cross: { mode: "brackets" },
+    },
+    {
+      name: "分辨率",
+      key: "resolutionIds",
+      options: [
+        { name: "4320p", value: 1 },
+        { name: "2160p", value: 2 },
+        { name: "1080p", value: 3 },
+        { name: "1080i", value: 4 },
+        { name: "720p", value: 5 },
+        { name: "576p", value: 6 },
+        { name: "576i", value: 7 },
+        { name: "480p", value: 8 },
+        { name: "480i", value: 9 },
+        { name: "Other", value: 10 },
+      ],
+      cross: { mode: "brackets" },
+    },
+    CategoryFree,
+  ],
+
+  search: {
+    ...SchemaMetadata.search,
+    skipNonLatinCharacters: true,
+    selectors: {
+      ...SchemaMetadata.search!.selectors,
+      category: {
+        selector: ":self",
+        data: "categoryId",
+        filters: [(query: string) => categoryMap[Number(query)]],
+      },
+      subTitle: {
+        selector: "span.torrent-quality-score__value",
+        filters: [{ name: "prepend", args: ["Quality Score: "] }],
+      },
+      tags: [
+        ...SchemaMetadata.search!.selectors!.tags!,
+        {
+          name: "H&R",
+          selector: "*",
+          color: "red",
+        },
+      ],
+    },
+  },
+
+  levelRequirements: [
+    {
+      id: 0,
+      name: "Leech",
+      privilege: "上传种子 0下载槽",
+    },
+    {
+      id: 1,
+      name: "User",
+      privilege: "上传种子 3下载槽",
+    },
+    {
+      id: 2,
+      name: "Member",
+      interval: "P2W",
+      ratio: 0.6,
+      uploaded: "500GiB",
+      privilege: "上传种子 5下载槽 发送邀请",
+    },
+    {
+      id: 3,
+      name: "Seeder",
+      interval: "P1M",
+      averageSeedingTime: "P1M",
+      ratio: 0.8,
+      uploaded: "5TiB",
+      seedingSize: "5TiB",
+      privilege: "上传种子 10下载槽 发送邀请 自动通过候选",
+    },
+    {
+      id: 4,
+      name: "Power User",
+      interval: "P1M",
+      ratio: 0.8,
+      uploaded: "5TiB",
+      uploads: 10,
+      privilege: "上传种子 10下载槽 发送邀请 自动通过候选",
+    },
+    {
+      id: 5,
+      name: "Archivist",
+      interval: "P3M",
+      averageSeedingTime: "P2M",
+      ratio: 1,
+      uploaded: "10TiB",
+      seedingSize: "10TiB",
+      privilege: "上传种子 25下载槽 发送邀请 自动通过候选 访问邀请区 站免 免疫HR",
+    },
+    {
+      id: 6,
+      name: "Elite",
+      interval: "P3M",
+      ratio: 1,
+      uploaded: "10TiB",
+      uploads: 50,
+      privilege: "上传种子 25下载槽 发送邀请 自动通过候选 访问邀请区 站免 免疫HR",
+    },
+    {
+      id: 7,
+      name: "DataHoarder",
+      interval: "P6M",
+      averageSeedingTime: "P3M",
+      ratio: 1,
+      uploaded: "25TiB",
+      seedingSize: "20TiB",
+      privilege: "上传种子 50下载槽 发送邀请 自动通过候选 访问邀请区 站免 免疫HR 双倍上传",
+    },
+    {
+      id: 8,
+      name: "Torrent Master",
+      interval: "P6M",
+      ratio: 1,
+      uploaded: "25TiB",
+      uploads: 100,
+      privilege: "上传种子 50下载槽 发送邀请 自动通过候选 访问邀请区 站免 免疫HR 双倍上传",
+    },
+    {
+      id: 9,
+      name: "Elite Torrent Master",
+      interval: "P1Y",
+      averageSeedingTime: "P3M",
+      ratio: 1,
+      uploaded: "50TiB",
+      seedingSize: "20TiB",
+      uploads: 100,
+      privilege: "上传种子 100下载槽 发送邀请 自动通过候选 访问邀请区 站免 免疫HR 双倍上传",
+    },
+    {
+      id: 10,
+      name: "Luminal",
+      groupType: "vip",
+      privilege: "上传种子 100下载槽 发送邀请 自动通过候选 访问邀请区 站免 免疫HR 双倍上传",
+    },
+  ],
+};

--- a/src/packages/site/definitions/mooko.ts
+++ b/src/packages/site/definitions/mooko.ts
@@ -203,7 +203,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       name: "note",
       label: "点我（不需要填）",
-      hint: "需要将 搜索结果显示 改为 列表视图 才能正常使用搜索功能！如果需要搜索剧集，需要启用 剧集 搜索入口！",
+      hint: "需要将『搜索结果显示』改为『列表视图』才能正常使用搜索功能！如果需要搜索剧集，需要启用『剧集』搜索入口！",
       required: false,
     },
   ],

--- a/src/packages/site/definitions/onlyencodes.ts
+++ b/src/packages/site/definitions/onlyencodes.ts
@@ -1,10 +1,11 @@
 import type { ISiteMetadata } from "../types";
-import { SchemaMetadata } from "../schemas/Unit3D.ts";
+import { CategoryFree, SchemaMetadata } from "../schemas/Unit3D.ts";
+import { buildCategoryOptionsFromDict } from "../utils.ts";
 
-const categoryOptions = [
-  { name: "Movie", value: 1 },
-  { name: "TV Show", value: 2 },
-];
+const categoryMap: Record<number, string> = {
+  1: "Movie",
+  2: "TV Show",
+};
 
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,
@@ -25,7 +26,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       name: "类别",
       key: "categoryIds",
-      options: categoryOptions,
+      options: buildCategoryOptionsFromDict(categoryMap),
       cross: { mode: "brackets" },
     },
     {
@@ -59,32 +60,7 @@ export const siteMetadata: ISiteMetadata = {
       ],
       cross: { mode: "brackets" },
     },
-    {
-      name: "Buff",
-      key: "free",
-      options: [
-        { name: "0% Freeleech", value: 0 },
-        { name: "25% Free", value: 25 },
-        { name: "50% Free", value: 50 },
-        { name: "75% Free", value: 75 },
-        { name: "100% Free", value: 100 },
-        { name: "双倍上传", value: "doubleup" },
-        { name: "精选", value: "featured" },
-        { name: "Refundable", value: "refundable" },
-      ],
-      cross: { mode: "custom" },
-      generateRequestConfig: (selectedOptions) => {
-        const params: Record<string, any> = { free: [] };
-        (selectedOptions as Array<number | string>).forEach((value) => {
-          if (value === "doubleup" || value === "featured" || value === "refundable") {
-            params[value] = 1;
-          } else {
-            params.free.push(value);
-          }
-        });
-        return { requestConfig: { params } };
-      },
-    },
+    CategoryFree,
   ],
 
   search: {
@@ -95,7 +71,7 @@ export const siteMetadata: ISiteMetadata = {
       category: {
         selector: ":self",
         data: "categoryId",
-        filters: [(catID: number) => categoryOptions.find((cat) => cat.value == catID)?.name ?? ""],
+        filters: [(query: string) => categoryMap[Number(query)]],
       },
       tags: [
         ...SchemaMetadata.search!.selectors!.tags!,

--- a/src/packages/site/definitions/reelflix.ts
+++ b/src/packages/site/definitions/reelflix.ts
@@ -1,5 +1,5 @@
-import type { ISiteMetadata, ITorrent, ITorrentTag, ISearchInput } from "../types";
-import Unit3D, { SchemaMetadata } from "../schemas/Unit3D.ts";
+import type { ISiteMetadata } from "../types";
+import { CategoryFree, SchemaMetadata } from "../schemas/Unit3D.ts";
 
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,
@@ -47,32 +47,7 @@ export const siteMetadata: ISiteMetadata = {
       ],
       cross: { mode: "brackets" },
     },
-    {
-      name: "Buff",
-      key: "free",
-      options: [
-        { name: "0% Freeleech", value: 0 },
-        { name: "25% Free", value: 25 },
-        { name: "50% Free", value: 50 },
-        { name: "75% Free", value: 75 },
-        { name: "100% Free", value: 100 },
-        { name: "双倍上传", value: "doubleup" },
-        { name: "精选", value: "featured" },
-        { name: "Refundable", value: "refundable" },
-      ],
-      cross: { mode: "custom" },
-      generateRequestConfig: (selectedOptions) => {
-        const params: Record<string, any> = { free: [] };
-        (selectedOptions as Array<number | string>).forEach((value) => {
-          if (value === "doubleup" || value === "featured" || value === "refundable") {
-            params[value] = 1;
-          } else {
-            params.free.push(value);
-          }
-        });
-        return { requestConfig: { params } };
-      },
-    },
+    CategoryFree,
   ],
 
   levelRequirements: [

--- a/src/packages/site/definitions/seedpool.ts
+++ b/src/packages/site/definitions/seedpool.ts
@@ -1,22 +1,23 @@
 import { type ISiteMetadata } from "../types";
-import { SchemaMetadata } from "../schemas/Unit3D.ts";
+import { CategoryFree, SchemaMetadata } from "../schemas/Unit3D.ts";
+import { buildCategoryOptionsFromDict } from "../utils.ts";
 
 const seedingSizeTrans: string[] = ["Seedpool"];
 
-const categoryOptions = [
-  { name: "TV Show", value: 2 },
-  { name: "Movie", value: 1 },
-  { name: "Anime", value: 6 },
-  { name: "Sports", value: 8 },
-  { name: "Music", value: 5 },
-  { name: "Audiobook", value: 9 },
-  { name: "E-Book", value: 7 },
-  { name: "Hobby", value: 12 },
-  { name: "Software", value: 16 },
-  { name: "Game", value: 3 },
-  { name: "Music Production", value: 21 },
-  { name: "Other", value: 11 },
-];
+const categoryMap: Record<number, string> = {
+  2: "TV Show",
+  1: "Movie",
+  6: "Anime",
+  8: "Sports",
+  5: "Music",
+  9: "Audiobook",
+  7: "E-Book",
+  12: "Hobby",
+  16: "Software",
+  3: "Game",
+  21: "Music Production",
+  11: "Other",
+};
 
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,
@@ -120,7 +121,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       name: "类别",
       key: "categoryIds",
-      options: categoryOptions,
+      options: buildCategoryOptionsFromDict(categoryMap),
       cross: { mode: "brackets" },
     },
     {
@@ -181,32 +182,7 @@ export const siteMetadata: ISiteMetadata = {
       ],
       cross: { mode: "brackets" },
     },
-    {
-      name: "Buff",
-      key: "free",
-      options: [
-        { name: "0% Freeleech", value: 0 },
-        { name: "25% Free", value: 25 },
-        { name: "50% Free", value: 50 },
-        { name: "75% Free", value: 75 },
-        { name: "100% Free", value: 100 },
-        { name: "双倍上传", value: "doubleup" },
-        { name: "精选", value: "featured" },
-        { name: "Refundable", value: "refundable" },
-      ],
-      cross: { mode: "custom" },
-      generateRequestConfig: (selectedOptions) => {
-        const params: Record<string, any> = { free: [] };
-        (selectedOptions as Array<number | string>).forEach((value) => {
-          if (value === "doubleup" || value === "featured" || value === "refundable") {
-            params[value] = 1;
-          } else {
-            params.free.push(value);
-          }
-        });
-        return { requestConfig: { params } };
-      },
-    },
+    CategoryFree,
   ],
 
   search: {
@@ -217,7 +193,7 @@ export const siteMetadata: ISiteMetadata = {
       category: {
         selector: ":self",
         data: "categoryId",
-        filters: [(catID: number) => categoryOptions.find((cat) => cat.value == catID)?.name ?? ""],
+        filters: [(query: string) => categoryMap[Number(query)]],
       },
       tags: [
         ...SchemaMetadata.search!.selectors!.tags!,

--- a/src/packages/site/definitions/uploadcx.ts
+++ b/src/packages/site/definitions/uploadcx.ts
@@ -1,10 +1,11 @@
 import { type ISiteMetadata } from "../types";
-import { SchemaMetadata } from "../schemas/Unit3D.ts";
+import { CategoryFree, SchemaMetadata } from "../schemas/Unit3D.ts";
+import { buildCategoryOptionsFromDict } from "../utils.ts";
 
-const categoryOptions = [
-  { name: "Movies", value: 1 },
-  { name: "TV", value: 2 },
-];
+const categoryMap: Record<number, string> = {
+  1: "Movies",
+  2: "TV",
+};
 
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,
@@ -24,7 +25,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       name: "类别",
       key: "categoryIds",
-      options: categoryOptions,
+      options: buildCategoryOptionsFromDict(categoryMap),
       cross: { mode: "brackets" },
     },
     {
@@ -57,32 +58,7 @@ export const siteMetadata: ISiteMetadata = {
       ],
       cross: { mode: "brackets" },
     },
-    {
-      name: "Buff",
-      key: "free",
-      options: [
-        { name: "0% Freeleech", value: 0 },
-        { name: "25% Free", value: 25 },
-        { name: "50% Free", value: 50 },
-        { name: "75% Free", value: 75 },
-        { name: "100% Free", value: 100 },
-        { name: "双倍上传", value: "doubleup" },
-        { name: "精选", value: "featured" },
-        { name: "Refundable", value: "refundable" },
-      ],
-      cross: { mode: "custom" },
-      generateRequestConfig: (selectedOptions) => {
-        const params: Record<string, any> = { free: [] };
-        (selectedOptions as Array<number | string>).forEach((value) => {
-          if (value === "doubleup" || value === "featured" || value === "refundable") {
-            params[value] = 1;
-          } else {
-            params.free.push(value);
-          }
-        });
-        return { requestConfig: { params } };
-      },
-    },
+    CategoryFree,
   ],
 
   search: {
@@ -93,7 +69,7 @@ export const siteMetadata: ISiteMetadata = {
       category: {
         selector: ":self",
         data: "categoryId",
-        filters: [(catID: number) => categoryOptions.find((cat) => cat.value == catID)?.name ?? ""],
+        filters: [(query: string) => categoryMap[Number(query)]],
       },
       tags: [
         ...SchemaMetadata.search!.selectors!.tags!,

--- a/src/packages/site/schemas/Unit3D.ts
+++ b/src/packages/site/schemas/Unit3D.ts
@@ -11,6 +11,7 @@ import {
   type ITorrent,
   type ISearchInput,
   type ITorrentTag,
+  type ISearchCategories,
 } from "../types";
 import { parseTimeToLiveToDate, parseValidTimeString } from "../utils";
 
@@ -25,6 +26,33 @@ const averageSeedingTimeTrans: string[] = ["Average Seedtime", "Average seedtime
 const invitesTrans: string[] = ["Invites", "邀请", "邀請"];
 const ratioTrans: string[] = ["Ratio", "分享率", "比率"];
 const trueRatioTrans: string[] = ["Real Ratio", "真实分享率", "真實比率"];
+
+export const CategoryFree: ISearchCategories = {
+  name: "Buff",
+  key: "free",
+  options: [
+    { name: "0% Freeleech", value: 0 },
+    { name: "25% Free", value: 25 },
+    { name: "50% Free", value: 50 },
+    { name: "75% Free", value: 75 },
+    { name: "100% Free", value: 100 },
+    { name: "双倍上传", value: "doubleup" },
+    { name: "精选", value: "featured" },
+    { name: "Refundable", value: "refundable" },
+  ],
+  cross: { mode: "custom" },
+  generateRequestConfig: (selectedOptions) => {
+    const params: Record<string, any> = { free: [] };
+    (selectedOptions as Array<number | string>).forEach((value) => {
+      if (value === "doubleup" || value === "featured" || value === "refundable") {
+        params[value] = 1;
+      } else {
+        params.free.push(value);
+      }
+    });
+    return { requestConfig: { params } };
+  },
+};
 
 export const SchemaMetadata: Partial<ISiteMetadata> = {
   version: 0,


### PR DESCRIPTION
## Summary by Sourcery

Add Luminarr tracker support and centralize shared Unit3D search category behavior.

New Features:
- Introduce Luminarr (LUME) Unit3D-based site definition with categories, search configuration, and level requirements.

Enhancements:
- Extract common freeleech/buff search category into a reusable Unit3D CategoryFree helper and apply it across multiple site definitions.
- Refactor several Unit3D-based site definitions to use category ID/name maps and shared category option builders for both search filters and result parsing.
- Tweak mooko site hint text wording and punctuation for clarity.
- Add explicit search category mapping for fearnopeer and aither to properly resolve category names from IDs.