### PR TITLE
fix(pkg/site): potential bug that caused by string "false" (truthy)

### DIFF
--- a/src/packages/site/definitions/pter.ts
+++ b/src/packages/site/definitions/pter.ts
@@ -412,7 +412,7 @@ export const siteMetadata: ISiteMetadata = {
 export default class Pter extends NexusPHP {
   public override async getUserInfoResult(lastUserInfo: Partial<IUserInfo> = {}): Promise<IUserInfo> {
     const flushUserInfo = await super.getUserInfoResult(lastUserInfo);
-    if (flushUserInfo.isDonor && typeof flushUserInfo.bonusPerHour === "number") {
+    if (flushUserInfo.isDonor === true && typeof flushUserInfo.bonusPerHour === "number") {
       flushUserInfo.bonusPerHour *= 2;
     }
     return flushUserInfo;

--- a/src/packages/site/schemas/AbstractBittorrentSite.ts
+++ b/src/packages/site/schemas/AbstractBittorrentSite.ts
@@ -427,7 +427,7 @@ export default class BittorrentSite {
     }
 
     // 此时如果 query 仍为 undefined 应该回落到 elementQuery.text ?? ""
-    query ??= String(elementQuery.text ?? "");
+    query ??= elementQuery.text ?? ""; // 不强制转为字符串，保持原有类型，方便后续处理
 
     // noinspection SuspiciousTypeOfGuard
     if (typeof query === "string") {
@@ -436,6 +436,8 @@ export default class BittorrentSite {
         // 尽可能的将返回值转成数字类型
         query = isNaN(parseInt(query)) ? 0 : parseInt(query);
       }
+    } else if (typeof query === "number") {
+      query = isNaN(query) ? 0 : Math.trunc(query); // 这里还是保持取整数，不改变原来的逻辑
     }
 
     return query;

--- a/src/packages/site/schemas/NexusPHP.ts
+++ b/src/packages/site/schemas/NexusPHP.ts
@@ -564,7 +564,6 @@ export const SchemaMetadata: Pick<
           "hnrPreWarning",
           "lastAccessAt",
           "isDonor",
-          "isKept",
         ],
       },
       {


### PR DESCRIPTION
主要参考了 #1057 中 Copilot 的意见进行了修改，防止 bool 类型的 false 被强制转为字符串，然后误判为 true 的情况。

因为改动了 AbstractBittorrentSite.ts，作用范围比较广，请 @Rhilip review 一下。

## Summary by Sourcery

Handle boolean-like values more safely in site metadata processing to avoid misinterpreting false as truthy and to normalize numeric queries.

Bug Fixes:
- Preserve the original type of query values from site elements to avoid coercing boolean false to the truthy string 'false'.
- Ensure donor bonus doubling only occurs when the isDonor flag is explicitly true rather than any truthy value.