### PR TITLE
fix(pkg/site/aither): update userInfo selectors

### DIFF
--- a/src/packages/site/definitions/aither.ts
+++ b/src/packages/site/definitions/aither.ts
@@ -1,5 +1,5 @@
 import { type ISiteMetadata } from "../types";
-import { CategoryFree, SchemaMetadata } from "../schemas/Unit3D.ts";
+import { CategoryFree, SchemaMetadata, userInfoTrans } from "../schemas/Unit3D.ts";
 import { buildCategoryOptionsFromDict } from "../utils.ts";
 
 const categoryMap: Record<number, string> = {
@@ -22,6 +22,117 @@ export const siteMetadata: ISiteMetadata = {
   schema: "Unit3D",
 
   urls: ["uggcf://nvgure.pp/"],
+
+  category: [
+    {
+      name: "类别",
+      key: "categoryIds",
+      options: buildCategoryOptionsFromDict(categoryMap),
+      cross: { mode: "brackets" },
+    },
+    {
+      name: "规格",
+      key: "typeIds",
+      options: [
+        { name: "Full Disc", value: 1 },
+        { name: "Remux", value: 2 },
+        { name: "Encode", value: 3 },
+        { name: "WEB-DL", value: 4 },
+        { name: "WEBRip", value: 5 },
+        { name: "HDTV", value: 6 },
+        { name: "Other", value: 7 },
+        { name: "Movie Pack", value: 10 },
+        { name: "Music - General", value: 20 },
+        { name: "Blues", value: 29 },
+        { name: "Classical", value: 30 },
+        { name: "Electronic", value: 31 },
+        { name: "Hip-Hop / Rap", value: 32 },
+        { name: "Jazz &amp; Funk", value: 33 },
+        { name: "Latin", value: 34 },
+        { name: "Pop", value: 35 },
+        { name: "Rock", value: 36 },
+        { name: "Test", value: 16 },
+      ],
+      cross: { mode: "brackets" },
+    },
+    {
+      name: "分辨率",
+      key: "resolutionIds",
+      options: [
+        { name: "4320p", value: 1 },
+        { name: "2160p", value: 2 },
+        { name: "1080p", value: 3 },
+        { name: "1080i", value: 4 },
+        { name: "720p", value: 5 },
+        { name: "576p", value: 6 },
+        { name: "576i", value: 7 },
+        { name: "480p", value: 8 },
+        { name: "480i", value: 9 },
+        { name: "Other", value: 10 },
+      ],
+      cross: { mode: "brackets" },
+    },
+    CategoryFree,
+  ],
+
+  search: {
+    ...SchemaMetadata.search,
+    skipNonLatinCharacters: true,
+    selectors: {
+      ...SchemaMetadata.search!.selectors,
+      category: {
+        selector: ":self",
+        data: "categoryId",
+        filters: [(query: string) => categoryMap[Number(query)]],
+      },
+      tags: [
+        ...SchemaMetadata.search!.selectors!.tags!,
+        {
+          name: "H&R",
+          selector: "*",
+          color: "red",
+        },
+      ],
+    },
+  },
+
+  userInfo: {
+    ...SchemaMetadata.userInfo!,
+    selectors: {
+      ...SchemaMetadata.userInfo!.selectors!,
+      id: {
+        ...SchemaMetadata.userInfo!.selectors!.id,
+        selector: userInfoTrans.id.map((x) => `span[title='${x}'] + span`),
+      },
+      seedingSize: {
+        ...SchemaMetadata.userInfo!.selectors!.seedingSize,
+        selector: userInfoTrans.seedingSize.map((x) => `span[title='${x}'] + span`),
+      },
+      joinTime: {
+        ...SchemaMetadata.userInfo!.selectors!.joinTime,
+        selector: userInfoTrans.joinTime.map((x) => `span[title='${x}'] + span`),
+      },
+      averageSeedingTime: {
+        ...SchemaMetadata.userInfo!.selectors!.averageSeedingTime,
+        selector: userInfoTrans.averageSeedingTime.map((x) => `span[title='${x}'] + span`),
+      },
+      lastAccessAt: {
+        selector: userInfoTrans.lastAccessAt.map((x) => `span[title='${x}'] + span`),
+        filters: [{ name: "parseTTL" }],
+      },
+      invites: {
+        ...SchemaMetadata.userInfo!.selectors!.invites,
+        selector: ".ratio-bar__invites",
+      },
+      ratio: {
+        selector: "li.ratio-bar__ratio a:has( > i.fa-sync-alt)",
+        filters: [{ name: "parseNumber" }],
+      },
+      uploads: {
+        selector: ".user-profile-card__meta-item  a[href*='/uploads']",
+      },
+    },
+  },
 
   levelRequirements: [
     {
@@ -97,77 +208,4 @@ export const siteMetadata: ISiteMetadata = {
       privilege: "自动通过候选 访问邀请区 免疫HR 不计算下载量 50下载槽 发送邀请",
     },
   ],
-
-  category: [
-    {
-      name: "类别",
-      key: "categoryIds",
-      options: buildCategoryOptionsFromDict(categoryMap),
-      cross: { mode: "brackets" },
-    },
-    {
-      name: "规格",
-      key: "typeIds",
-      options: [
-        { name: "Full Disc", value: 1 },
-        { name: "Remux", value: 2 },
-        { name: "Encode", value: 3 },
-        { name: "WEB-DL", value: 4 },
-        { name: "WEBRip", value: 5 },
-        { name: "HDTV", value: 6 },
-        { name: "Other", value: 7 },
-        { name: "Movie Pack", value: 10 },
-        { name: "Music - General", value: 20 },
-        { name: "Blues", value: 29 },
-        { name: "Classical", value: 30 },
-        { name: "Electronic", value: 31 },
-        { name: "Hip-Hop / Rap", value: 32 },
-        { name: "Jazz &amp; Funk", value: 33 },
-        { name: "Latin", value: 34 },
-        { name: "Pop", value: 35 },
-        { name: "Rock", value: 36 },
-        { name: "Test", value: 16 },
-      ],
-      cross: { mode: "brackets" },
-    },
-    {
-      name: "分辨率",
-      key: "resolutionIds",
-      options: [
-        { name: "4320p", value: 1 },
-        { name: "2160p", value: 2 },
-        { name: "1080p", value: 3 },
-        { name: "1080i", value: 4 },
-        { name: "720p", value: 5 },
-        { name: "576p", value: 6 },
-        { name: "576i", value: 7 },
-        { name: "480p", value: 8 },
-        { name: "480i", value: 9 },
-        { name: "Other", value: 10 },
-      ],
-      cross: { mode: "brackets" },
-    },
-    CategoryFree,
-  ],
-
-  search: {
-    ...SchemaMetadata.search,
-    skipNonLatinCharacters: true,
-    selectors: {
-      ...SchemaMetadata.search!.selectors,
-      category: {
-        selector: ":self",
-        data: "categoryId",
-        filters: [(query: string) => categoryMap[Number(query)]],
-      },
-      tags: [
-        ...SchemaMetadata.search!.selectors!.tags!,
-        {
-          name: "H&R",
-          selector: "*",
-          color: "red",
-        },
-      ],
-    },
-  },
 };

--- a/src/packages/site/schemas/Unit3D.ts
+++ b/src/packages/site/schemas/Unit3D.ts
@@ -15,18 +15,30 @@ import {
 } from "../types";
 import { parseTimeToLiveToDate, parseValidTimeString } from "../utils";
 
+type TUserInfoTransKey =
+  | "id"
+  | "seedingSize"
+  | "joinTime"
+  | "averageSeedingTime"
+  | "invites"
+  | "ratio"
+  | "trueRatio"
+  | "lastAccessAt";
+
 /**
- * Trans Array
+ * Trans Map
  * Source: https://github.com/HDInnovations/UNIT3D-Community-Edition/commit/cb1efe0868caf771b9917c090a79b28b4e183b74
  */
-const idTrans: string[] = ["User ID", "用户 ID", "用ID", "用户ID"];
-const seedingSizeTrans: string[] = ["Seeding Size", "Seeding size", "做种体积", "做種體積"];
-const joinTimeTrans: string[] = ["Registration date", "注册日期", "註冊日期"];
-const averageSeedingTimeTrans: string[] = ["Average Seedtime", "Average seedtime", "平均做种时间", "平均做種時間"];
-const invitesTrans: string[] = ["Invites", "邀请", "邀請"];
-const ratioTrans: string[] = ["Ratio", "分享率", "比率"];
-const trueRatioTrans: string[] = ["Real Ratio", "真实分享率", "真實比率"];
-const lastAccessAtTrans: string[] = ["Last login", "Last Login", "上次登录时间", "上次登入"];
+export const userInfoTrans: Record<TUserInfoTransKey, string[]> = {
+  id: ["User ID", "用户 ID", "用ID", "用户ID"],
+  seedingSize: ["Seeding Size", "Seeding size", "做种体积", "做種體積"],
+  joinTime: ["Registration date", "注册日期", "註冊日期"],
+  averageSeedingTime: ["Average Seedtime", "Average seedtime", "平均做种时间", "平均做種時間"],
+  invites: ["Invites", "邀请", "邀請"],
+  ratio: ["Ratio", "分享率", "比率"],
+  trueRatio: ["Real Ratio", "真实分享率", "真實比率"],
+  lastAccessAt: ["Last login", "Last Login", "上次登录时间", "上次登入"],
+};
 
 export const CategoryFree: ISearchCategories = {
   name: "Buff",
@@ -374,7 +386,10 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
       },
       // "/users/$user.name$"
       id: {
-        selector: idTrans.map((x) => `td:contains('${x}') + td`),
+        selector: [
+          ...userInfoTrans.id.map((x) => `dt:contains('${x}') + dd`),
+          ...userInfoTrans.id.map((x) => `td:contains('${x}') + td`),
+        ],
         filters: [(query: string) => parseInt(query || "0")],
       },
       uploaded: {
@@ -387,8 +402,8 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
       },
       ratio: {
         selector: [
-          ...ratioTrans.map((x) => `td:contains('${x}') + td`),
-          ...ratioTrans.map((x) => `dt:contains('${x}') + dd`),
+          ...userInfoTrans.ratio.map((x) => `dt:contains('${x}') + dd`),
+          ...userInfoTrans.ratio.map((x) => `td:contains('${x}') + td`),
           "li.ratio-bar__ratio a:has( > i.fa-sync-alt)",
           "span:has( > i.fa-sync-alt)",
         ],
@@ -396,8 +411,8 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
       },
       trueRatio: {
         selector: [
-          ...trueRatioTrans.map((x) => `td:contains('${x}') + td`),
-          ...trueRatioTrans.map((x) => `dt:contains('${x}') + dd`),
+          ...userInfoTrans.trueRatio.map((x) => `dt:contains('${x}') + dd`),
+          ...userInfoTrans.trueRatio.map((x) => `td:contains('${x}') + td`),
         ],
         filters: [{ name: "parseNumber" }],
       },
@@ -416,16 +431,16 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
       seedingSize: {
         // table.table-condensed:first
         selector: [
-          ...seedingSizeTrans.map((x) => `td:contains('${x}') + td`),
-          ...seedingSizeTrans.map((x) => `dt:contains('${x}') + dd`),
+          ...userInfoTrans.seedingSize.map((x) => `dt:contains('${x}') + dd`),
+          ...userInfoTrans.seedingSize.map((x) => `td:contains('${x}') + td`),
         ],
         filters: [{ name: "parseSize" }],
       },
       averageSeedingTime: {
         // table.table-condensed:first
         selector: [
-          ...averageSeedingTimeTrans.map((x) => `td:contains('${x}') + td span.badge-user`),
-          ...averageSeedingTimeTrans.map((x) => `dt:contains('${x}') + dd`),
+          ...userInfoTrans.averageSeedingTime.map((x) => `dt:contains('${x}') + dd`),
+          ...userInfoTrans.averageSeedingTime.map((x) => `td:contains('${x}') + dd span.badge-user`),
         ],
         filters: [{ name: "parseDuration" }],
       },
@@ -459,10 +474,13 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
         },
       },
       joinTime: {
-        selector: ["time.profile__registration", ...joinTimeTrans.map((x) => `div.content h4:contains('${x}')`)],
+        selector: [
+          "time.profile__registration",
+          ...userInfoTrans.joinTime.map((x) => `div.content h4:contains('${x}')`),
+        ],
         filters: [
           (query: string) => {
-            query = query.replace(RegExp(joinTimeTrans.join("|")), "");
+            query = query.replace(RegExp(userInfoTrans.joinTime.join("|")), "");
             query = query.replace(/^:+/g, "").trim();
             return parseValidTimeString(query, ["MMM dd yyyy, HH:mm:ss", "MMM dd yyyy", "yyyy-MM-dd"]);
           },
@@ -470,8 +488,8 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
       },
       lastAccessAt: {
         selector: [
-          ...lastAccessAtTrans.map((x) => `dt:contains('${x}') + dd time`),
-          ...lastAccessAtTrans.map((x) => `td:contains('${x}') + td`),
+          ...userInfoTrans.lastAccessAt.map((x) => `dt:contains('${x}') + dd time`),
+          ...userInfoTrans.lastAccessAt.map((x) => `td:contains('${x}') + td`),
         ],
         elementProcess: (el: Element) => {
           const dateStr = el.getAttribute("title") ?? el.getAttribute("datetime");
@@ -480,8 +498,8 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
       },
       invites: {
         selector: [
-          ...invitesTrans.map((x) => `td:contains('${x}'):last + td`),
-          ...invitesTrans.map((x) => `dt:contains('${x}'):last + dd`),
+          ...userInfoTrans.invites.map((x) => `dt:contains('${x}'):last + dd`),
+          ...userInfoTrans.invites.map((x) => `td:contains('${x}'):last + td`),
         ],
         filters: [{ name: "parseNumber" }],
       },


### PR DESCRIPTION
## Summary by Sourcery

Unify and extend UNIT3D user info parsing to support updated profile markup and translations, and adjust the Aither site definition to use the shared user info translation map and new selectors.

Bug Fixes:
- Fix extraction of user profile fields (ID, seeding size, join time, average seedtime, invites, ratio, last access) for UNIT3D-based sites when page structure or labels vary.
- Correct Aither user info selectors to match the current DOM structure and reliably parse stats and activity data.

Enhancements:
- Introduce a centralized translation map for UNIT3D user info labels and refactor existing selectors to use it for better maintainability and localization coverage.
- Extend UNIT3D and Aither user info selectors to support additional DOM patterns (e.g., dt/dd blocks, span title attributes) and add an extra search tag for H&R torrents.