### PR TITLE
feat(pkg/site/HDB): bonusPerHour & lastAccessAt

### DIFF
--- a/src/packages/site/definitions/hdbits.ts
+++ b/src/packages/site/definitions/hdbits.ts
@@ -256,11 +256,24 @@ export const siteMetadata: ISiteMetadata = {
           },
           seedingSize: {
             selector: ["td.rowhead:contains('Seeding size') + td"],
-            filters: [{ name: "parseSize" }],
+            filters: [
+              (query: string) => {
+                return query.includes("(") ? query.split("(")[0] : query;
+              },
+              { name: "parseSize" },
+            ],
           },
           uploads: {
             selector: ["td.heading:contains('Uploaded'):contains('torrents') + td"],
             filters: [{ name: "replace", args: ["-", ""] }, { name: "parseNumber" }],
+          },
+          bonusPerHour: {
+            selector: ["td.heading:contains('Bonus per hour') + td"],
+            filters: [{ name: "parseNumber" }],
+          },
+          lastAccessAt: {
+            selector: ["td.rowhead:contains('seen') + td"],
+            filters: [{ name: "replace", args: ["\\s*\\(.*\\)", ""] }, { name: "parseTime" }],
           },
         },
       },


### PR DESCRIPTION
## Summary by Sourcery

Add support for additional user statistics fields on HDBits user pages and adjust seeding size parsing to ignore supplemental text.

New Features:
- Expose a bonus-per-hour statistic for HDBits users in the site metadata scraper.
- Expose a last-access timestamp for HDBits users in the site metadata scraper.

Enhancements:
- Improve HDBits seeding-size scraping by stripping trailing parenthetical text before parsing the size value.