### PR TITLE
fix(pkg/site/tjupt): fix rows selector to exclude last tr.

### DIFF
--- a/src/packages/site/definitions/tjupt.ts
+++ b/src/packages/site/definitions/tjupt.ts
@@ -127,6 +127,7 @@ export const siteMetadata: ISiteMetadata = {
     },
     selectors: {
       ...SchemaMetadata.search!.selectors,
+      rows: { selector: "table.torrents:last > tbody > tr:gt(0):not(:last)" },
       progress: selectorSearchProgress,
       status: selectorSearchStatus,
       tags: [


### PR DESCRIPTION
fix these:

<img width="1189" height="130" alt="Snipaste_2026-03-29_11-28-15" src="https://github.com/user-attachments/assets/81d4cb79-c50a-4145-9dd2-08a715666581" />

<img width="1445" height="124" alt="Snipaste_2026-03-29_11-27-53" src="https://github.com/user-attachments/assets/18d9c113-73d6-411e-be3e-78cd7d6152f9" />

## Summary by Sourcery

Bug Fixes:
- Fix tjupt search results parsing by excluding the last table row from the rows selector.