### PR TITLE
fix(filesize): restrict size regex to prevent misidentification.

### DIFF
--- a/src/packages/site/utils/filesize.ts
+++ b/src/packages/site/utils/filesize.ts
@@ -1,4 +1,4 @@
-export const sizePattern = /^(\d*\.?\d+)(.*[^ZEPTGMK])?([ZEPTGMK](B|iB))s?$/i;
+export const sizePattern = /^(\d*\.?\d+)([\s\-_]{0,3})([ZEPTGMK](B|iB))s?$/i;
 
 export type TSizeUnit = `${"" | "K" | "M" | "G" | "T" | "P" | "E" | "Z"}${"i" | ""}B`;
 export type TSize = `${number}${" " | ""}${TSizeUnit}`;


### PR DESCRIPTION
在正在做种的种子列表中，当某个种子标题正好夹杂了 `数字 + EB 或者 ZB` 此类的字符，且正好位于做种列表的第一个时，会导致将某个 td 误判为体积。

close: #1097

## Summary by Sourcery

Bug Fixes:
- Prevent torrent list entries with titles containing number+EB/ZB-like substrings from being incorrectly parsed as file sizes.