### PR TITLE
fix(pkg/site/NexusPHP): restrict isDonor selector scope

### DIFF
--- a/src/packages/site/schemas/NexusPHP.ts
+++ b/src/packages/site/schemas/NexusPHP.ts
@@ -433,7 +433,7 @@ export const SchemaMetadata: Pick<
       },
       isDonor: {
         text: false,
-        selector: ["img[alt='Donor']"],
+        selector: ["h1:has(img[src^='pic/flag']) img[alt='Donor']"],
         elementProcess: () => true,
       },
       bonus: {


### PR DESCRIPTION
原本的选择器可能选到其它地方的黄星图标，比如 邀请人 的，参考了几个站点结构将搜索范围限制在用户名元素内，以尝试解决该问题

## Summary by Sourcery

Bug Fixes:
- Prevent misidentification of donor status by narrowing the donor icon selector to the user title section.