### PR TITLE
fix(pkg/site/uhdbits): site closed

### DIFF
--- a/src/packages/site/definitions/uhdbits.ts
+++ b/src/packages/site/definitions/uhdbits.ts
@@ -1,10 +1,14 @@
-import Sizzle from "sizzle";
-import type { ISiteMetadata, ISearchInput, ITorrent } from "../types";
-import BittorrentSite from "../schemas/AbstractBittorrentSite";
-import GazelleJSONAPI, { SchemaMetadata } from "../schemas/GazelleJSONAPI";
+// import Sizzle from "sizzle";
+import type {
+  ISiteMetadata,
+  // ISearchInput,
+  // ITorrent,
+} from "../types";
+// import BittorrentSite from "../schemas/AbstractBittorrentSite";
+// import GazelleJSONAPI, { SchemaMetadata } from "../schemas/GazelleJSONAPI";
 
 export const siteMetadata: ISiteMetadata = {
-  ...SchemaMetadata,
+  // ...SchemaMetadata,
 
   version: 1,
   id: "uhdbits",
@@ -19,6 +23,10 @@ export const siteMetadata: ISiteMetadata = {
 
   urls: ["https://uhdbits.org/"],
 
+  // refs: https://t.me/Ptfxq/950
+  isDead: true,
+
+  /*
   category: [
     {
       name: "Category",
@@ -105,6 +113,7 @@ export const siteMetadata: ISiteMetadata = {
       },
     },
   },
+  */
 
   levelRequirements: [
     {
@@ -164,9 +173,11 @@ export const siteMetadata: ISiteMetadata = {
   ],
 };
 
+/*
 export default class UHDBits extends GazelleJSONAPI {
   // 使用 AbstractBittorrentSite 的解析方法 (HTML)
   public override async transformSearchPage(doc: Document, searchConfig: ISearchInput): Promise<ITorrent[]> {
     return BittorrentSite.prototype.transformSearchPage.call(this, doc, searchConfig);
   }
 }
+*/


### PR DESCRIPTION
https://t.me/Ptfxq/950
https://old.reddit.com/r/trackers/comments/1of51pa/uhdbitsorg_closure_february_28_2026/

## Summary by Sourcery

Mark the UHDBits site definition as dead and disable its implementation.

Bug Fixes:
- Prevent usage of the UHDBits tracker integration now that the site has closed.

Enhancements:
- Comment out UHDBits-specific metadata and class implementation to effectively retire the site without deleting the definition.