### PR TITLE
fix(pkg/site): bonusPerHour page for hxpt.

### DIFF
--- a/src/packages/site/definitions/hxpt.ts
+++ b/src/packages/site/definitions/hxpt.ts
@@ -100,6 +100,11 @@ export const siteMetadata: ISiteMetadata = {
         filters: [{ name: "parseNumber" }],
       },
     },
+    process: SchemaMetadata.userInfo!.process!.map((item) =>
+      item.requestConfig?.url === "/mybonus.php"
+        ? { ...item, requestConfig: { ...item.requestConfig, url: "/mybonusmine.php" } }
+        : item,
+    ),
   },
 
   levelRequirements: [


### PR DESCRIPTION
观察几天，等稳定后 mr

## Summary by Sourcery

Bug Fixes:
- Correct the HXPT user info bonus process URL from /mybonus.php to /mybonusmine.php in the site metadata configuration.