### PR TITLE
feat: support M-Team H5 torrent detail page

### DIFF
--- a/src/entries/content-script/index.ts
+++ b/src/entries/content-script/index.ts
@@ -1,6 +1,6 @@
 // This file is the entry point for the content script
 
-import { definitionList, getDefinedSiteMetadata, getHostFromUrl } from "@ptd/site";
+import { getHostFromUrl } from "@ptd/site";
 import { socialPageParserMatchesMap } from "@ptd/social";
 
 import { sendMessage } from "@/messages.ts";
@@ -8,41 +8,6 @@ import type { IMetadataPiniaStorageSchema } from "@/shared/types/storages/metada
 import type { IConfigPiniaStorageSchema } from "@/shared/types/storages/config.ts";
 
 import { mountApp } from "./app/init.ts";
-
-async function resolveSiteIdByHost(host: string, metadataStore: IMetadataPiniaStorageSchema) {
-  if (metadataStore.siteHostMap[host]) {
-    return metadataStore.siteHostMap[host];
-  }
-
-  const candidateSiteIds = Array.from(new Set([...Object.keys(metadataStore.sites ?? {}), ...definitionList]));
-
-  for (const siteId of candidateSiteIds) {
-    const candidateUrls = new Set<string>();
-    const siteConfig = metadataStore.sites?.[siteId];
-
-    if (siteConfig?.url) {
-      candidateUrls.add(siteConfig.url);
-    }
-
-    try {
-      const siteMetadata = await getDefinedSiteMetadata(siteId);
-      for (const url of siteMetadata.urls ?? []) {
-        candidateUrls.add(url);
-      }
-      for (const url of siteMetadata.legacyUrls ?? []) {
-        candidateUrls.add(url);
-      }
-    } catch (error) {
-      console.debug(`[PTD] Failed to load site metadata for host resolution: ${siteId}`, error);
-    }
-
-    for (const candidateUrl of candidateUrls) {
-      if (getHostFromUrl(candidateUrl) === host) {
-        return siteId;
-      }
-    }
-  }
-}
 
 sendMessage("getExtStorage", "config").then(async (data) => {
   const configStore = data as IConfigPiniaStorageSchema;
@@ -65,14 +30,10 @@ sendMessage("getExtStorage", "config").then(async (data) => {
 
       const host = getHostFromUrl(window.location.href); // 获取当前页面的 host
 
-      const siteId = await resolveSiteIdByHost(host, metadataStore);
-
-      if (siteId) {
-        if (!metadataStore.siteHostMap[host]) {
-          metadataStore.siteHostMap[host] = siteId;
-          sendMessage("setExtStorage", { key: "metadata", value: metadataStore }).catch();
-        }
+      if (metadataStore.siteHostMap[host]) {
         // 如果当前页面的 host 在 metadataStore 中有对应的 siteId，加载 app
+        const siteId = metadataStore.siteHostMap[host];
+
         if (
           configStore?.contentScript?.allowExceptionSites === true &&
           metadataStore.sites[siteId]?.allowContentScript === false


### PR DESCRIPTION
Summary
- support M-Team H5 detail pages like `https://h5.m-team.cc/#/torrent/:id`
- resolve torrent id from the H5 route instead of relying on mobile page DOM
- reuse the user-configured M-Team site domain for follow-up detail/download flow
- keep compatibility with frequently changing M-Team domains

Tested
- verified the PTD floating button appears on M-Team H5 torrent detail pages
- verified push/download works after resolving the torrent id from H5 URL
- verified the logic follows the site domain configured in PTD settings instead of hardcoding a domain

## Summary by Sourcery

Support M-Team H5 torrent detail pages and make M-Team site and host resolution more robust and configuration-driven.

New Features:
- Enable handling of M-Team H5 torrent detail URLs alongside the existing desktop detail pages.

Bug Fixes:
- Ensure torrent download works reliably by robustly resolving the torrent ID from detail, link, or URL when it is missing.

Enhancements:
- Normalize the configured M-Team site URL and derive API, Origin, and web base URLs from it instead of relying on hardcoded domains.
- Update M-Team detail page parsing to extract torrent IDs from both legacy and H5-style URLs and propagate a canonical detail URL into torrent metadata.
- Introduce a content-script host resolution helper that maps arbitrary hosts (including legacy URLs) to site IDs using both stored config and built-in site metadata, caching the result in metadata storage.