### PR TITLE
fix(pkg/site/pussytorrents): Update seeding/seedingSize filters to include additional "Act" condition on data

### DIFF
--- a/src/packages/site/definitions/pussytorrents.ts
+++ b/src/packages/site/definitions/pussytorrents.ts
@@ -283,7 +283,7 @@ export const siteMetadata: ISiteMetadata = {
             if (!Array.isArray(aaData)) {
               return 0;
             }
-            return aaData.filter((data: any) => data[7] === 1).length;
+            return aaData.filter((data: any) => data[7] === 1 && data[8] === "Yes").length;
           }
         ]
       },
@@ -293,7 +293,7 @@ export const siteMetadata: ISiteMetadata = {
           (aaData: any) => {
             if (!Array.isArray(aaData)) return 0;
             return aaData.reduce((total: number, data: any) => {
-              return data[7] === 1 && data[1] ? total + parseSizeString(data[1]) : total;
+              return data[7] === 1 && data[8] === "Yes" && data[1] ? total + parseSizeString(data[1]) : total;
             }, 0);
           }
         ]


### PR DESCRIPTION
Update seeding/seedingSize filters to include additional "Act" condition on data

## Summary by Sourcery

Tighten PussyTorrents seeding-related metrics to only count entries that are both actively seeding and marked as active.

Bug Fixes:
- Ensure seeding count only includes rows that are actively seeding and flagged as active in the data.
- Ensure total seeding size calculation only sums sizes for rows that are actively seeding and flagged as active in the data.