### PR TITLE
fix(pkg/site): mark sugoimusic and pornbay as dead

### DIFF
--- a/src/packages/site/definitions/pornbay.ts
+++ b/src/packages/site/definitions/pornbay.ts
@@ -1,8 +1,8 @@
 import { type ISiteMetadata } from "../types";
-import { SchemaMetadata } from "../schemas/Luminance";
+// import { SchemaMetadata } from "../schemas/Luminance";
 
 export const siteMetadata: ISiteMetadata = {
-  ...SchemaMetadata,
+  // ...SchemaMetadata,
   id: "pornbay",
   version: 1,
   name: "Pornbay",
@@ -14,6 +14,10 @@ export const siteMetadata: ISiteMetadata = {
 
   urls: ["uggcf://cbeaonl.bet/"],
 
+  // Extensive downtime
+  isDead: true,
+
+  /*
   category: [
     {
       name: "类别",
@@ -97,6 +101,7 @@ export const siteMetadata: ISiteMetadata = {
       },
     },
   },
+  */
 
   levelRequirements: [
     {

--- a/src/packages/site/definitions/sugoimusic.ts
+++ b/src/packages/site/definitions/sugoimusic.ts
@@ -1,8 +1,8 @@
 import { type ISiteMetadata } from "../types";
-import { SchemaMetadata } from "../schemas/GazelleJSONAPI.ts";
+// import { SchemaMetadata } from "../schemas/GazelleJSONAPI.ts";
 
 export const siteMetadata: ISiteMetadata = {
-  ...SchemaMetadata,
+  // ...SchemaMetadata,
 
   version: 1,
   id: "sugoimusic",
@@ -19,12 +19,17 @@ export const siteMetadata: ISiteMetadata = {
 
   urls: ["https://sugoimusic.me/"],
 
+  // Official recruitment on JPS is closed + extensive downtime
+  isDead: true,
+
+  /*
   search: {
     ...SchemaMetadata.search!,
     advanceKeywordParams: {
       imdb: false,
     },
   },
+  */
 
   levelRequirements: [
     {


### PR DESCRIPTION
两个站点均已离线很久，同时 SugoiMusic 在 JPopsuki 上的官邀也关闭了。因此将这些站点标记为 `isDead: true`。

## Summary by Sourcery

Mark legacy Pornbay and SugoiMusic site definitions as dead and disable their schema-based configuration.

Enhancements:
- Comment out shared schema imports and spreads in the Pornbay and SugoiMusic site metadata definitions to decouple them from active schema logic.

Chores:
- Annotate Pornbay and SugoiMusic with isDead flags and comments indicating prolonged downtime and closed recruitment.