### PR TITLE
fix(pkg/site/skyeysnow): fix torrent link parsing on detail page.

### DIFF
--- a/src/packages/site/definitions/skyeysnow.ts
+++ b/src/packages/site/definitions/skyeysnow.ts
@@ -124,6 +124,29 @@ export const siteMetadata: ISiteMetadata = {
       },
     },
   },
+
+  list: [
+    {
+      urlPattern: [/\/forum\.php\?mod=torrents/],
+    },
+  ],
+
+  detail: {
+    urlPattern: [/\/forum\.php\?mod=viewthread/],
+    selectors: {
+      title: { selector: ["span#thread_subject"] },
+      id: {
+        selector: ['div.pi a[href*="download.php?id="]'],
+        attr: "href",
+        filters: [{ name: "querystring", args: ["id"] }],
+      },
+      link: {
+        selector: ['div.pi a[href*="download.php?id="][href*="&passkey="]', 'div.pi a[href*="download.php?id="]'],
+        attr: "href",
+      },
+    },
+  },
+
   userInfo: {
     pickLast: ["id", "name"],
     process: [


### PR DESCRIPTION
close: #1150

## Summary by Sourcery

Bug Fixes:
- Correct torrent link and ID extraction on skyeysnow detail pages by updating selectors and URL patterns.