### PR TITLE
fix(pkg/site/pter): add no-cache headers for userInfo requests.

### DIFF
--- a/src/packages/site/definitions/pter.ts
+++ b/src/packages/site/definitions/pter.ts
@@ -13,7 +13,7 @@ import NexusPHP, {
   CategorySpstate,
   SchemaMetadata,
 } from "../schemas/NexusPHP.ts";
-import { parseSizeString } from "@ptd/site";
+import { parseSizeString } from "../utils";
 
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,

--- a/src/packages/site/schemas/NexusPHP.ts
+++ b/src/packages/site/schemas/NexusPHP.ts
@@ -364,6 +364,7 @@ export const SchemaMetadata: Pick<
         ],
       },
       uploaded: {
+        text: 0,
         selector: [
           "td.rowhead:contains('传输') + td",
           "td.rowhead:contains('傳送') + td",
@@ -378,6 +379,7 @@ export const SchemaMetadata: Pick<
         ],
       },
       trueUploaded: {
+        text: 0,
         selector: [
           "td.rowhead:contains('传输') + td",
           "td.rowhead:contains('傳送') + td",
@@ -394,6 +396,7 @@ export const SchemaMetadata: Pick<
         ],
       },
       downloaded: {
+        text: 0,
         selector: [
           "td.rowhead:contains('传输') + td",
           "td.rowhead:contains('傳送') + td",
@@ -408,6 +411,7 @@ export const SchemaMetadata: Pick<
         ],
       },
       trueDownloaded: {
+        text: 0,
         selector: [
           "td.rowhead:contains('传输') + td",
           "td.rowhead:contains('傳送') + td",


### PR DESCRIPTION
close: #1130

## Summary by Sourcery

Improve Pter site user info parsing and enforce no-cache headers on user info requests.

Bug Fixes:
- Correctly extract and parse real uploaded and downloaded traffic values from the Pter user info page.
- Prevent stale user info data by adding no-cache headers to all user info requests for the Pter site.