### PR TITLE
feat(pkg/site): add lastAccessAt selectors for various sites

### DIFF
--- a/src/packages/site/definitions/digitalcore.ts
+++ b/src/packages/site/definitions/digitalcore.ts
@@ -255,7 +255,8 @@ export const siteMetadata: ISiteMetadata = {
         },
         assertion: { id: "url" },
         selectors: {
-          joinTime: { selector: "added" },
+          joinTime: { selector: "added", filters: [{ name: "parseTime" }] },
+          lastAccessAt: { selector: "last_access", filters: [{ name: "parseTime" }] },
           downloaded: { selector: "downloaded" },
           trueDownloaded: { selector: "downloaded_real" },
           uploaded: { selector: "uploaded" },

--- a/src/packages/site/definitions/fearnopeer.ts
+++ b/src/packages/site/definitions/fearnopeer.ts
@@ -211,6 +211,10 @@ export const siteMetadata: ISiteMetadata = {
         ...SchemaMetadata.userInfo!.selectors!.joinTime!,
         selector: "span.profile-hero-2026__meta-item:contains('Registration date')",
       },
+      lastAccessAt: {
+        selector: "span.profile-hero-2026__meta-item:contains('Last login') > strong",
+        filters: [{ name: "parseTTL" }],
+      },
       invites: {
         selector: "span.profile-hero-2026__info-label:contains('Invites') + span",
         filters: [{ name: "parseNumber" }],

--- a/src/packages/site/definitions/filelist.ts
+++ b/src/packages/site/definitions/filelist.ts
@@ -207,6 +207,15 @@ export const siteMetadata: ISiteMetadata = {
               },
             ],
           },
+          lastAccessAt: {
+            selector: ["td:contains('Last'):contains('seen') + td"],
+            filters: [
+              (query: string) => {
+                query = query.split(" (")[0];
+                return parseValidTimeString(query);
+              },
+            ],
+          },
           seeding: {
             selector: ["td:contains('Seed'):contains('bonus') + td > div:first"],
             filters: [

--- a/src/packages/site/definitions/gazellegames.ts
+++ b/src/packages/site/definitions/gazellegames.ts
@@ -360,6 +360,7 @@ export default class GazelleGames extends GazelleJSONAPI {
       "bonusPerHour",
       "seedingSize",
       "seedingBonus",
+      "lastAccessAt",
     ] as (keyof Partial<IUserInfo>)[]) as Partial<IUserInfo>;
   }
 }

--- a/src/packages/site/definitions/hdtorrents.ts
+++ b/src/packages/site/definitions/hdtorrents.ts
@@ -227,6 +227,10 @@ export const siteMetadata: ISiteMetadata = {
             selector: "td.header:contains('Joined on') + td",
             filters: [{ name: "parseTime", args: ["dd/MM/yyyy HH:mm:ss"] }],
           },
+          lastAccessAt: {
+            selector: "td.header:contains('Last access') + td",
+            filters: [{ name: "parseTime", args: ["dd/MM/yyyy HH:mm:ss"] }],
+          },
           seeding: { selector: "td.nav[title='Active-Torrents'] > a[href*='#actives'] > span" },
           seedingSize: {
             selector: "td.header:contains('Total Size of torrents') + td",

--- a/src/packages/site/definitions/lst.ts
+++ b/src/packages/site/definitions/lst.ts
@@ -169,6 +169,10 @@ export const siteMetadata: ISiteMetadata = {
         ...SchemaMetadata.userInfo!.selectors!.joinTime!,
         selector: "span.profile-hero__meta-item:contains('Registration date')",
       },
+      lastAccessAt: {
+        selector: "span.profile-hero__meta-item:contains('Last login')",
+        filters: [{ name: "split", args: [":", 1] }, { name: "trim" }, { name: "parseTTL" }],
+      },
       seedingSize: {
         selector: "div.profile-mini-stat__label:contains('Seeding size') + div",
         filters: [{ name: "parseSize" }],

--- a/src/packages/site/definitions/monikadesign.ts
+++ b/src/packages/site/definitions/monikadesign.ts
@@ -248,14 +248,6 @@ export const siteMetadata: ISiteMetadata = {
         selector: ["aside .panelV2 dd:nth-child(6)"],
         filters: [{ name: "parseNumber" }],
       },
-      lastAccessAt: {
-        selector: ["div.block td:contains('上次登录时间') +td"],
-        filters: [
-          (query: string) => {
-            return +new Date(query.split("(")[0]);
-          },
-        ],
-      },
     },
   },
 

