### PR TITLE
fix(pkg/site): fix site baozi

### DIFF
--- a/src/packages/site/definitions/baozi.ts
+++ b/src/packages/site/definitions/baozi.ts
@@ -1,6 +1,5 @@
 import type { ISiteMetadata, IUserInfo } from "../types";
 import NexusPHP, {
-  baseUserIdSelector,
   CategoryInclbookmarked,
   CategoryIncldead,
   CategorySpstate,
@@ -272,16 +271,17 @@ export default class BaoZi extends NexusPHP {
       selector: "b:eq(0)",
       filters: [(x) => parseInt(x)],
     });
-    flushUserInfo.seedingSize = this.getFieldData(userSeedingDocument, {
-      selector: "b:eq(0)",
-      elementProcess: (el: Element) => {
-        const summaryText = el.closest("div")?.textContent ?? "";
-        const candidateText = (summaryText.split("|")[1] ?? summaryText).replace(/,/g, "");
-        const numberStartIndex = candidateText.search(/[\d.]/);
-        const sizeText = numberStartIndex >= 0 ? candidateText.slice(numberStartIndex).trim() : "";
-        return sizeText ? parseSizeString(sizeText) : 0;
-      },
-    });
+    flushUserInfo.seedingSize =
+      this.getFieldData(userSeedingDocument, {
+        selector: "b:eq(0)",
+        elementProcess: (el: Element) => {
+          const summaryText = el.closest("div")?.textContent ?? "";
+          const candidateText = (summaryText.split("|")[1] ?? summaryText).replace(/,/g, "");
+          const numberStartIndex = candidateText.search(/[\d.]/);
+          const sizeText = numberStartIndex >= 0 ? candidateText.slice(numberStartIndex).trim() : "";
+          return sizeText ? parseSizeString(sizeText) : 0;
+        },
+      }) ?? 0;
 
     return flushUserInfo;
   }


### PR DESCRIPTION
Draft: 

先尝试修复 seeding，有待测试

## Summary by Sourcery

Update BaoZi site definition to correctly resolve user identity and seeding statistics using a custom NexusPHP-based implementation.

New Features:
- Add a BaoZi-specific class extending the NexusPHP schema to parse user seeding count and total seeding size from the user seeding page.

Bug Fixes:
- Fix user ID extraction and clear cached IDs for BaoZi so user-related data is fetched reliably.
- Correct donor bonus configuration so bonus-per-hour values account for BaoZi's multiplier.
- Handle BaoZi seeding status parsing with a site-specific fallback when the standard seeding summary markup is present.

Enhancements:
- Extend the BaoZi site metadata with refined user info selectors and utilities for parsing numeric and size fields from HTML responses.