### PR TITLE
fix(pkg/site): fix discount tags

### DIFF
--- a/src/packages/site/definitions/avistaz.ts
+++ b/src/packages/site/definitions/avistaz.ts
@@ -1,5 +1,5 @@
 import { ISiteMetadata, ISearchInput, IAdvancedSearchRequestConfig, ITorrent, ITorrentTag } from "../types";
-import AvistazNetwork, { SchemaMetadata, IAvzNetRawTorrent } from "../schemas/AvistazNetwork.ts";
+import AvistazNetwork, { SchemaMetadata, avzNetDiscountMap, IAvzNetRawTorrent } from "../schemas/AvistazNetwork.ts";
 
 const categoryMap: Record<number, string> = {
   0: "All",
@@ -21,12 +21,6 @@ const tvTypeMap: Record<number, string> = {
   1: "Single Episode",
   2: "Full Season",
   3: "Complete",
-};
-
-const discountMap: Record<number, string> = {
-  1: "Free-Download",
-  2: "Half-Download",
-  3: "Double Upload",
 };
 
 export const siteMetadata: ISiteMetadata = {
@@ -73,7 +67,7 @@ export const siteMetadata: ISiteMetadata = {
       name: "促销",
       key: "discount",
       keyPath: "params",
-      options: Object.entries(discountMap).map(([value, name]) => ({ name, value: Number(value) })),
+      options: Object.entries(avzNetDiscountMap).map(([value, name]) => ({ name, value: Number(value) })),
       cross: { mode: "appendQuote" },
     },
     {
@@ -149,8 +143,8 @@ export default class Avistaz extends AvistazNetwork {
     row: IAvzRawTorrent,
     searchConfig: ISearchInput,
   ): Partial<ITorrent> {
-    const tags: ITorrentTag[] = [];
     const extendTorrent = super.parseTorrentRowForTags(torrent, row, searchConfig);
+    const tags: ITorrentTag[] = extendTorrent.tags || [];
 
     // 完结
     if (row.movie_tv?.tv_complete) {

--- a/src/packages/site/definitions/cinemaz.ts
+++ b/src/packages/site/definitions/cinemaz.ts
@@ -1,5 +1,5 @@
 import { ISiteMetadata, ISearchInput, ITorrent, ITorrentTag } from "../types";
-import AvistazNetwork, { SchemaMetadata, IAvzNetRawTorrent } from "../schemas/AvistazNetwork.ts";
+import AvistazNetwork, { SchemaMetadata, avzNetDiscountMap, IAvzNetRawTorrent } from "../schemas/AvistazNetwork.ts";
 
 const categoryMap: Record<number, string> = {
   0: "All",
@@ -21,12 +21,6 @@ const tvTypeMap: Record<number, string> = {
   1: "Single Episode",
   2: "Full Season",
   3: "Complete",
-};
-
-const discountMap: Record<number, string> = {
-  1: "Free-Download",
-  2: "Half-Download",
-  3: "Double Upload",
 };
 
 export const siteMetadata: ISiteMetadata = {
@@ -70,7 +64,7 @@ export const siteMetadata: ISiteMetadata = {
       name: "促销",
       key: "discount",
       keyPath: "params",
-      options: Object.entries(discountMap).map(([value, name]) => ({ name, value: Number(value) })),
+      options: Object.entries(avzNetDiscountMap).map(([value, name]) => ({ name, value: Number(value) })),
       cross: { mode: "appendQuote" },
     },
     {

--- a/src/packages/site/definitions/exoticaz.ts
+++ b/src/packages/site/definitions/exoticaz.ts
@@ -1,6 +1,7 @@
 import { ISiteMetadata, ISearchInput, IAdvancedSearchRequestConfig, ITorrent, ITorrentTag } from "../types";
 import AvistazNetwork, {
   SchemaMetadata,
+  avzNetDiscountMap,
   IAvzNetRawTorrent,
 } from "../schemas/AvistazNetwork.ts";
 
@@ -25,12 +26,6 @@ const resolutionMap: Record<number, string> = {
   7: "4320p",
   8: "VR 180°",
   9: "VR 360°",
-};
-
-const discountMap: Record<number, string> = {
-  1: "Free-Download",
-  2: "Half-Download",
-  3: "Double Upload",
 };
 
 export const siteMetadata: ISiteMetadata = {
@@ -81,7 +76,7 @@ export const siteMetadata: ISiteMetadata = {
       name: "促销",
       key: "discount",
       keyPath: "params",
-      options: Object.entries(discountMap).map(([value, name]) => ({ name, value: Number(value) })),
+      options: Object.entries(avzNetDiscountMap).map(([value, name]) => ({ name, value: Number(value) })),
       cross: { mode: "appendQuote" },
     },
     {
@@ -268,6 +263,7 @@ export default class Exoticaz extends AvistazNetwork {
     searchConfig: ISearchInput,
   ): Partial<ITorrent> {
     const extendTorrent = super.parseTorrentRowForTags(torrent, row, searchConfig);
+    const tags: ITorrentTag[] = extendTorrent.tags || [];
 
     // 处理副标题相关逻辑
     const performersObject = row.performers;
@@ -279,7 +275,6 @@ export default class Exoticaz extends AvistazNetwork {
     const subTitle = [performersStr, tagsStr].filter(Boolean).join(" | ");
     extendTorrent.subTitle = subTitle;
 
-    const tags: ITorrentTag[] = [];
     const statusTags: Record<string, { name: string }> = {
       asian: { name: "亚洲" },
       softcore: { name: "擦边" },

--- a/src/packages/site/schemas/AvistazNetwork.ts
+++ b/src/packages/site/schemas/AvistazNetwork.ts
@@ -37,6 +37,12 @@ const commonListSelectors: TSchemaMetadataListSelectors = {
   category: { selector: "i[data-original-title]", attr: "data-original-title" },
 };
 
+export const avzNetDiscountMap: Record<number, string> = {
+  1: "Free-Download",
+  2: "Half-Download",
+  3: "Double Upload",
+};
+
 export interface IAvzNetRawTorrent {
   id: number;
   file_name: string;


### PR DESCRIPTION
## Summary by Sourcery

Unify Avistaz-network discount handling and ensure site-specific tag parsing preserves tags from the shared schema.

Bug Fixes:
- Fix discount filter options for Avistaz, Cinemaz, and Exoticaz to use the shared AvistazNetwork discount mapping.
- Preserve existing tags from AvistazNetwork when adding additional tags in Avistaz and Exoticaz torrent row parsing.

Enhancements:
- Extract the AvistazNetwork discount map into a shared export reused across Avistaz, Cinemaz, and Exoticaz site definitions.