### PR TITLE
fix(site/hdsky): enhance torrent download link retrieval in firefox

### DIFF
--- a/src/packages/site/definitions/hdsky.ts
+++ b/src/packages/site/definitions/hdsky.ts
@@ -345,7 +345,7 @@ export default class Hdsky extends NexusPHP {
      */
     if (torrent.link) {
       const hasPasskey = /&passkey=/.test(torrent.link);
-      if (!hasPasskey) {
+      if (hasPasskey) {
         return torrent.link;
       }
 


### PR DESCRIPTION
在原先的 link 获取过程中，由于 HDSKY 在 Firefox 环境中返回的链接格式为 `/download.php?id=<tid>&passkey=<passkey>&sign=<sign>` 导致 站点实例在执行 getTorrentDownloadLink 方法时，无法获取到 `&t=` 参数，进而导致导致可以下载的正确链接被错误的移除，随后回落到 NexusPHP 模板的 getTorrentDownloadLink 方法，导致错误的下载链接 `/download.php?id=<tid>` 被拼出。
至此， HDSKY 站点在符合： ①使用 Firefox 浏览器； ②在种子详情页使用助手推送 的情况下，无法获取到正确的下载链接。


closed: #1098

## Summary by Sourcery

Bug Fixes:
- Ensure Firefox retrieves stable HDSky torrent download links by prioritizing passkey-based URLs over time-limited ones.