### PR TITLE
feat(pkg/site): hdb uploads

### DIFF
--- a/src/packages/site/definitions/beyondhd.ts
+++ b/src/packages/site/definitions/beyondhd.ts
@@ -264,7 +264,7 @@ export const siteMetadata: ISiteMetadata = {
       },
       uploads: {
         selector: [".button-right .bhd-block:nth-child(1) .class-highlight"],
-        filters: [(text) => text.match(/\d+/)?.[0] ?? ""],
+        filters: [(text) => text.replace(/,/g, "").match(/\d+/)?.[0] ?? ""],
       },
       leeching: {
         selector: [".button-right .bhd-block:nth-child(2) .bhd-tidbit-icon"],

--- a/src/packages/site/definitions/hdbits.ts
+++ b/src/packages/site/definitions/hdbits.ts
@@ -258,6 +258,10 @@ export const siteMetadata: ISiteMetadata = {
             selector: ["td.rowhead:contains('Seeding size') + td"],
             filters: [{ name: "parseSize" }],
           },
+          uploads: {
+            selector: ["td.heading:contains('Uploaded'):contains('torrents') + td"],
+            filters: [{ name: "replace", args: ["-", ""] }, { name: "parseNumber" }],
+          },
         },
       },
     ],


### PR DESCRIPTION
## Summary by Sourcery

Add upload statistics parsing for HDBits and improve BeyondHD upload count extraction.

New Features:
- Extract user upload torrent counts from HDBits profile pages.

Bug Fixes:
- Handle comma-separated numbers when parsing BeyondHD upload counts to avoid mis-reading values.