--- a/src/packages/site/definitions/speedapp.ts
+++ b/src/packages/site/definitions/speedapp.ts
@@ -9,6 +9,7 @@ const averageSeedingTimeTrans: string[] = ["Average seed time", "平均种子时
 const uploadedTrans: string[] = ["Uploaded", "已上传"];
 const downloadedTrans: string[] = ["Downloaded", "已下载"];
 const ratioTrans: string[] = ["Ratio", "分享率", "比率"];
+const lastAccessAtTrans: string[] = ["Last access", "上次访问"];
 
 const categoryMapXXX: Record<number, string> = {
   15: "XXX Movies",
@@ -401,11 +402,11 @@ export const siteMetadata: ISiteMetadata = {
           },
           joinTime: {
             selector: joinTimeTrans.map((x) => `dt:contains('${x}') + dd`),
-            filters: [
-              { name: "replace", args: [/日/g, " "] },
-              { name: "replace", args: [/[年月]/g, "-"] },
-              { name: "parseTime" },
-            ],
+            filters: [{ name: "parseTime", args: ["yyyy年M月d日 HH:mm:ss"] }],
+          },
+          lastAccessAt: {
+            selector: lastAccessAtTrans.map((x) => `dt:contains('${x}') + dd`),
+            filters: [{ name: "parseTime", args: ["yyyy年M月d日 HH:mm:ss"] }],
           },
           seedingSize: {
             selector: bonusTrans.map((x) => `dt:contains('${x}') + dd > b:nth-of-type(2)`),
@@ -433,7 +434,15 @@ export const siteMetadata: ISiteMetadata = {
           },
           averageSeedingTime: {
             selector: averageSeedingTimeTrans.map((x) => `a[href='/snatch/seeding'][title='${x}']`),
-            filters: [{ name: "parseDuration" }],
+            filters: [{ name: "replace", args: ["个", ""] }, { name: "parseDuration" }],
+          },
+          hnrUnsatisfied: {
+            selector: "a[href='/snatch/need-seed']",
+            filters: [{ name: "parseNumber" }],
+          },
+          hnrPreWarning: {
+            selector: "a[href='/snatch/hit-and-run']",
+            filters: [{ name: "parseNumber" }],
           },
         },
       },
@@ -444,10 +453,12 @@ export const siteMetadata: ISiteMetadata = {
     {
       id: 1,
       name: "Peasant",
+      nameAka: ["农民"],
     },
     {
       id: 2,
       name: "User",
+      nameAka: ["用户"],
       interval: "P30D",
       uploaded: "25GB",
       ratio: 1.05,
@@ -456,6 +467,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       id: 3,
       name: "Power User",
+      // nameAka: ["超级用户"],
       interval: "P90D",
       uploaded: "200GB",
       ratio: 2,
@@ -464,6 +476,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       id: 4,
       name: "Elite User",
+      nameAka: ["精英用户"],
       interval: "P180D",
       uploaded: "1TB",
       ratio: 3,
@@ -472,6 +485,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       id: 5,
       name: "Xtreme User",
+      nameAka: ["极端用户"],
       interval: "P12M",
       uploaded: "5TB",
       ratio: 4,
@@ -480,6 +494,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       id: 6,
       name: "Super User",
+      // nameAka: ["超级用户"],
       interval: "P2Y",
       uploaded: "20TB",
       ratio: 5,
@@ -488,6 +503,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       id: 7,
       name: "Legend User",
+      nameAka: ["传奇用户"],
       interval: "P6Y",
       uploaded: "100TB",
       ratio: 6,
@@ -496,6 +512,7 @@ export const siteMetadata: ISiteMetadata = {
     {
       id: 8,
       name: "VIP",
+      nameAka: ["贵宾"],
       groupType: "vip",
       privilege: "Same privileges as Elite User, immune to automated HnR warnings.",
     },

--- a/src/packages/site/definitions/sportscult.ts
+++ b/src/packages/site/definitions/sportscult.ts
@@ -252,6 +252,10 @@ export const siteMetadata: ISiteMetadata = {
             selector: "td.header:contains('Joined on') + td",
             filters: [{ name: "parseTime", args: ["dd/MM/yyyy HH:mm:ss"] }],
           },
+          lastAccessAt: {
+            selector: "td.header:contains('Last access') + td",
+            filters: [{ name: "parseTime", args: ["dd/MM/yyyy HH:mm:ss"] }],
+          },
           // FIXME 暂未实现 uploads
         },
       },

--- a/src/packages/site/schemas/TCG.ts
+++ b/src/packages/site/schemas/TCG.ts
@@ -82,6 +82,10 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
               { name: "parseTime" },
             ],
           },
