### PR TITLE
fix(pkg/site/byrbt): 修复用户名特效引起的 id 与用户名获取错误

### DIFF
--- a/src/packages/site/definitions/byrbt.ts
+++ b/src/packages/site/definitions/byrbt.ts
@@ -108,6 +108,9 @@ export const siteMetadata: ISiteMetadata = {
         attr: "href",
         filters: [{ name: "querystring", args: ["id"] }],
       },
+      name: {
+        selector: ["a[href*='userdetails.php']:first"],
+      },
       messageCount: {
         text: 0,
         selector: "#msg-bar a[href*='messages.php'] strong",


### PR DESCRIPTION
Close  #1023  

在 BYRBT 魔力值系统的商店中购买任意用户名特效后，用户名 DOM 元素会由
```html
<a class="XXXXX_Name" href="/userdetails.php?id=XXXXX"><span style="font-weight: bold">XXXXX</span></a>
```
变为
```html
<a class="text-gradient text-gradient-animated text-nature" href="/userdetails.php?id=XXXXX"><span style="font-weight: bold">XXXXX</span></a>
```
导致使用 NexusPHP 的通用 schema 匹配时 id 会被错误地匹配到主页上其他用户 id（通常为竞价置顶列表中第一个非匿名用户的 id），用户名也会匹配为该 id 对应的用户名，因此需要定制 selector 以修复该问题；当 id 成功获取后，用户名仍会因相同的原因导致错误地匹配到个人信息页上的其他用户的用户名（通常为邀请人用户名），因此同样需要定制 selector

## Summary by Sourcery

Adjust BYRBT user info parsing to correctly extract the current user’s id and username when username visual effects change the DOM structure.

Bug Fixes:
- Fix incorrect user id extraction on BYRBT caused by generic NexusPHP selectors matching other users’ profile links.
- Fix incorrect username extraction on BYRBT by using a dedicated selector for the current user’s profile link.