### PR TITLE
fix(pkg/site/chdbits): 适配 chdbits H&R 数据获取

### DIFF
--- a/src/packages/site/definitions/chdbits.ts
+++ b/src/packages/site/definitions/chdbits.ts
@@ -200,7 +200,20 @@ export const siteMetadata: ISiteMetadata = {
       },
     },
   },
-
+  userInfo: {
+    ...SchemaMetadata.userInfo!,
+    selectors: {
+      ...SchemaMetadata.userInfo!.selectors!,
+      hnrPreWarning: {
+        text: 0,
+        selector: ["#info_block a[href*='hnr.php']"],
+        elementProcess: (e: HTMLElement) => {
+          const text = e.nextSibling?.textContent?.trim();
+          return text ? parseInt(text) : 0;
+        },
+      },
+    },
+  },
   levelRequirements: [
     {
       id: 1,


### PR DESCRIPTION
添加 chdbits 站点的 hnrPreWarning 的 selector，以解决#915

## Summary by Sourcery

Bug Fixes:
- Fix H&R pre-warning value extraction for chdbits by adding the appropriate user info selector.