+          lastAccessAt: {
+            selector: ".embedded td:contains('Last seen') + td:first",
+            filters: [{ name: "split", args: ["(", 0] }, { name: "trim" }, { name: "parseTime" }],
+          },
           messageCount: {
             selector: "a[href='message.php?action=viewmailbox'] + b",
             filters: [{ name: "parseNumber" }],

--- a/src/packages/site/schemas/Unit3D.ts
+++ b/src/packages/site/schemas/Unit3D.ts
@@ -26,6 +26,7 @@ const averageSeedingTimeTrans: string[] = ["Average Seedtime", "Average seedtime
 const invitesTrans: string[] = ["Invites", "邀请", "邀請"];
 const ratioTrans: string[] = ["Ratio", "分享率", "比率"];
 const trueRatioTrans: string[] = ["Real Ratio", "真实分享率", "真實比率"];
+const lastAccessAtTrans: string[] = ["Last login", "Last Login", "上次登录时间", "上次登入"];
 
 export const CategoryFree: ISearchCategories = {
   name: "Buff",
@@ -466,6 +467,16 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
             return parseValidTimeString(query, ["MMM dd yyyy, HH:mm:ss", "MMM dd yyyy", "yyyy-MM-dd"]);
           },
         ],
+      },
+      lastAccessAt: {
+        selector: [
+          ...lastAccessAtTrans.map((x) => `dt:contains('${x}') + dd time`),
+          ...lastAccessAtTrans.map((x) => `td:contains('${x}') + td`),
+        ],
+        elementProcess: (el: Element) => {
+          const dateStr = el.getAttribute("title") ?? el.getAttribute("datetime");
+          return parseValidTimeString(dateStr || el.textContent.split("(")[0]);
+        },
       },
       invites: {
         selector: [


### PR DESCRIPTION
## Summary by Sourcery

Add and standardize last access time parsing across multiple tracker site definitions and schemas while reusing shared time parsing helpers.

New Features:
- Expose lastAccessAt in user info for multiple sites including HD-Space, SpeedApp, Unit3D-based trackers, FileList, FearNoPeer, HD-Torrents, LST, Sportscult, TCG, DigitalCore, and GazelleGames.
- Add hit-and-run related metrics (hnrUnsatisfied and hnrPreWarning) to SpeedApp user info.

Bug Fixes:
- Align last access/login selectors to robustly handle different DOM structures and localized labels, including replacing a brittle implementation for MonikaDesign and adding missing last seen selectors for TCG and others.

Enhancements:
- Refactor HD-Space time parsing into reusable helpers shared between torrent list and user profile join/last access selectors.
- Improve SpeedApp join time parsing to use a direct localized time format, and adjust average seeding time parsing to handle Chinese duration text.
- Extend Unit3D and SpeedApp user level metadata with localized alternate names for user classes.
- Normalize time parsing for DigitalCore join time and other schema-based selectors, and wire lastAccessAt into GazelleGames JSON API user info.