### PR TITLE
feat(pkg/site): 添加 isDonor 选择器

### DIFF
--- a/src/packages/site/definitions/pter.ts
+++ b/src/packages/site/definitions/pter.ts
@@ -410,6 +410,14 @@ export const siteMetadata: ISiteMetadata = {
 };
 
 export default class Pter extends NexusPHP {
+  public override async getUserInfoResult(lastUserInfo: Partial<IUserInfo> = {}): Promise<IUserInfo> {
+    const flushUserInfo = await super.getUserInfoResult(lastUserInfo);
+    if (flushUserInfo.isDonor && typeof flushUserInfo.bonusPerHour === "number") {
+      flushUserInfo.bonusPerHour *= 2;
+    }
+    return flushUserInfo;
+  }
+
   protected override async parseUserInfoForUploads(flushUserInfo: Partial<IUserInfo>): Promise<Partial<IUserInfo>> {
     flushUserInfo.uploads = 0;
     if (flushUserInfo.name) {

--- a/src/packages/site/definitions/totheglory.ts
+++ b/src/packages/site/definitions/totheglory.ts
@@ -242,6 +242,11 @@ export const siteMetadata: ISiteMetadata = {
           levelName: {
             selector: ["td.rowhead:contains('等级') + td", "td.rowhead:contains('等級') + td"],
           },
+          isDonor: {
+            text: false,
+            selector: ["img[alt='Donor']"],
+            elementProcess: () => true,
+          },
           bonus: {
             selector: ["td.rowhead:contains('积分') + td", "td.rowhead:contains('積分') + td"],
             filters: [{ name: "parseNumber" }],

--- a/src/packages/site/schemas/NexusPHP.ts
+++ b/src/packages/site/schemas/NexusPHP.ts
@@ -431,6 +431,11 @@ export const SchemaMetadata: Pick<
         ],
         attr: "title",
       },
+      isDonor: {
+        text: false,
+        selector: ["img[alt='Donor']"],
+        elementProcess: () => true,
+      },
       bonus: {
         selector: [
           "td.rowhead:contains('魔力') + td",
@@ -558,6 +563,8 @@ export const SchemaMetadata: Pick<
           "hnrUnsatisfied",
           "hnrPreWarning",
           "lastAccessAt",
+          "isDonor",
+          "isKept",
         ],
       },
       {

--- a/src/packages/site/types/search.ts
+++ b/src/packages/site/types/search.ts
@@ -253,7 +253,7 @@ export interface IElementQuery {
    * 特殊值：
    * - N/A 表示源站并没有提供该信息
    */
-  text?: string | number | "N/A";
+  text?: string | number | boolean | "N/A";
 
   /**
    * 如果selector为 string[]， 则会依次尝试并找到第一个成功获取到有效信息的

--- a/src/packages/site/types/userinfo.ts
+++ b/src/packages/site/types/userinfo.ts
@@ -90,6 +90,7 @@ export interface IUserInfo extends Omit<IImplicitUserInfo, "interval"> {
 
   id?: number | string; // 用户ID
   name?: string; // 用户名
+  isDonor?: boolean; // 是否是捐赠者
   levelId?: TLevelId; // 等级ID
   levelName?: TLevelName; // 等级名称
   joinTime?: number; // 入站时间


### PR DESCRIPTION
添加 isDonor （捐赠/黄星）选择器

有下面两个好处：
 - 对于很多站点，可以修正“双倍时魔”
 - 有些站点默认黄星保号，比如 猫，ttg，后续可以提供支持（但目前没想到好的实现方式）

## Summary by Sourcery

Add donor status support to NexusPHP-based sites and adjust bonus calculations for donors.

New Features:
- Introduce an isDonor flag in user info to represent donor (yellow star) status.
- Add isDonor selector support to NexusPHP schema and specific site definitions such as Pter and ToTheGlory.

Enhancements:
- Adjust Pter user bonus-per-hour calculation to double bonuses for donor users.
- Extend element query text type to support boolean values for selectors.