### PR TITLE
fix(pkg/site/speedapp): fix level nameAka.

### DIFF
--- a/src/packages/site/definitions/speedapp.ts
+++ b/src/packages/site/definitions/speedapp.ts
@@ -1,4 +1,11 @@
-import type { ISiteMetadata, ISearchEntryRequestConfig, ISearchResult, ITorrent } from "../types.ts";
+import type {
+  ISiteMetadata,
+  ISearchEntryRequestConfig,
+  ISearchResult,
+  ITorrent,
+  IUserInfo,
+  TLevelId,
+} from "../types.ts";
 import PrivateSite from "../schemas/AbstractPrivateSite.ts";
 import { buildCategoryOptionsFromDict } from "../utils.ts";
 
@@ -520,6 +527,19 @@ export const siteMetadata: ISiteMetadata = {
 };
 
 export default class SpeedApp extends PrivateSite {
+  protected override guessUserLevelId(userInfo: IUserInfo): TLevelId {
+    if (userInfo.levelName === "超级用户" && typeof userInfo.uploaded === "number") {
+      // 区分 SpeedApp 中同名中文级别的特征，Super User (20TB) vs Power User (200GB)
+      const uploadedTB = userInfo.uploaded / (1024 * 1024 * 1024 * 1024);
+      if (uploadedTB >= 20) {
+        return 6; // Super User
+      } else {
+        return 3; // Power User
+      }
+    }
+    return super.guessUserLevelId(userInfo);
+  }
+
   /**
    * SpeedApp 搜索方法
    * 适配 SpeedApp 高级搜索多个分类共用 tags 参数的情况


### PR DESCRIPTION
close: #1153


再等个 power user 的别名，改完了一起 merge

## Summary by Sourcery

Bug Fixes:
- Restore the Chinese alias for the Super User level so it is recognized in site metadata.