### PR TITLE
fix(pkg/site): fix subTitle selector for SSD.

### DIFF
--- a/src/packages/site/definitions/springsunday.ts
+++ b/src/packages/site/definitions/springsunday.ts
@@ -248,7 +248,7 @@ export const siteMetadata: ISiteMetadata = {
         attr: "href",
       },
       subTitle: {
-        selector: ["div.torrent-smalldescr:first > span"],
+        selector: ["div.torrent-smalldescr:first > span:not(.torrent-icon-fast)"],
       },
 
       progress: {


### PR DESCRIPTION
close: #1201

## Summary by Sourcery

Bug Fixes:
- Prevent subtitle extraction from including elements with the fast torrent icon class in the SpringSunday site definition.