### PR TITLE
fix(pkg/site/springsunday): add seedingBonusPerHour selector for bonus calculation

### DIFF
--- a/src/packages/site/definitions/springsunday.ts
+++ b/src/packages/site/definitions/springsunday.ts
@@ -329,6 +329,11 @@ export const siteMetadata: ISiteMetadata = {
         selector: ["tbody tr.nowrap:first td:last"],
         filters: [{ name: "parseNumber" }],
       },
+      // issue #1205
+      seedingBonusPerHour: {
+        selector: ["tbody tr.nowrap:first > td:nth-child(9)"],
+        filters: [{ name: "parseNumber" }],
+      },
       messageCount: {
         ...SchemaMetadata.userInfo!.selectors!.messageCount,
         selector: ["a[href*='messages.php'] > b[style*='background: darkorange']"],


### PR DESCRIPTION
closed: #1205

## Summary by Sourcery

New Features:
- Introduce a seedingBonusPerHour selector in the SpringSunday site metadata to enable hourly bonus computation.