### PR TITLE
fix(pkg/site/asiancinema): re-implement using standard Unit3D template

### DIFF
--- a/src/packages/site/definitions/asiancinema.ts
+++ b/src/packages/site/definitions/asiancinema.ts
@@ -1,12 +1,19 @@
 /**
  * @JackettDefinitions https://github.com/Jackett/Jackett/blob/master/src/Jackett.Common/Definitions/asiancinema.yml
  */
-import Unit3D, { SchemaMetadata } from "../schemas/Unit3D.ts";
+import { SchemaMetadata, CategoryFree } from "../schemas/Unit3D.ts";
 import { type ISiteMetadata } from "../types";
+import { buildCategoryOptionsFromDict } from "../utils.ts";
+
+const categoryMap: Record<number, string> = {
+  1: "Movies",
+  2: "TV",
+  3: "Music",
+};
 
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,
-  version: 1,
+  version: 2,
   id: "asiancinema",
   name: "AsianCinema",
   aka: ["ACM"],
@@ -20,40 +27,54 @@ export const siteMetadata: ISiteMetadata = {
   urls: ["uggcf://rvtn.zbv/"],
   legacyUrls: ["uggcf://nfvnapvarzn.zr/"],
 
-  userInfo: {
-    selectors: {
-      ...SchemaMetadata.userInfo!.selectors,
-      bonusPerHour: {
-        selector: ["div.text-orange > h2 > strong"],
-        filters: [{ name: "parseNumber" }],
-      },
+  category: [
+    {
+      name: "类别",
+      key: "categoryIds",
+      options: buildCategoryOptionsFromDict(categoryMap),
+      cross: { mode: "brackets" },
     },
-  },
+    {
+      name: "规格",
+      key: "typeIds",
+      options: [
+        { name: "Full Disc", value: 1 },
+        { name: "Remux", value: 7 },
+        { name: "WEB-DL", value: 9 },
+        { name: "HDTV", value: 17 },
+        { name: "UHDTV", value: 19 },
+        { name: "SDTV", value: 13 },
+        { name: "FLAC", value: 15 },
+      ],
+      cross: { mode: "brackets" },
+    },
+    {
+      name: "分辨率",
+      key: "resolutionIds",
+      options: [
+        { name: "2160p", value: 1 },
+        { name: "1080i/p", value: 2 },
+        { name: "720p", value: 3 },
+        { name: "576i/p", value: 4 },
+        { name: "480i/p", value: 5 },
+        { name: "Other", value: 6 },
+      ],
+      cross: { mode: "brackets" },
+    },
+    CategoryFree,
+  ],
 
   search: {
     ...SchemaMetadata.search,
-    keywordPath: "params.search",
-    requestConfig: {
-      url: "/torrents/filter",
-      responseType: "document",
-      params: {
-        view: "list", // 强制使用 种子列表 的形式返回
-      },
-    },
-    advanceKeywordParams: {
-      imdb: {
-        requestConfigTransformer: ({ requestConfig: config }) => {
-          if (config?.params?.search) {
-            config.params.imdb = config.params.search;
-            delete config.params.search;
-          }
-          return config!;
-        },
-      },
-    },
     selectors: {
-      ...SchemaMetadata.search?.selectors,
+      ...SchemaMetadata.search!.selectors,
+      category: {
+        selector: ":self",
+        data: "categoryId",
+        filters: [(query: string) => categoryMap[Number(query)]],
+      },
       tags: [
+        ...SchemaMetadata.search!.selectors!.tags!,
         {
           name: "H&R",
           selector: "*",
@@ -66,81 +87,80 @@ export const siteMetadata: ISiteMetadata = {
   levelRequirements: [
     {
       id: 0,
-      name: "User",
-      uploaded: "1TB",
-      ratio: 1.0,
-      privilege: "",
+      name: "Leech",
     },
     {
       id: 1,
-      name: "Power User",
-      uploaded: "1TB",
-      interval: "P1M",
-      ratio: 1.0,
-      privilege: "",
+      name: "User",
+      ratio: 0.4,
+      privilege: "4 download slots",
     },
     {
       id: 2,
-      name: "Super User",
-      uploaded: "5TB",
-      interval: "P2M",
-      ratio: 1.0,
-      privilege: "",
+      name: "Power User",
+      uploaded: "1TB",
+      interval: "P1M",
+      ratio: 0.4,
+      uploads: 1,
+      privilege: "10 download slots",
     },
     {
       id: 3,
-      name: "Extreme User",
-      uploaded: "20TB",
-      interval: "P3M",
-      ratio: 1.0,
-      privilege: "Trusted member",
+      name: "Super User",
+      uploaded: "5TB",
+      interval: "P2M",
+      ratio: 0.4,
+      uploads: 5,
+      privilege: "25 download slots",
     },
     {
       id: 4,
-      name: "Insane User",
-      uploaded: "50TB",
-      interval: "P6M",
-      ratio: 1.0,
-      privilege: "Trusted member",
+      name: "Extreme User",
+      uploaded: "20TB",
+      interval: "P3M",
+      ratio: 0.4,
+      uploads: 10,
+      privilege: "50 download slots; Trusted member",
     },
     {
       id: 5,
-      name: "Veteran",
-      uploaded: "100TB",
-      interval: "P1Y",
-      ratio: 1.0,
-      privilege: "Special freeleech",
+      name: "Insane User",
+      uploaded: "50TB",
+      interval: "P6M",
+      ratio: 0.4,
+      uploads: 15,
+      privilege: "50 download slots; Trusted member",
     },
     {
       id: 6,
-      name: "Seeder",
-      seedingSize: "5TB",
-      interval: "P1M",
-      averageSeedingTime: "P30D",
-      ratio: 1.0,
-      privilege: "Trusted member",
+      name: "Veteran",
+      uploaded: "100TB",
+      interval: "P1Y",
+      ratio: 0.4,
+      uploads: 20,
+      privilege: "Special freeleech",
     },
     {
       id: 7,
+      name: "Seeder",
+      uploaded: "200TB",
+      seedingSize: "20TB",
+      interval: "P1M",
+      averageSeedingTime: "P1M",
+      ratio: 1.5,
+      uploads: 5,
+      privilege: "Trusted member",
+    },
+    {
+      id: 8,
       name: "Archivist",
-      seedingSize: "10TB",
-      interval: "P6M",
-      averageSeedingTime: "P60D",
-      ratio: 1.0,
+      uploaded: "400TB",
+      seedingSize: "40TB",
+      interval: "P3M",
+      averageSeedingTime: "P2M",
+      ratio: 1.5,
+      uploads: 10,
       privilege: "Immunity from H&Rs & Special freeleech",
     },
   ],
 };
-
-export default class AsianCinema extends Unit3D {
-  protected override async getUserBonusPerHour(): Promise<number> {
-    const { data: document } = await this.request<Document>(
-      {
-        url: `/bonus`,
-        responseType: "document",
-      },
-      true,
-    );
-    return this.getFieldData(document, this.metadata.userInfo?.selectors?.bonusPerHour!);
-  }
-}

--- a/src/packages/site/schemas/Unit3D.ts
+++ b/src/packages/site/schemas/Unit3D.ts
@@ -184,6 +184,7 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
       // /resources/views/torrent/results.blade.php#L213-L219
       comments: {
         selector: ['a[href*="#comments"]', "i.torrent-icons__comments"],
+        filters: [{ name: "parseNumber" }], // 空值返回 0
       },
 
       status: {


### PR DESCRIPTION
site uses standard Unit3D layout currently

## Summary by Sourcery

Rework the AsianCinema site definition to rely on the shared Unit3D schema while updating categories, search metadata, and user level requirements.

New Features:
- Define structured torrent category, type, resolution, and freeleech filters for AsianCinema using the shared Unit3D category utilities.

Bug Fixes:
- Fix AsianCinema search result category parsing by mapping backend category IDs to human-readable names and ensuring comment counts are correctly parsed as numbers.

Enhancements:
- Align AsianCinema metadata with the standard Unit3D template, including updated site versioning and revised user level requirements with clearer privileges and thresholds.
- Enhance the common Unit3D schema to always parse torrent comment counts as numeric values.