### PR TITLE
feat(pkg/site): avz & exo HR页list

### DIFF
--- a/src/packages/site/definitions/exoticaz.ts
+++ b/src/packages/site/definitions/exoticaz.ts
@@ -151,7 +151,7 @@ export const siteMetadata: ISiteMetadata = {
     },
     // 下载历史页和HR页
     {
-      urlPattern: ["/profile/(.)/history"],
+      urlPattern: ["/profile/(.+)/history"],
       mergeSearchSelectors: false,
       selectors: {
         subTitle: { text: "" },

--- a/src/packages/site/definitions/exoticaz.ts
+++ b/src/packages/site/definitions/exoticaz.ts
@@ -2,7 +2,6 @@ import { ISiteMetadata, ISearchInput, IAdvancedSearchRequestConfig, ITorrent, IT
 import AvistazNetwork, {
   SchemaMetadata,
   IAvzNetRawTorrent,
-  listHistoryPageMetadata,
 } from "../schemas/AvistazNetwork.ts";
 
 const categoryMap: Record<number, string> = {
@@ -150,7 +149,40 @@ export const siteMetadata: ISiteMetadata = {
         completed: { selector: "td:nth-child(8)" },
       },
     },
-    listHistoryPageMetadata,
+    // 下载历史页和HR页
+    {
+      urlPattern: ["/profile/(.)/history"],
+      mergeSearchSelectors: false,
+      selectors: {
+        subTitle: { text: "" },
+        comments: { text: "N/A" },
+        rows: { selector: "div.card-body.p-2 > div.table-responsive > table > tbody > tr" },
+
+        id: {
+          selector: "div.mb-1 a[href*='/torrent/']",
+          attr: "href",
+          filters: [
+            (href: string) => {
+              const torrentIdMatch = href.match(/\/torrent\/(\d+)/);
+              if (torrentIdMatch && torrentIdMatch[1]) {
+                return torrentIdMatch[1];
+              }
+              return undefined;
+            },
+          ],
+        },
+        title: { selector: "div.mb-1 a[href*='/torrent/']", attr: "title" },
+        // Bootstrap tooltip 初始化后会将 title 移至 data-original-title
+        category: { selector: "i.category-icon", attr: "data-original-title" },
+        url: { selector: "div.mb-1 a[href*='/torrent/']", attr: "href" },
+        link: { selector: "div.float-right a[href*='/download/torrent/']", attr: "href" },
+        // 通过 div.d-block 父上下文限定范围，避免与行内其他同色 span 冲突，同时不依赖 title 属性
+        size: { selector: "div.d-block span.text-yellow", filters: [{ name: "parseSize" }] },
+        seeders: { selector: "div.d-block span.text-green.mr-2" },
+        leechers: { selector: "div.d-block span.text-red.mr-2" },
+        completed: { selector: "div.d-block span.text-blue.mr-2" },
+      },
+    },
   ],
 
   detail: {

--- a/src/packages/site/schemas/AvistazNetwork.ts
+++ b/src/packages/site/schemas/AvistazNetwork.ts
@@ -111,15 +111,28 @@ export const listHistoryPageMetadata = {
   mergeSearchSelectors: false,
   selectors: {
     ...commonListSelectors,
-    rows: { selector: "div.card-body.p-2 > div.table-responsive > table > tbody > tr" },
+    rows: { selector: "div.block > div.table-responsive > table > tbody > tr" },
 
-    title: { selector: "div.mb-1 a[title]", attr: "title" },
-    link: { selector: "div.float-right a[href*='/download/torrent/']", attr: "href" },
-    size: { selector: "span.text-yellow[data-original-title='File Size']", filters: [{ name: "parseSize" }] },
-
-    seeders: { selector: "span.text-green.mr-2[data-original-title='Seeders']" },
-    leechers: { selector: "span.text-red.mr-2[data-original-title='Leechers']" },
-    completed: { selector: "span.text-blue.mr-2[data-original-title='Completed']" },
+    id: {
+      selector: "a.torrent-filename",
+      attr: "href",
+      filters: [
+        (href: string) => {
+          const match = href.match(/\/torrent\/(\d+)/);
+          return match ? match[1] : undefined;
+        },
+      ],
+    },
+    // Bootstrap tooltip 初始化后将 title 移至 data-original-title
+    title: { selector: "a.torrent-filename", attr: "data-original-title" },
+    category: { selector: "td:first-child i", attr: "data-original-title" },
+    url: { selector: "a.torrent-filename", attr: "href" },
+    link: { selector: "a.torrent-download-icon", attr: "href" },
+    // 行内存在同色的 span.badge-extra（上传量/下载量/Credited Download），用 FA 图标类唯一区分
+    size: { selector: "span.badge-extra.fa-database", filters: [{ name: "parseSize" }] },
+    seeders: { selector: "span.badge-extra.fa-arrow-up" },
+    leechers: { selector: "span.badge-extra.fa-arrow-down" },
+    completed: { selector: "span.badge-extra.fa-check" },
   },
 };
 

--- a/src/packages/site/schemas/AvistazNetwork.ts
+++ b/src/packages/site/schemas/AvistazNetwork.ts
@@ -107,7 +107,7 @@ export const listTorrentPageMetadata = {
 
 // 下载历史页和HR页
 export const listHistoryPageMetadata = {
-  urlPattern: ["/profile/(.)/history"],
+  urlPattern: ["/profile/(.+)/history"],
   mergeSearchSelectors: false,
   selectors: {
     ...commonListSelectors,
@@ -216,7 +216,7 @@ export const SchemaMetadata: Pick<
   },
 
   list: [listTorrentPageMetadata, listHistoryPageMetadata],
-  
+
   detail: {
     urlPattern: ["/torrent/"],
     selectors: {


### PR DESCRIPTION
## Summary by Sourcery

Update Avistaz-based site list parsers for history and HR pages to match the latest layout and tooltip structure.

Bug Fixes:
- Fix torrent history list parsing on Avistaz network sites after DOM and tooltip attribute changes.

Enhancements:
- Inline and specialize Exoticaz history/HR page list selectors instead of relying on the shared Avistaz list metadata for better compatibility.