### PR TITLE
fix(pkg/site/cgpeers): new selectors

### DIFF
--- a/src/packages/site/definitions/cgpeers.ts
+++ b/src/packages/site/definitions/cgpeers.ts
@@ -15,9 +15,15 @@ const categoryMap: Record<number, string> = {
   9: "Web Development",
 };
 
+const linkSelector = { selector: "a[href*='torrent/download/']", attr: "href" };
+const idSelector = {
+  ...linkSelector,
+  filters: [{ name: "split", args: ["/", 3] }, { name: "split", args: ["?", 0] }, { name: "parseNumber" }],
+};
+
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,
-  version: 1,
+  version: 2,
   id: "cgpeers",
   name: "CGPeers",
   aka: ["CGP"],
@@ -26,7 +32,7 @@ export const siteMetadata: ISiteMetadata = {
   timezoneOffset: "+0000",
 
   type: "private",
-  schema: "Luminance",
+  schema: "Luminance", // CGPeers
 
   urls: ["https://cgpeers.to/"],
   legacyUrls: ["https://www.cgpeers.com/"],
@@ -47,11 +53,19 @@ export const siteMetadata: ISiteMetadata = {
 
   search: {
     ...SchemaMetadata.search,
+    requestConfig: {
+      ...SchemaMetadata.search!.requestConfig!,
+      url: "/torrent/browse",
+    },
     advanceKeywordParams: {
       imdb: false,
     },
     selectors: {
       ...SchemaMetadata.search!.selectors,
+      id: idSelector,
+      title: { selector: "span + a[href*='torrent/']" },
+      url: { selector: "span + a[href*='torrent/']", attr: "href" },
+      link: linkSelector,
       category: {
         selector: "td.cats_col > div[title] > a",
         attr: "href",
@@ -85,18 +99,48 @@ export const siteMetadata: ISiteMetadata = {
 
   userInfo: {
     ...SchemaMetadata.userInfo!,
+    process: [
+      {
+        requestConfig: { url: "/", responseType: "document" },
+        fields: ["id"],
+      },
+      {
+        requestConfig: { url: "/user/$id$", responseType: "document" },
+        assertion: { id: "url" },
+        fields: [
+          "name",
+          "joinTime",
+          "lastAccessAt",
+          "uploaded",
+          "downloaded",
+          "levelName",
+          "bonus",
+          "ratio",
+          "uploads",
+          "bonusPerHour",
+          "seeding",
+          "seedingSize",
+          "messageCount",
+          "posts",
+        ],
+      },
+    ],
     selectors: {
       ...SchemaMetadata.userInfo!.selectors,
+      id: {
+        selector: ["div.user-dropdown-section a[href^='/user/']"],
+        attr: "href",
+        filters: [{ name: "split", args: ["/", 2] }],
+      },
       name: {
         selector: ["a#userDropdownTrigger", "span.user_name"],
         switchFilters: { "span.user_name": [{ name: "split", args: ["\n", 0] }] },
       },
-      id: {
-        selector: ["a[href^='/user.php?id=']"],
-        attr: "href",
-        filters: [{ name: "querystring", args: ["id"] }],
+      messageCount: {
+        text: 0,
+        selector: "a#userDropdownTrigger .user-notification-badge",
+        filters: [{ name: "parseNumber" }],
       },
-      messageCount: { selector: "a#userDropdownTrigger .user-notification-badge", filters: [{ name: "parseNumber" }] },
     },
   },
 
@@ -104,7 +148,9 @@ export const siteMetadata: ISiteMetadata = {
     ...SchemaMetadata.detail!,
     selectors: {
       ...SchemaMetadata.detail!.selectors,
-      title: { selector: "table.cgp-tb-torrent-details div.torrent-name-details > span:first-child" },
+      title: { selector: "div.page-header h2" },
+      id: idSelector,
+      link: linkSelector,
     },
   },
 

--- a/src/packages/site/schemas/Luminance.ts
+++ b/src/packages/site/schemas/Luminance.ts
@@ -1,13 +1,5 @@
-import { omit, toMerged } from "es-toolkit";
-import {
-  ETorrentStatus,
-  EResultParseStatus,
-  type ISiteMetadata,
-  type IUserInfo,
-  type ITorrent,
-  type ISearchInput,
-  NeedLoginError,
-} from "../types";
+import { toMerged } from "es-toolkit";
+import { ETorrentStatus, type ISiteMetadata, type IUserInfo, type ITorrent, type ISearchInput } from "../types";
 import { GazelleBase } from "./Gazelle";
 import { parseSizeString, definedFilters } from "../utils";
 import Sizzle from "sizzle";
@@ -85,14 +77,46 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
 
   userInfo: {
     pickLast: ["id"],
+    process: [
+      {
+        requestConfig: { url: "/", responseType: "document" },
+        fields: ["id"],
+      },
+      {
+        requestConfig: {
+          url: "/user.php",
+          params: {
+            /* id: flushUserInfo.id */
+          },
+          responseType: "document",
+        },
+        assertion: { id: "params.id" },
+        fields: [
+          "name",
+          "joinTime",
+          "lastAccessAt",
+          "uploaded",
+          "downloaded",
+          "levelName",
+          "bonus",
+          "ratio",
+          "uploads",
+          "bonusPerHour",
+          "seeding",
+          "seedingSize",
+          "messageCount",
+          "posts",
+        ],
+      },
+    ],
     selectors: {
       // "/user.php?id="
-      name: { selector: ["a.username"] },
       id: {
         selector: ["a.username"],
         attr: "href",
         filters: [{ name: "querystring", args: ["id"] }],
       },
+      name: { selector: ["a.username"] },
       joinTime: {
         selector: ["ul.stats > li:contains('Joined:') > span.time"],
         attr: "title",
@@ -156,6 +180,7 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
           "ul.stats > li:contains('Seeding:')": [{ name: "split", args: ["(", 0] }, { name: "parseNumber" }],
         },
       },
+      seedingSize: { selector: "ul.stats > li:contains('Seeding Size:')", filters: [{ name: "parseSize" }] },
       messageCount: {
         selector: ":self",
         elementProcess: (doc: Document) => {
@@ -177,7 +202,7 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
   detail: {
     urlPattern: ["/torrents\\.php\\?id=\\d+"],
     selectors: {
-      title: { selector: ["table.torrent_table tr[id] strong"] },
+      title: { selector: ["#content > .details > h2", "table.torrent_table tr[id] strong"] },
       id: {
         selector: ["a[href*='/torrents.php?action=download']"],
         attr: "href",
@@ -258,90 +283,22 @@ export default class Luminance extends GazelleBase {
     return this.getTorrentDownloadLinkFactory("id")(torrent);
   }
 
-  public override async getUserInfoResult(lastUserInfo: Partial<IUserInfo> = {}): Promise<IUserInfo> {
-    let flushUserInfo: IUserInfo = {
-      status: EResultParseStatus.unknownError,
-      updateAt: +new Date(),
-      site: this.metadata.id,
-    };
+  protected async parseUserInfoForSeedingSize(
+    flushUserInfo: Partial<IUserInfo>,
+    dataDocument: Document,
+  ): Promise<Partial<IUserInfo>> {
+    // 对有 Seeding Size 行的站点直接解析对应元素
+    let seedingSize =
+      this.metadata.userInfo?.selectors?.seedingSize &&
+      this.getFieldData(dataDocument, this.metadata.userInfo.selectors.seedingSize); // 在 elementQuery 内进行大小解析
 
-    if (!this.allowQueryUserInfo) {
-      flushUserInfo.status = EResultParseStatus.passParse;
-      return flushUserInfo;
-    }
+    flushUserInfo.seedingSize = seedingSize;
 
-    // 如果定义了 process，则按照 AbstractPrivateSite 的方式处理
-    if (Array.isArray(this.metadata.userInfo?.process)) {
-      return await super.getUserInfoResult(lastUserInfo);
-    }
-
-    // 否则直接使用 Luminance 的方式获取用户信息
-    try {
-      let id: number;
-      if (lastUserInfo !== null && lastUserInfo.id) {
-        id = lastUserInfo.id as number;
-      } else {
-        // 如果没有 id 信息，则访问一次 主页
-        id = await this.getUserIdFromSite();
-      }
-      flushUserInfo.id = id;
-
-      const { data: userDetailDocument } = await this.request<Document>({
-        url: `/user.php?id=${id}`,
-        responseType: "document",
-      });
-
-      // 导入基本 Details 页面获取到的用户信息
-      flushUserInfo = toMerged(flushUserInfo, await this.getUserInfoFromDetailsPage(userDetailDocument));
-
-      if (flushUserInfo.seeding) {
-        // 对有 Seeding Size 行的站点直接解析对应元素
-        const seedingList = Sizzle("ul.stats > li:contains('Seeding Size:')", userDetailDocument);
-        if (seedingList.length > 0) {
-          flushUserInfo.seedingSize = definedFilters.parseSize(seedingList[0].textContent);
-        } else {
-          // 否则则尝试解析做种列表计算获取
-          flushUserInfo = toMerged(flushUserInfo, await this.getSeedingSize(id));
-        }
-      }
-
-      // 如果前面没有获取到用户等级的id，则尝试通过定义的 levelRequirements 来获取
-      if (this.metadata.levelRequirements && flushUserInfo.levelName && typeof flushUserInfo.levelId === "undefined") {
-        flushUserInfo.levelId = this.guessUserLevelId(flushUserInfo as IUserInfo);
-      }
-
-      flushUserInfo.status = EResultParseStatus.success;
-    } catch (e) {
-      flushUserInfo.status = EResultParseStatus.parseError;
-
-      if (e instanceof NeedLoginError) {
-        flushUserInfo.status = EResultParseStatus.needLogin;
-      }
+    if (!seedingSize) {
+      // 否则则尝试解析做种列表计算获取
+      flushUserInfo = toMerged(flushUserInfo, await this.getSeedingSize(flushUserInfo.id as number));
     }
 
     return flushUserInfo;
-  }
-
-  protected async getUserIdFromSite(): Promise<number> {
-    await this.sleepAction(this.metadata.userInfo?.requestDelay);
-
-    const { data: indexDocument } = await this.request<Document>(
-      {
-        url: "/",
-        responseType: "document",
-      },
-      true,
-    );
-    return this.getFieldData(indexDocument, this.metadata.userInfo?.selectors?.id!);
-  }
-
-  protected async getUserInfoFromDetailsPage(userDetailDocument: Document): Promise<Partial<IUserInfo>> {
-    await this.sleepAction(this.metadata.userInfo?.requestDelay);
-
-    return this.getFieldsData(
-      userDetailDocument,
-      this.metadata.userInfo?.selectors!,
-      Object.keys(omit(this.metadata.userInfo?.selectors!, ["id"])),
-    ) as Partial<IUserInfo>;
   }
 }


### PR DESCRIPTION
此更改还将 `Luminance` 的用户数据获取更换成了更简单的 `SchemaMetadata.userInfo.process` + `parseUserInfoForSeedingSize` 写法，方便站点自定义用户数据获取方法

## Summary by Sourcery

Update Luminance schema and cgpeers site definition to use the generic userInfo process pipeline and new DOM selectors for search, torrent details, and user data.

New Features:
- Support parsing user seeding size via a dedicated seedingSize selector in the Luminance schema.

Bug Fixes:
- Correct cgpeers search, detail, and user info parsing by updating selectors and request URLs to match the current site markup.

Enhancements:
- Refactor Luminance user info handling to rely on SchemaMetadata.userInfo.process combined with parseUserInfoForSeedingSize instead of custom request logic.
- Expand torrent title and id selectors in Luminance and cgpeers to be more robust against markup variations.