### PR TITLE
feat(i18n): add more description for download link suffix.

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -917,7 +917,7 @@
       "otherSettings": "Other Settings",
       "downloadLinkSuffix": "Download Link Suffix",
       "downloadLinkSuffixHint": "This field will be automatically appended to the site's download links",
-      "downloadLinkSuffixExample": "E.g. if the plugin gets https://example.com/download.php?id=1 and you set &passkey=xxxx, the final download link will be https://example.com/download.php?id=1&passkey=xxxx",
+      "downloadLinkSuffixExample": "E.g. if the plugin gets https://example.com/download.php?id=1 and you set &passkey=xxxx, the final download link will be https://example.com/download.php?id=1&passkey=xxxx. Leave this empty by default, and only fill in the passkey if the correct download link cannot be obtained.",
       "requestTimeout": "Request Timeout",
       "requestTimeoutHint": "Affects the timeout for site requests (torrent search, user info retrieval)",
       "downloadInterval": "Download Interval",

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -914,7 +914,7 @@
       "otherSettings": "其他设置",
       "downloadLinkSuffix": "下载链接后缀",
       "downloadLinkSuffixHint": "该字段会被自动添加到该站点的下载链接后",
-      "downloadLinkSuffixExample": "如插件获得的链接为 https://example.com/download.php?id=1，此处设置为 &passkey=xxxx， 则最终下载链接为 https://example.com/download.php?id=1&passkey=xxxx",
+      "downloadLinkSuffixExample": "如插件获得的链接为 https://example.com/download.php?id=1，此处设置为 &passkey=xxxx， 则最终下载链接为 https://example.com/download.php?id=1&passkey=xxxx. 通常无须填写，仅在无法获得 passkey 时可手动添加",
       "requestTimeout": "请求超时",
       "requestTimeoutHint": "影响该站点请求（种子搜索、用户信息获取）的超时等待时间",
       "downloadInterval": "下载间隔",


### PR DESCRIPTION
close: #1181

## Summary by Sourcery

Expand internationalized descriptions related to the download link suffix in both English and Simplified Chinese locale files.

New Features:
- Add more descriptive i18n strings for the download link suffix in the English locale.
- Add corresponding descriptive i18n strings for the download link suffix in the Simplified Chinese locale.