### PR TITLE
feat(keepUpload): add reseed task feature

### DIFF
--- a/src/entries/messages.ts
+++ b/src/entries/messages.ts
@@ -13,6 +13,17 @@ import type { IMediaServerId, IMediaServerSearchOptions, IMediaServerSearchResul
 import type { IBackupData, IBackupFileInfo } from "@ptd/backupServer";
 import type { TorrentClientStatus } from "@ptd/downloader";
 
+// 可序列化的种子信息，用于辅种检测
+export interface ITorrentInfoForVerification {
+  infoHash: string;
+  name: string;
+  length: number;
+  files: Array<{
+    path: string;
+    length: number;
+  }>;
+}
+
 import type { TExtensionStorageKey, IExtensionStorageSchema } from "@/storage.ts";
 import {
   ILoggerItem,
@@ -27,6 +38,8 @@ import {
   IDownloadTorrentOption,
   IDownloadTorrentResult,
   AugmentedRequired,
+  IKeepUploadTask,
+  TKeepUploadTaskKey,
 } from "@/shared/types.ts";
 
 import { isDebug } from "~/helper.ts";
@@ -97,6 +110,7 @@ interface ProtocolMap extends TMessageMap {
   getDownloaderVersion(downloaderId: string): string;
   getDownloaderStatus(downloaderId: string): TorrentClientStatus;
   getTorrentDownloadLink(torrent: ITorrent): string;
+  getTorrentInfoForVerification(torrent: ITorrent): ITorrentInfoForVerification;
 
   downloadTorrent(data: IDownloadTorrentOption): IDownloadTorrentResult;
 
@@ -123,6 +137,14 @@ interface ProtocolMap extends TMessageMap {
   deleteBackupHistory(data: { backupServerId: string; path: string }): boolean;
   restoreBackupData(data: { restoreData: IBackupData; restoreOptions?: IRestoreOptions }): boolean;
   getRemoteBackupData(data: { backupServerId: string; path: string; decryptKey?: string }): IBackupData;
+
+  // 2.7 辅种任务 ( utils/keepUploadTask )
+  getKeepUploadTasks(): IKeepUploadTask[];
+  getKeepUploadTaskById(taskId: TKeepUploadTaskKey): IKeepUploadTask;
+  createKeepUploadTask(task: IKeepUploadTask): void;
+  updateKeepUploadTask(task: IKeepUploadTask): void;
+  deleteKeepUploadTask(taskId: TKeepUploadTaskKey): void;
+  clearKeepUploadTasks(): void;
 }
 
 // 全局消息处理函数映射

--- a/src/entries/offscreen/offscreen.ts
+++ b/src/entries/offscreen/offscreen.ts
@@ -7,3 +7,4 @@ import "./utils/download.ts";
 import "./utils/userInfo.ts";
 import "./utils/backup.ts";
 import "./utils/socialInformation.ts";
+import "./utils/keepUploadTask.ts";

--- a/src/entries/offscreen/utils/download.ts
+++ b/src/entries/offscreen/utils/download.ts
@@ -72,6 +72,30 @@ export async function getTorrentDownloadLink(torrent: ITorrent) {
 
 onMessage("getTorrentDownloadLink", async ({ data: torrent }) => await getTorrentDownloadLink(torrent));
 
+export async function getTorrentInfoForVerification(torrent: ITorrent) {
+  const downloadUrl = await getTorrentDownloadLink(torrent);
+  const siteInstance = await getSiteInstance<"public">(torrent.site);
+
+  const downloadRequestConfig = await siteInstance.getTorrentDownloadRequestConfig(torrent);
+  downloadRequestConfig.url = downloadUrl;
+  downloadRequestConfig.responseType = "arraybuffer";
+
+  const parsedTorrent = await getRemoteTorrentFile(downloadRequestConfig);
+
+  // 返回可序列化的种子信息
+  return {
+    infoHash: (parsedTorrent as unknown as { infoHash: string }).infoHash ?? "",
+    name: parsedTorrent.info.name ?? "unknown",
+    length: parsedTorrent.info.length ?? 0,
+    files: (parsedTorrent.info.files || []).map((f) => ({
+      path: f.path,
+      length: f.length,
+    })),
+  };
+}
+
+onMessage("getTorrentInfoForVerification", async ({ data: torrent }) => await getTorrentInfoForVerification(torrent));
+
 function buildDownloadHistory(downloadOption: IDownloadTorrentOption): ITorrentDownloadMetadata {
   const { torrent = {}, downloaderId = "local" } = downloadOption;
   return {

--- a/src/entries/offscreen/utils/keepUploadTask.ts
+++ b/src/entries/offscreen/utils/keepUploadTask.ts
@@ -1,0 +1,88 @@
+/**
+ * 辅种任务处理函数
+ */
+
+import { onMessage, sendMessage } from "@/messages.ts";
+import type { IKeepUploadTask, TKeepUploadTaskKey, TKeepUploadTaskStorageSchema } from "@/shared/types.ts";
+
+const STORAGE_KEY = "keepUploadTask" as const;
+
+/**
+ * 获取所有辅种任务
+ */
+export async function getKeepUploadTasks(): Promise<IKeepUploadTask[]> {
+  const tasks = await sendMessage("getExtStorage", STORAGE_KEY);
+  return tasks ? Object.values(tasks as TKeepUploadTaskStorageSchema) : [];
+}
+
+onMessage("getKeepUploadTasks", getKeepUploadTasks);
+
+/**
+ * 根据ID获取辅种任务
+ */
+export async function getKeepUploadTaskById(taskId: TKeepUploadTaskKey): Promise<IKeepUploadTask | undefined> {
+  const tasks = await sendMessage("getExtStorage", STORAGE_KEY);
+  return (tasks as TKeepUploadTaskStorageSchema)?.[taskId];
+}
+
+onMessage("getKeepUploadTaskById", async ({ data: taskId }) => {
+  const task = await getKeepUploadTaskById(taskId);
+  return task!;
+});
+
+/**
+ * 创建辅种任务
+ */
+export async function createKeepUploadTask(task: IKeepUploadTask): Promise<void> {
+  const tasks = ((await sendMessage("getExtStorage", STORAGE_KEY)) as TKeepUploadTaskStorageSchema) || {};
+  tasks[task.id] = task;
+  await sendMessage("setExtStorage", { key: STORAGE_KEY, value: tasks });
+}
+
+onMessage("createKeepUploadTask", async ({ data: task }) => {
+  await createKeepUploadTask(task);
+});
+
+/**
+ * 更新辅种任务
+ */
+export async function updateKeepUploadTask(task: IKeepUploadTask): Promise<void> {
+  const tasks = ((await sendMessage("getExtStorage", STORAGE_KEY)) as TKeepUploadTaskStorageSchema) || {};
+  if (tasks[task.id]) {
+    tasks[task.id] = task;
+    await sendMessage("setExtStorage", { key: STORAGE_KEY, value: tasks });
+  }
+}
+
+onMessage("updateKeepUploadTask", async ({ data: task }) => {
+  await updateKeepUploadTask(task);
+});
+
+/**
+ * 删除辅种任务
+ */
+export async function deleteKeepUploadTask(taskId: TKeepUploadTaskKey): Promise<void> {
+  const tasks = ((await sendMessage("getExtStorage", STORAGE_KEY)) as TKeepUploadTaskStorageSchema) || {};
+  delete tasks[taskId];
+  await sendMessage("setExtStorage", { key: STORAGE_KEY, value: tasks });
+}
+
+onMessage("deleteKeepUploadTask", async ({ data: taskId }) => {
+  await deleteKeepUploadTask(taskId);
+});
+
+/**
+ * 清空所有辅种任务
+ */
+export async function clearKeepUploadTasks(): Promise<void> {
+  await sendMessage("setExtStorage", { key: STORAGE_KEY, value: {} });
+}
+
+onMessage("clearKeepUploadTasks", clearKeepUploadTasks);
+
+/**
+ * 生成唯一ID
+ */
+export function generateKeepUploadTaskId(): TKeepUploadTaskKey {
+  return `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+}

--- a/src/entries/options/plugins/router.ts
+++ b/src/entries/options/plugins/router.ts
@@ -77,6 +77,12 @@ export const routes: RouteRecordRaw[] = [
         meta: { icon: "mdi-history" },
         component: () => import("../views/Overview/DownloadHistory/Index.vue"),
       },
+      {
+        path: "/keep-upload-task",
+        name: "KeepUploadTask",
+        meta: { icon: "mdi-merge" },
+        component: () => import("../views/Overview/KeepUploadTask/Index.vue"),
+      },
     ],
   },
   {

--- a/src/entries/options/views/Overview/KeepUploadTask/Index.vue
+++ b/src/entries/options/views/Overview/KeepUploadTask/Index.vue
@@ -1,0 +1,356 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { useI18n } from "vue-i18n";
+
+import type { IKeepUploadTask } from "@/shared/types.ts";
+import { sendMessage } from "@/messages.ts";
+import { formatSize, formatDate } from "@/options/utils.ts";
+import { useRuntimeStore } from "@/options/stores/runtime.ts";
+import { useMetadataStore } from "@/options/stores/metadata.ts";
+
+import SiteFavicon from "@/options/components/SiteFavicon/Index.vue";
+
+const { t } = useI18n();
+const runtimeStore = useRuntimeStore();
+const metadataStore = useMetadataStore();
+
+const tasks = ref<IKeepUploadTask[]>([]);
+const selectedTasks = ref<IKeepUploadTask[]>([]);
+const expanded = ref<string[]>([]);
+const loading = ref(false);
+const tableKey = ref(0); // 用于强制刷新表格
+
+const headers = [
+  { title: t("KeepUploadTask.table.site"), key: "site", align: "center" as const, sortable: false },
+  { title: t("KeepUploadTask.table.title"), key: "title", align: "start" as const },
+  { title: t("KeepUploadTask.table.size"), key: "size", align: "end" as const },
+  { title: t("KeepUploadTask.table.count"), key: "count", align: "center" as const },
+  { title: t("KeepUploadTask.table.time"), key: "time", align: "center" as const },
+  { title: t("common.action"), key: "action", align: "center" as const, sortable: false },
+];
+
+async function loadTasks() {
+  loading.value = true;
+  try {
+    tasks.value = await sendMessage("getKeepUploadTasks", undefined);
+  } catch (e) {
+    console.error("Failed to load keep upload tasks:", e);
+    tasks.value = [];
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(() => {
+  loadTasks();
+});
+
+async function deleteTask(task: IKeepUploadTask) {
+  if (!confirm(t("KeepUploadTask.deleteConfirm"))) return;
+
+  try {
+    await sendMessage("deleteKeepUploadTask", task.id);
+    tasks.value = tasks.value.filter((t) => t.id !== task.id);
+    runtimeStore.showSnakebar(t("KeepUploadTask.deleteSuccess"), { color: "success" });
+  } catch (e) {
+    runtimeStore.showSnakebar(t("KeepUploadTask.deleteError"), { color: "error" });
+  }
+}
+
+async function deleteSelectedTasks() {
+  if (selectedTasks.value.length === 0) return;
+  if (!confirm(t("KeepUploadTask.deleteSelectedConfirm", { count: selectedTasks.value.length }))) return;
+
+  try {
+    for (const task of selectedTasks.value) {
+      await sendMessage("deleteKeepUploadTask", task.id);
+    }
+    tasks.value = tasks.value.filter((t) => !selectedTasks.value.includes(t));
+    selectedTasks.value = [];
+    runtimeStore.showSnakebar(t("KeepUploadTask.deleteSuccess"), { color: "success" });
+  } catch (e) {
+    runtimeStore.showSnakebar(t("KeepUploadTask.deleteError"), { color: "error" });
+  }
+}
+
+async function clearAllTasks() {
+  if (!confirm(t("KeepUploadTask.clearConfirm"))) return;
+
+  try {
+    await sendMessage("clearKeepUploadTasks", undefined);
+    tasks.value = [];
+    runtimeStore.showSnakebar(t("KeepUploadTask.clearSuccess"), { color: "success" });
+  } catch (e) {
+    runtimeStore.showSnakebar(t("KeepUploadTask.clearError"), { color: "error" });
+  }
+}
+
+// 发送种子到下载器
+async function sendTorrentsToDownloader(task: IKeepUploadTask, items: IKeepUploadTask["items"]) {
+  if (items.length === 0) return;
+
+  const downloader = metadataStore.downloaders[task.downloadOptions.downloaderId];
+  if (!downloader) {
+    runtimeStore.showSnakebar("下载器不存在", { color: "error" });
+    return;
+  }
+
+  try {
+    for (const item of items) {
+      await sendMessage("downloadTorrent", {
+        torrent: {
+          site: item.site,
+          title: item.title,
+          subTitle: item.subTitle,
+          link: item.url,
+          url: item.url,
+          size: item.size,
+        },
+        downloaderId: task.downloadOptions.downloaderId,
+        addTorrentOptions: {
+          localDownload: true,
+          addAtPaused: true,
+          savePath: task.downloadOptions.savePath || "",
+          ...task.downloadOptions.addTorrentOptions,
+        },
+      });
+    }
+    runtimeStore.showSnakebar(t("KeepUploadTask.sendSingleSuccess"), { color: "success" });
+  } catch (e) {
+    runtimeStore.showSnakebar(t("KeepUploadTask.sendSingleError"), { color: "error" });
+  }
+}
+
+// 设为基准种子（移动到第一位并更新存储）
+async function setAsBaseTorrent(task: IKeepUploadTask, itemIndex: number) {
+  if (itemIndex === 0) {
+    return;
+  }
+
+  // 将选中的种子移动到第一位
+  const item = task.items.splice(itemIndex, 1)[0];
+  task.items.unshift(item);
+
+  // 更新任务存储
+  try {
+    await sendMessage("updateKeepUploadTask", task);
+    // 强制刷新表格
+    tableKey.value++;
+    runtimeStore.showSnakebar(t("KeepUploadTask.setBaseSuccess"), { color: "success" });
+  } catch (e) {
+    runtimeStore.showSnakebar(t("KeepUploadTask.setBaseError"), { color: "error" });
+  }
+}
+
+// 发送基准种子到下载器
+function sendBaseTorrent(task: IKeepUploadTask) {
+  const items = task.items.slice(0, 1);
+  sendTorrentsToDownloader(task, items);
+}
+
+// 发送其他种子到下载器
+function sendOtherTorrents(task: IKeepUploadTask) {
+  if (task.items.length <= 1) return;
+  if (!confirm(t("KeepUploadTask.sendConfirm", { count: task.items.length - 1 }))) return;
+  const items = task.items.slice(1);
+  sendTorrentsToDownloader(task, items);
+}
+
+// 发送所有种子到下载器
+function sendAllTorrents(task: IKeepUploadTask) {
+  if (!confirm(t("KeepUploadTask.sendConfirm", { count: task.items.length }))) return;
+  const items = task.items.slice(0);
+  sendTorrentsToDownloader(task, items);
+}
+
+// 复制下载链接
+async function copyLinksToClipboard(task: IKeepUploadTask) {
+  const urls = task.items.map((item) => item.url).join("\n");
+  try {
+    await navigator.clipboard.writeText(urls);
+    runtimeStore.showSnakebar(t("KeepUploadTask.copySuccess", { count: task.items.length }), { color: "success" });
+  } catch (e) {
+    runtimeStore.showSnakebar(t("KeepUploadTask.copyError"), { color: "error" });
+  }
+}
+</script>
+
+<template>
+  <v-alert type="info">
+    {{ t("KeepUploadTask.title") }}
+  </v-alert>
+
+  <v-card>
+    <v-card-title>
+      <v-btn color="error" :disabled="selectedTasks.length === 0" class="mr-2" @click="deleteSelectedTasks">
+        <v-icon class="mr-2">mdi-delete</v-icon>
+        {{ t("common.remove") }}
+      </v-btn>
+
+      <v-btn color="error" :disabled="tasks.length === 0" @click="clearAllTasks">
+        <v-icon class="mr-2">mdi-delete-sweep</v-icon>
+        {{ t("KeepUploadTask.clearAll") }}
+      </v-btn>
+
+      <v-btn
+        color="info"
+        href="https://github.com/pt-plugins/PT-Plugin-Plus/wiki/keep-upload-task"
+        target="_blank"
+        rel="noopener noreferrer nofollow"
+        class="ml-2"
+      >
+        <v-icon class="mr-2">mdi-help</v-icon>
+        {{ t("common.howToUse") }}
+      </v-btn>
+    </v-card-title>
+
+    <v-data-table
+      :key="tableKey"
+      v-model="selectedTasks"
+      v-model:expanded="expanded"
+      :headers="headers"
+      :items="tasks"
+      :loading="loading"
+      item-value="id"
+      show-select
+      show-expand
+      class="elevation-1"
+    >
+      <template #item.site="{ item }">
+        <div class="d-flex flex-column align-center">
+          <SiteFavicon :site-id="item.items[0]?.site" :size="18" />
+        </div>
+      </template>
+
+      <template #item.title="{ item }">
+        <div>
+          <a :href="item.items[0]?.link" target="_blank" rel="noopener noreferrer nofollow">
+            {{ item.title }}
+          </a>
+          <div class="text-caption text-grey">
+            {{ t("KeepUploadTask.savePath") }}{{ item.downloadOptions?.clientName }} ->
+            {{ item.downloadOptions?.savePath || t("KeepUploadTask.defaultPath") }}
+          </div>
+          <div class="text-caption">{{ t("KeepUploadTask.torrentCount") }}{{ item.items.length }}</div>
+        </div>
+      </template>
+
+      <template #item.size="{ item }">
+        {{ formatSize(item.size) }}
+      </template>
+
+      <template #item.count="{ item }">
+        {{ item.items.length }}
+      </template>
+
+      <template #item.time="{ item }">
+        {{ formatDate(item.time) }}
+      </template>
+
+      <template #item.action="{ item }">
+        <v-btn
+          icon
+          variant="text"
+          color="primary"
+          :title="t('KeepUploadTask.sendBaseTorrent')"
+          @click="sendBaseTorrent(item)"
+        >
+          <v-icon>mdi-numeric-1-circle</v-icon>
+        </v-btn>
+        <v-btn
+          icon
+          variant="text"
+          color="info"
+          :title="t('KeepUploadTask.sendOtherTorrents')"
+          @click="sendOtherTorrents(item)"
+        >
+          <v-icon>mdi-numeric-2-circle</v-icon>
+        </v-btn>
+        <v-btn
+          icon
+          variant="text"
+          color="success"
+          :title="t('KeepUploadTask.sendAllTorrents')"
+          @click="sendAllTorrents(item)"
+        >
+          <v-icon>mdi-download</v-icon>
+        </v-btn>
+        <v-btn
+          icon
+          variant="text"
+          color="info"
+          :title="t('KeepUploadTask.copyLinks')"
+          @click="copyLinksToClipboard(item)"
+        >
+          <v-icon>mdi-content-copy</v-icon>
+        </v-btn>
+        <v-btn icon variant="text" color="error" :title="t('common.remove')" @click="deleteTask(item)">
+          <v-icon>mdi-delete</v-icon>
+        </v-btn>
+      </template>
+
+      <template #expanded-row="{ item }">
+        <tr>
+          <td :colspan="headers.length + 1" class="pa-0">
+            <v-list density="compact" class="ml-10">
+              <v-list-item v-for="(subItem, index) in item.items" :key="index">
+                <template #prepend>
+                  <SiteFavicon :site-id="subItem.site" :size="16" />
+                </template>
+                <v-list-item-title>
+                  <a :href="subItem.link" target="_blank" rel="noopener noreferrer nofollow">
+                    {{ subItem.title }}
+                  </a>
+                </v-list-item-title>
+                <v-list-item-subtitle>
+                  {{ formatSize(subItem.size) }}, {{ t("KeepUploadTask.seeders") }}{{ subItem.seeders ?? "-" }},
+                  {{ t("KeepUploadTask.leechers") }}{{ subItem.leechers ?? "-" }}
+                </v-list-item-subtitle>
+                <template #append>
+                  <v-btn
+                    icon
+                    variant="text"
+                    color="primary"
+                    size="small"
+                    :title="t('KeepUploadTask.setAsBaseTorrent')"
+                    @click="setAsBaseTorrent(item, index)"
+                  >
+                    <v-icon>mdi-arrow-up-bold</v-icon>
+                  </v-btn>
+                </template>
+              </v-list-item>
+            </v-list>
+          </td>
+        </tr>
+      </template>
+
+      <template #no-data>
+        <v-alert type="info" variant="tonal">
+          {{ t("KeepUploadTask.emptyNotice") }}
+        </v-alert>
+      </template>
+    </v-data-table>
+  </v-card>
+
+  <v-alert type="warning" class="mt-4">
+    <div>
+      {{ t("KeepUploadTask.warning.title") }}
+      <ul>
+        <li>{{ t("KeepUploadTask.warning.item1") }}</li>
+        <li>{{ t("KeepUploadTask.warning.item2") }}</li>
+        <li>{{ t("KeepUploadTask.warning.item3") }}</li>
+      </ul>
+    </div>
+  </v-alert>
+</template>
+
+<style scoped lang="scss">
+a {
+  color: #000;
+  text-decoration: none;
+}
+
+a:hover {
+  color: #008c00;
+}
+</style>

--- a/src/entries/options/views/Overview/SearchEntity/ActionTd.vue
+++ b/src/entries/options/views/Overview/SearchEntity/ActionTd.vue
@@ -8,6 +8,7 @@ import { useRuntimeStore } from "@/options/stores/runtime.ts";
 import { useMetadataStore } from "@/options/stores/metadata.ts";
 
 import SentToDownloaderDialog from "@/options/components/SentToDownloaderDialog/Index.vue";
+import KeepUploadDialog from "./KeepUploadDialog.vue";
 
 const { torrentItems, density = "default" } = defineProps<{
   torrentItems: ISearchResultTorrent[];
@@ -69,6 +70,12 @@ function sendToDownloader(defaultDownload = false) {
   isDefaultSend.value = defaultDownload;
   showDownloadClientDialog.value = true;
 }
+
+const showKeepUploadDialog = ref(false);
+
+function openKeepUploadDialog() {
+  showKeepUploadDialog.value = true;
+}
 </script>
 
 <template>
@@ -108,6 +115,14 @@ function sendToDownloader(defaultDownload = false) {
       :title="t('SearchEntity.ActionTd.localDownload')"
       @click="() => localDlTorrentDownloadLink()"
     />
+    <!-- 辅种检测 -->
+    <v-btn
+      :disabled="torrentItems.length < 2"
+      :size="btnSize"
+      icon="mdi-merge"
+      :title="t('SearchEntity.KeepUploadDialog.keepUpload')"
+      @click="openKeepUploadDialog"
+    />
   </v-btn-group>
 
   <!-- 在点击发送到远程服务器时，弹出选择下载器及其他自定义选项 -->
@@ -116,6 +131,9 @@ function sendToDownloader(defaultDownload = false) {
     :torrent-items="torrentItems"
     :is-default-send="isDefaultSend"
   />
+
+  <!-- 辅种检测对话框 -->
+  <KeepUploadDialog v-model="showKeepUploadDialog" :torrent-items="torrentItems" />
 </template>
 
 <style scoped lang="scss"></style>

--- a/src/entries/options/views/Overview/SearchEntity/KeepUploadDialog.vue
+++ b/src/entries/options/views/Overview/SearchEntity/KeepUploadDialog.vue
@@ -1,0 +1,454 @@
+<script setup lang="ts">
+import { ref, watch, computed } from "vue";
+import { useI18n } from "vue-i18n";
+
+import type { ITorrent } from "@ptd/site";
+
+import { sendMessage } from "@/messages.ts";
+import type { ITorrentInfoForVerification } from "@/messages.ts";
+import type { IKeepUploadTask, IKeepUploadTaskItem, IKeepUploadTaskDownloadOptions } from "@/shared/types.ts";
+import { formatSize } from "@/options/utils.ts";
+import { useMetadataStore } from "@/options/stores/metadata.ts";
+import { useRuntimeStore } from "@/options/stores/runtime.ts";
+
+import SiteFavicon from "@/options/components/SiteFavicon/Index.vue";
+
+const showDialog = defineModel<boolean>();
+const { torrentItems } = defineProps<{
+  torrentItems: ITorrent[];
+}>();
+
+const { t } = useI18n();
+const metadataStore = useMetadataStore();
+const runtimeStore = useRuntimeStore();
+
+interface IVerifiedItem {
+  id: string; // Map key
+  data: ITorrent;
+  torrent: ITorrentInfoForVerification | null;
+  loading: boolean;
+  verified: boolean;
+  status: string;
+  error: boolean;
+}
+
+const verifiedItems = ref<Map<string, IVerifiedItem>>(new Map());
+const verifiedItemsOrder = ref<string[]>([]); // 保持顺序
+const baseTorrent = ref<ITorrentInfoForVerification | null>(null);
+const verifiedCount = ref(0);
+const creating = ref(false);
+
+// 下载选项
+const selectedDownloaderId = ref<string>("");
+const savePath = ref("");
+
+// 是否可以创建任务
+const canCreateTask = computed(() => {
+  return verifiedCount.value > 1 && selectedDownloaderId.value;
+});
+
+// 状态文本
+const statusText = {
+  downloading: t("SearchEntity.KeepUploadDialog.status.downloading"),
+  waiting: t("SearchEntity.KeepUploadDialog.status.waiting"),
+  downloaded: t("SearchEntity.KeepUploadDialog.status.downloaded"),
+  success: t("SearchEntity.KeepUploadDialog.status.success"),
+  failed: t("SearchEntity.KeepUploadDialog.status.failed"),
+  downloadFailed: t("SearchEntity.KeepUploadDialog.status.downloadFailed"),
+  missingFiles: t("SearchEntity.KeepUploadDialog.status.missingFiles"),
+};
+
+// 打开对话框时初始化
+watch(showDialog, (val) => {
+  if (val) {
+    startVerification();
+  }
+});
+
+function startVerification() {
+  verifiedItems.value = new Map();
+  verifiedItemsOrder.value = [];
+  baseTorrent.value = null;
+  verifiedCount.value = 0;
+  selectedDownloaderId.value = metadataStore.defaultDownloader?.id || "";
+  savePath.value = metadataStore.defaultDownloader?.folder || "";
+
+  torrentItems.forEach((item) => {
+    if (item.link) {
+      const id = crypto.randomUUID();
+
+      verifiedItems.value.set(id, {
+        id,
+        data: item,
+        torrent: null,
+        loading: true,
+        verified: false,
+        status: statusText.downloading,
+        error: false,
+      });
+      verifiedItemsOrder.value.push(id);
+
+      getTorrent(item, id)
+        .then((result) => {
+          verification(result, id);
+        })
+        .catch(() => {
+          verification(null, id);
+        });
+    }
+  });
+}
+
+async function getTorrent(torrent: ITorrent, id: string): Promise<ITorrentInfoForVerification | null> {
+  try {
+    const result = await sendMessage("getTorrentInfoForVerification", torrent);
+    // 边界检查：确保项仍然存在
+    const item = verifiedItems.value.get(id);
+    if (!item) return null;
+    item.status = statusText.waiting;
+    return result;
+  } catch (e) {
+    // 边界检查：确保项仍然存在
+    const item = verifiedItems.value.get(id);
+    if (item) {
+      item.status = statusText.downloadFailed;
+      item.error = true;
+    }
+    throw e;
+  }
+}
+
+function verification(torrent: ITorrentInfoForVerification | null, id: string) {
+  // 边界检查：确保项仍然存在
+  const item = verifiedItems.value.get(id);
+  if (!item) return;
+
+  const isFirstItem = verifiedItemsOrder.value[0] === id;
+
+  if (isFirstItem) {
+    // 第一个种子作为基准种子
+    if (!baseTorrent.value) {
+      baseTorrent.value = torrent;
+      item.loading = false;
+
+      if (torrent) {
+        item.torrent = torrent;
+        item.verified = true;
+        item.status = statusText.downloaded;
+        verifiedCount.value++;
+      } else {
+        item.verified = false;
+        item.status = statusText.failed;
+      }
+    }
+  } else {
+    // 等待基准种子下载完成
+    const baseItem = verifiedItems.value.get(verifiedItemsOrder.value[0]);
+    if (baseItem?.loading) {
+      setTimeout(() => verification(torrent, id), 200);
+      return;
+    }
+
+    const result: Partial<IVerifiedItem> = {
+      loading: false,
+    };
+
+    if (!baseItem?.verified) {
+      result.status = statusText.failed;
+    }
+
+    if (!torrent || !baseItem?.verified) {
+      Object.assign(item, result);
+      return;
+    }
+
+    const baseTorrentInfo = baseTorrent.value!;
+    const torrentInfo = torrent;
+
+    // 首先检查 infoHash 是否相同
+    if (torrentInfo.infoHash && baseTorrentInfo.infoHash && torrentInfo.infoHash === baseTorrentInfo.infoHash) {
+      // infoHash 完全相同，说明是同一个种子
+      result.verified = true;
+    } else {
+      // infoHash 不同，检查名称和总大小是否相同
+      if (torrentInfo.name === baseTorrentInfo.name && torrentInfo.length === baseTorrentInfo.length) {
+        // 检查文件数量是否相同
+        if (torrentInfo.files?.length === baseTorrentInfo.files?.length) {
+          // 检查所有文件是否都能匹配（不要求顺序一致）
+          result.verified = torrentInfo.files.every((file) => {
+            return baseTorrentInfo.files.some(
+              (sourceFile) => file.path === sourceFile.path && file.length === sourceFile.length,
+            );
+          });
+        } else {
+          // 文件数量不同，检查是否缺少文件
+          const allFilesFound = torrentInfo.files.every((file) => {
+            return baseTorrentInfo.files.some(
+              (sourceFile) => file.path === sourceFile.path && file.length === sourceFile.length,
+            );
+          });
+          if (allFilesFound) {
+            result.status = statusText.missingFiles;
+          }
+        }
+      }
+    }
+
+    result.torrent = torrent;
+    if (result.verified) {
+      verifiedCount.value++;
+    }
+
+    if (!result.status) {
+      result.status = result.verified ? statusText.success : statusText.failed;
+    }
+
+    Object.assign(item, result);
+  }
+}
+
+function addToVerified(id: string) {
+  if (confirm(t("SearchEntity.KeepUploadDialog.addToKeepUploadConfirm"))) {
+    const item = verifiedItems.value.get(id);
+    if (item) {
+      item.verified = true;
+      verifiedCount.value++;
+    }
+  }
+}
+
+function removeVerifiedItem(id: string) {
+  const item = verifiedItems.value.get(id);
+  if (!item) return;
+  if (item.verified) {
+    verifiedCount.value--;
+  }
+  verifiedItems.value.delete(id);
+  verifiedItemsOrder.value = verifiedItemsOrder.value.filter((itemId) => itemId !== id);
+}
+
+function reDownload(id: string) {
+  const item = verifiedItems.value.get(id);
+  if (!item) return;
+  item.loading = true;
+  item.status = statusText.downloading;
+
+  getTorrent(item.data, id)
+    .then((result) => {
+      verification(result, id);
+    })
+    .catch(() => {
+      verification(null, id);
+    });
+}
+
+function closeDialog() {
+  showDialog.value = false;
+}
+
+// 获取种子文件数量
+function getFileCount(item: IVerifiedItem): number | string {
+  return item.torrent?.files?.length ?? "N/A";
+}
+
+// 创建辅种任务
+async function createKeepUploadTask() {
+  if (!canCreateTask.value || !selectedDownloaderId.value) return;
+
+  const verifiedList = Array.from(verifiedItems.value.values()).filter((item) => item.verified);
+  if (verifiedList.length === 0) {
+    runtimeStore.showSnakebar(t("SearchEntity.KeepUploadDialog.noVerifiedItem"), { color: "error" });
+    return;
+  }
+
+  creating.value = true;
+
+  try {
+    const downloader = metadataStore.downloaders[selectedDownloaderId.value];
+    const downloadOptions: IKeepUploadTaskDownloadOptions = {
+      downloaderId: selectedDownloaderId.value,
+      savePath: savePath.value || undefined,
+      clientName: downloader?.name || selectedDownloaderId.value,
+    };
+
+    const task: IKeepUploadTask = {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
+      time: Date.now(),
+      title: verifiedList[0].data.title || "Unknown",
+      size: verifiedList[0].data.size || 0,
+      downloadOptions,
+      items: verifiedList.map((item) => ({
+        site: item.data.site,
+        title: item.data.title || "",
+        subTitle: item.data.subTitle,
+        link: item.data.url || "", // ITorrent.url = 详情页链接
+        url: item.data.link || "", // ITorrent.link = 下载链接
+        size: item.data.size || 0,
+        seeders: item.data.seeders,
+        leechers: item.data.leechers,
+      })) as IKeepUploadTaskItem[],
+    };
+
+    await sendMessage("createKeepUploadTask", task);
+    runtimeStore.showSnakebar(t("SearchEntity.KeepUploadDialog.createSuccess"), { color: "success" });
+    closeDialog();
+  } catch (e) {
+    runtimeStore.showSnakebar(t("SearchEntity.KeepUploadDialog.createError"), { color: "error" });
+  } finally {
+    creating.value = false;
+  }
+}
+</script>
+
+<template>
+  <v-dialog v-model="showDialog" persistent scrollable max-width="1024">
+    <v-card>
+      <v-toolbar dark color="blue-grey-darken-2">
+        <v-toolbar-title>{{ t("SearchEntity.KeepUploadDialog.title") }}</v-toolbar-title>
+        <v-spacer />
+        <v-btn
+          icon
+          variant="text"
+          color="success"
+          href="https://github.com/pt-plugins/PT-Plugin-Plus/wiki/keep-upload-task"
+          target="_blank"
+          rel="noopener noreferrer nofollow"
+          :title="t('common.howToUse')"
+        >
+          <v-icon>mdi-help</v-icon>
+        </v-btn>
+      </v-toolbar>
+      <v-card-text style="max-height: 80vh">
+        <v-list lines="two" density="compact">
+          <template v-for="(id, index) in verifiedItemsOrder" :key="id">
+            <v-list-subheader v-if="index === 0">
+              {{ t("SearchEntity.KeepUploadDialog.baseTorrent") }}
+            </v-list-subheader>
+            <v-list-subheader v-if="index === 1">
+              {{ t("SearchEntity.KeepUploadDialog.otherTorrent") }}
+            </v-list-subheader>
+            <v-list-item v-if="verifiedItems.get(id)">
+              <template #prepend>
+                <v-avatar size="18">
+                  <SiteFavicon :site-id="verifiedItems.get(id)!.data.site" :size="18" />
+                </v-avatar>
+              </template>
+
+              <v-list-item-title class="list-item">
+                <a :href="verifiedItems.get(id)!.data.link" target="_blank" rel="noopener noreferrer nofollow">
+                  {{ verifiedItems.get(id)!.data.title }}
+                </a>
+              </v-list-item-title>
+              <v-list-item-subtitle>
+                {{ t("SearchEntity.KeepUploadDialog.size") }}{{ formatSize(verifiedItems.get(id)!.data.size ?? 0) }},
+                {{ t("SearchEntity.KeepUploadDialog.fileCount") }}{{ getFileCount(verifiedItems.get(id)!) }},
+                {{ t("SearchEntity.KeepUploadDialog.status.label") }}{{ verifiedItems.get(id)!.status }}
+              </v-list-item-subtitle>
+
+              <template #append>
+                <div class="d-flex ga-1">
+                  <v-btn
+                    v-if="
+                      verifiedItems.get(verifiedItemsOrder[0])?.verified &&
+                      !verifiedItems.get(id)!.loading &&
+                      !verifiedItems.get(id)!.verified &&
+                      index > 0
+                    "
+                    icon
+                    variant="text"
+                    :title="t('SearchEntity.KeepUploadDialog.addToKeepUpload')"
+                    @click.stop="addToVerified(id)"
+                  >
+                    <v-icon color="info">mdi-plus</v-icon>
+                  </v-btn>
+
+                  <v-btn
+                    v-if="
+                      verifiedItems.get(verifiedItemsOrder[0])?.verified &&
+                      !verifiedItems.get(id)!.loading &&
+                      !verifiedItems.get(id)!.torrent &&
+                      index > 0
+                    "
+                    icon
+                    variant="text"
+                    :title="t('SearchEntity.KeepUploadDialog.redownload')"
+                    @click.stop="reDownload(id)"
+                  >
+                    <v-icon color="green">mdi-sync</v-icon>
+                  </v-btn>
+
+                  <v-btn
+                    icon
+                    variant="text"
+                    :loading="verifiedItems.get(id)!.loading"
+                    :title="verifiedItems.get(id)!.status"
+                  >
+                    <v-icon v-if="verifiedItems.get(id)!.verified" color="success">mdi-check-all</v-icon>
+                    <v-icon
+                      v-else
+                      color="error"
+                      :title="t('SearchEntity.KeepUploadDialog.removeFromKeepUpload')"
+                      @click.stop="removeVerifiedItem(id)"
+                    >
+                      mdi-close
+                    </v-icon>
+                  </v-btn>
+                </div>
+              </template>
+            </v-list-item>
+            <v-divider v-if="index > 0" inset />
+          </template>
+        </v-list>
+      </v-card-text>
+      <v-divider />
+      <v-card-actions>
+        <template v-if="verifiedCount > 1">
+          <v-select
+            v-model="selectedDownloaderId"
+            :items="metadataStore.getSortedEnabledDownloaders"
+            item-title="name"
+            item-value="id"
+            density="compact"
+            hide-details
+            :label="t('SearchEntity.KeepUploadDialog.setSavePath')"
+            style="max-width: 200px"
+          />
+          <v-text-field
+            v-model="savePath"
+            density="compact"
+            hide-details
+            :label="t('KeepUploadTask.savePath')"
+            style="max-width: 200px"
+          />
+          <v-btn
+            variant="text"
+            color="info"
+            :loading="creating"
+            :disabled="!canCreateTask"
+            @click="createKeepUploadTask"
+          >
+            <v-icon class="mr-1">mdi-content-save</v-icon>
+            {{ t("SearchEntity.KeepUploadDialog.create") }}
+          </v-btn>
+        </template>
+        <v-spacer />
+        <v-btn color="error" variant="text" @click="closeDialog">
+          {{ t("common.dialog.close") }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<style scoped lang="scss">
+.list-item {
+  a {
+    color: #000;
+    text-decoration: none;
+  }
+
+  a:hover {
+    color: #008c00;
+  }
+}
+</style>

--- a/src/entries/shared/types.ts
+++ b/src/entries/shared/types.ts
@@ -13,6 +13,7 @@ export * from "./types/storages/indexdb.ts";
 export * from "./types/storages/metadata.ts";
 export * from "./types/storages/runtime.ts";
 export * from "./types/storages/other.ts";
+export * from "./types/storages/keepUploadTask.ts";
 
 export interface IRestoreOptions {
   fields?: TBackupFields[]; // 需要恢复的字段

--- a/src/entries/shared/types/storages/keepUploadTask.ts
+++ b/src/entries/shared/types/storages/keepUploadTask.ts
@@ -1,0 +1,51 @@
+/**
+ * 辅种任务相关类型定义
+ */
+
+import type { TSiteID } from "@ptd/site";
+import type { TDownloaderKey } from "./metadata.ts";
+import type { CAddTorrentOptions } from "@ptd/downloader";
+
+export type TKeepUploadTaskKey = string;
+
+/**
+ * 辅种任务中的种子项
+ */
+export interface IKeepUploadTaskItem {
+  site: TSiteID; // 站点id
+  title: string; // 标题
+  subTitle?: string; // 副标题
+  link: string; // 详情页链接
+  url: string; // 种子下载链接
+  size: number; // 大小
+  seeders?: number; // 上传者数量
+  leechers?: number; // 下载者数量
+  [key: string]: any; // 其他属性
+}
+
+/**
+ * 辅种任务下载选项
+ */
+export interface IKeepUploadTaskDownloadOptions {
+  downloaderId: TDownloaderKey; // 下载器id
+  savePath?: string; // 保存路径
+  clientName?: string; // 下载器名称（用于显示）
+  addTorrentOptions?: Partial<CAddTorrentOptions>; // 其他下载选项
+}
+
+/**
+ * 辅种任务
+ */
+export interface IKeepUploadTask {
+  id: TKeepUploadTaskKey; // 任务id
+  time: number; // 创建时间
+  title: string; // 任务标题（第一个种子的标题）
+  size: number; // 种子大小
+  downloadOptions: IKeepUploadTaskDownloadOptions; // 下载选项
+  items: IKeepUploadTaskItem[]; // 种子列表
+}
+
+/**
+ * 辅种任务存储结构
+ */
+export type TKeepUploadTaskStorageSchema = Record<TKeepUploadTaskKey, IKeepUploadTask>;

--- a/src/entries/storage.ts
+++ b/src/entries/storage.ts
@@ -5,6 +5,7 @@ import {
   IMetadataPiniaStorageSchema,
   TUserInfoStorageSchema,
   TSearchResultSnapshotStorageSchema,
+  TKeepUploadTaskStorageSchema,
 } from "@/shared/types.ts";
 
 export interface IExtensionStorageSchema {
@@ -15,6 +16,7 @@ export interface IExtensionStorageSchema {
 
   userInfo: TUserInfoStorageSchema; // 用于存储用户信息
   searchResultSnapshot: TSearchResultSnapshotStorageSchema; // 用于存储搜索结果快照
+  keepUploadTask: TKeepUploadTaskStorageSchema; // 用于存储辅种任务
 }
 
 export type TExtensionStorageKey = keyof IExtensionStorageSchema;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -231,6 +231,7 @@
   "DownloadHistory": {
     "refresh": "Refresh download history list",
     "reDownload": "Re-download",
+    "searchTorrent": "Search this torrent across all sites",
     "filterPlaceholder": "Filter download history",
     "table": {
       "title": "Torrent",
@@ -245,6 +246,53 @@
       "title": "Re-download {0} records",
       "oldMethod": "Retry with original method",
       "selectDownloader": "Select Downloader"
+    }
+  },
+  "KeepUploadTask": {
+    "title": "Reseed Tasks",
+    "savePath": "Save Path: ",
+    "defaultPath": "Default Path",
+    "torrentCount": "Torrents: ",
+    "clearConfirm": "Confirm clearing all reseed tasks?",
+    "emptyNotice": "No reseed tasks yet. Select torrents from search results and click reseed check button.",
+    "clearAll": "Clear All",
+    "deleteConfirm": "Confirm deleting this reseed task?",
+    "deleteSelectedConfirm": "Confirm deleting {count} selected reseed tasks?",
+    "deleteSuccess": "Deleted successfully",
+    "deleteError": "Delete failed",
+    "clearSuccess": "Cleared successfully",
+    "clearError": "Clear failed",
+    "sendSuccess": "Sent successfully",
+    "sendError": "Send failed",
+    "sendSingleSuccess": "Sent",
+    "sendSingleError": "Failed to send",
+    "sendConfirm": "Confirm sending {count} torrents to downloader?",
+    "sendBaseTorrent": "Send base torrent",
+    "sendOtherTorrents": "Send other torrents",
+    "sendAllTorrents": "Send all torrents",
+    "setAsBaseTorrent": "Set as base torrent",
+    "setBaseSuccess": "Set as base torrent successfully",
+    "setBaseError": "Failed to set as base torrent",
+    "seeders": "Seeders: ",
+    "leechers": "Leechers: ",
+    "copyLinks": "Copy download links",
+    "copySuccess": "Copied {count} download links",
+    "copyError": "Copy failed",
+    "editSavePath": "Edit save path",
+    "updateSuccess": "Updated successfully",
+    "updateError": "Update failed",
+    "table": {
+      "site": "Site",
+      "title": "Title",
+      "size": "Size",
+      "count": "Count",
+      "time": "Created At"
+    },
+    "warning": {
+      "title": "Warning:",
+      "item1": "Please confirm that the download client has disabled 'auto start download' option before reseeding.",
+      "item2": "The assistant only performs simple verification on torrent files, reseeding success is not guaranteed!",
+      "item3": "Users are responsible for any issues caused by failed reseeding!"
     }
   },
   "torrent": {
@@ -485,6 +533,33 @@
     },
     "SaveSnapshotDialog": {
       "snapshotName": "Snapshot Name"
+    },
+    "KeepUploadDialog": {
+      "title": "Reseed Verification",
+      "keepUpload": "Reseed Check",
+      "baseTorrent": "Base Torrent",
+      "otherTorrent": "Other Torrents",
+      "size": "Size: ",
+      "fileCount": "Files: ",
+      "addToKeepUpload": "Add to reseed list",
+      "addToKeepUploadConfirm": "Confirm adding this torrent to reseed list?",
+      "redownload": "Re-download torrent info",
+      "removeFromKeepUpload": "Remove from list",
+      "setSavePath": "Set save path",
+      "create": "Create Task",
+      "createSuccess": "Reseed task created successfully",
+      "createError": "Failed to create reseed task",
+      "noVerifiedItem": "No verified torrents",
+      "status": {
+        "label": "Status: ",
+        "downloading": "Downloading torrent info...",
+        "waiting": "Waiting for verification...",
+        "downloaded": "Torrent info downloaded",
+        "success": "Verification passed",
+        "failed": "Verification failed",
+        "downloadFailed": "Failed to download torrent",
+        "missingFiles": "Missing files"
+      }
     }
   },
   "SearchResultSnapshot": {

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -231,6 +231,7 @@
   "DownloadHistory": {
     "refresh": "刷新下载记录列表",
     "reDownload": "重新下载",
+    "searchTorrent": "全站搜索此种子",
     "filterPlaceholder": "过滤下载记录",
     "table": {
       "title": "种子",
@@ -245,6 +246,53 @@
       "title": "重新下载 {0} 条记录",
       "oldMethod": "按原下载方式重试",
       "selectDownloader": "选择下载服务器"
+    }
+  },
+  "KeepUploadTask": {
+    "title": "辅种任务",
+    "savePath": "保存路径：",
+    "defaultPath": "默认路径",
+    "torrentCount": "种子数：",
+    "clearConfirm": "确认清空所有辅种任务吗？",
+    "emptyNotice": "暂无辅种任务，请在搜索结果页面选择种子后点击辅种检测按钮",
+    "clearAll": "清空全部",
+    "deleteConfirm": "确认删除该辅种任务吗？",
+    "deleteSelectedConfirm": "确认删除选中的 {count} 个辅种任务吗？",
+    "deleteSuccess": "删除成功",
+    "deleteError": "删除失败",
+    "clearSuccess": "清空成功",
+    "clearError": "清空失败",
+    "sendSuccess": "发送成功",
+    "sendError": "发送失败",
+    "sendSingleSuccess": "发送成功",
+    "sendSingleError": "发送失败",
+    "sendConfirm": "确认发送 {count} 个种子到下载器？",
+    "sendBaseTorrent": "发送基准种子",
+    "sendOtherTorrents": "发送其他种子",
+    "sendAllTorrents": "发送所有种子",
+    "setAsBaseTorrent": "设为基准种子",
+    "setBaseSuccess": "已设为基准种子",
+    "setBaseError": "设置失败",
+    "seeders": "上传：",
+    "leechers": "下载：",
+    "copyLinks": "复制下载链接",
+    "copySuccess": "已复制 {count} 个下载链接",
+    "copyError": "复制失败",
+    "editSavePath": "修改保存路径",
+    "updateSuccess": "更新成功",
+    "updateError": "更新失败",
+    "table": {
+      "site": "站点",
+      "title": "标题",
+      "size": "大小",
+      "count": "种子数",
+      "time": "创建时间"
+    },
+    "warning": {
+      "title": "警告：",
+      "item1": "辅种前请确认下载服务器已关闭类似于「自动开始下载」的选项（如果有）。",
+      "item2": "助手仅对种子文件做简单验证，不保证辅种成功，请自行斟酌是否要使用辅种功能！",
+      "item3": "如出现因辅种失败造成的爆仓，由用户自行负责！"
     }
   },
   "torrent": {
@@ -485,6 +533,33 @@
     },
     "SaveSnapshotDialog": {
       "snapshotName": "快照名称"
+    },
+    "KeepUploadDialog": {
+      "title": "辅种检测",
+      "keepUpload": "辅种检测",
+      "baseTorrent": "基准种子",
+      "otherTorrent": "其他种子",
+      "size": "大小：",
+      "fileCount": "文件数：",
+      "addToKeepUpload": "添加到辅种列表",
+      "addToKeepUploadConfirm": "确认将该种子添加到辅种列表？",
+      "redownload": "重新下载种子信息",
+      "removeFromKeepUpload": "从列表中移除",
+      "setSavePath": "设置保存路径",
+      "create": "创建任务",
+      "createSuccess": "辅种任务创建成功",
+      "createError": "辅种任务创建失败",
+      "noVerifiedItem": "没有验证通过的种子",
+      "status": {
+        "label": "状态：",
+        "downloading": "正在下载种子信息...",
+        "waiting": "等待验证...",
+        "downloaded": "种子信息已下载",
+        "success": "验证通过",
+        "failed": "验证失败",
+        "downloadFailed": "下载种子失败",
+        "missingFiles": "缺少文件"
+      }
     }
   },
   "SearchResultSnapshot": {


### PR DESCRIPTION
## 辅种任务管理功能

### 功能概述

实现了一个完整的辅种任务管理系统，帮助用户在不同 PT 站点间进行辅种操作，功能参照原PTPP插件。

### 主要功能

- **种子验证**：多选种子下载并解析种子文件，对比 `infoHash`、文件名称、大小和文件列表，判断是否可以辅种
- **任务管理**：提供辅种任务列表页面，支持查看、删除、清空任务，支持设置基准种子
- **批量操作**：支持发送基准种子、其他种子或全部种子到下载器

### 使用方法

1. 在搜索结果页面，选择 2 个及以上种子
2. 点击「辅种检测」按钮
3. 系统自动下载并验证种子信息
4. 验证通过的种子可创建辅种任务
5. 在「辅种任务」页面管理已创建的任务


## Add Reseed Task Management Feature

### Overview

Implements a complete reseed task management system to help users perform cross-tracker reseeding operations.

### Key Features

- **Torrent Verification**: Automatically downloads and parses torrent files, comparing `infoHash`, file names, sizes, and file lists to determine if reseeding is possible
- **Task Management**: Provides a reseed task list page with support for viewing, deleting, and clearing tasks
- **Batch Operations**: Supports sending base torrent, other torrents, or all torrents to the downloader

### Usage

1. On the search results page, select 2 or more torrents
2. Click the "Reseed Check" button
3. The system automatically downloads and verifies torrent information
4. Verified torrents can be used to create reseed tasks
5. Manage created tasks in the "Reseed Tasks" page

## Summary by Sourcery

Add reseed task management across sites, including torrent verification, task persistence, and UI for creating and managing reseed tasks from search results.

New Features:
- Introduce torrent verification API to fetch minimal torrent metadata for cross-site reseed checking.
- Add a reseed check dialog on the search results page to verify multiple torrents and create reseed tasks with downloader options.
- Provide a reseed task overview page to view, send, reorder, and delete stored reseed tasks.
- Persist reseed tasks in extension storage with typed schemas and message-based CRUD operations.