### PR TITLE
feat(site): add donor config for account-keeping and bonus handling

### DIFF
--- a/src/entries/options/views/Overview/MyData/UserLevelRequirementsTd.vue
+++ b/src/entries/options/views/Overview/MyData/UserLevelRequirementsTd.vue
@@ -54,7 +54,7 @@ const userLevelGroupType = computed(() => {
 });
 
 const isDonorAccountKept = computed(() => {
-  return userInfo.isDonor === true && userInfoMetadata.value?.donorConfig?.isAccoutKept === true;
+  return userInfo.isDonor === true && userInfoMetadata.value?.donorConfig?.isAccountKept === true;
 });
 
 const currentUserLevelColor = computed(() => {

--- a/src/packages/site/definitions/pter.ts
+++ b/src/packages/site/definitions/pter.ts
@@ -311,7 +311,7 @@ export const siteMetadata: ISiteMetadata = {
     },
     donorConfig: {
       ...SchemaMetadata.userInfo?.donorConfig,
-      isAccoutKept: true,
+      isAccountKept: true,
     },
   },
 

--- a/src/packages/site/definitions/totheglory.ts
+++ b/src/packages/site/definitions/totheglory.ts
@@ -301,7 +301,7 @@ export const siteMetadata: ISiteMetadata = {
       },
     ],
     donorConfig: {
-      isAccoutKept: true,
+      isAccountKept: true,
       bonusPerHourMultiplier: 1,
     },
   },

--- a/src/packages/site/schemas/NexusPHP.ts
+++ b/src/packages/site/schemas/NexusPHP.ts
@@ -573,11 +573,11 @@ export const SchemaMetadata: Pick<
     ],
     /**
      * donorConfig 配置捐赠者（黄星）的特殊权限
-     * - isAccoutKept: false（NexusPHP 默认黄星不免疫不活跃）
+     * - isAccountKept: false（NexusPHP 默认黄星不免疫不活跃）
      * - bonusPerHourMultiplier: 2（NexusPHP 默认时魔 2 倍） 站点配置中，如果能直接使用 selector 选出正确的时魔，则此系数应设为 1
      */
     donorConfig: {
-      isAccoutKept: false,
+      isAccountKept: false,
       bonusPerHourMultiplier: 2,
     },
   },

--- a/src/packages/site/types/site.ts
+++ b/src/packages/site/types/site.ts
@@ -356,11 +356,11 @@ export interface ISiteMetadata {
 
     /**
      * donorConfig 配置捐赠者（黄星）的特殊权限
-     * - isAccoutKept 捐赠者是否免疫账户不活跃封禁
+     * - isAccountKept 捐赠者是否免疫账户不活跃封禁
      * - bonusPerHourMultiplier 捐赠者的时魔倍数，如果能直接使用 selector 选出正确的时魔，此系数应设为 1
      */
     donorConfig?: {
-      isAccoutKept?: boolean;
+      isAccountKept?: boolean;
       bonusPerHourMultiplier?: number;
     };
 


### PR DESCRIPTION
在 site.ts 的 userInfo 中新增了一个 donorConfig，用来配置特定站点的如下属性：

- 黄星是否保号，即免除不活跃封禁
- 黄星的时魔修正系数

---

这一 PR 的原因：

前一段时间引入了”保号等级显示为蓝色“的功能，但判断依据是固定的 levelRequirements，无法处理特殊的情况。

为解决此问题，首先在 #1057 引入了一个选择器来匹配捐赠状态，做好了准备。

随后，要处理捐赠者保号这一逻辑：
- 第一个想法是在 getUserInfoResult() 中动态覆盖 levelRequirements 中的 isKept 属性，但这不利于站点适配，每次都要 override 比较麻烦。
 - 第二个想法，新增一个配置项，在 UserLevelRequirementsTd.vue 中加检查。思考了一下觉得此方法更适合，故采用。

## Summary by Sourcery

Add configurable donor behavior in site metadata and apply it to user info display and bonus calculations.

New Features:
- Introduce a donorConfig section in site metadata to define donor-specific privileges like account-keeping and bonus multipliers.
- Use donorConfig to adjust donors' hourly bonus values during user info parsing.
- Use donorConfig to treat qualifying donors as account-kept users in the user level color display.

Enhancements:
- Refactor site-specific donor handling (e.g., Pter) to rely on shared donorConfig instead of custom overrides.