### PR TITLE
feat(morethantv): add isKept to Engineer level

### DIFF
--- a/src/packages/site/definitions/morethantv.ts
+++ b/src/packages/site/definitions/morethantv.ts
@@ -199,6 +199,7 @@ export const siteMetadata: ISiteMetadata = {
       uploaded: "3000GB",
       uploads: 500,
       posts: 25,
+      isKept: true,
       privilege:
         "Engineer Restricted forum; FREE Invites (Send a staff PM for us to credit your account); Immune from inactivity disablement",
     },


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Introduce the isKept flag for the Engineer user level in the MoreThanTV site metadata.