### PR TITLE
fix(pkg/site): fearnopeer closed & emp new domain

### DIFF
--- a/src/packages/site/definitions/empornium.ts
+++ b/src/packages/site/definitions/empornium.ts
@@ -65,7 +65,7 @@ export const siteMetadata: ISiteMetadata = {
   type: "private",
   schema: "Luminance",
 
-  urls: ["uggcf://jjj.rzcbeavhz.fk/"],
+  urls: ["uggcf://rzcnenqvfr.ef/", "uggcf://jjj.rzcbeavhz.fk/"],
   legacyUrls: ["https://www.empornium.is/", "https://www.empornium.me/", "uggcf://jjj.rzcbeavhz.ef/"],
 
   category: [

--- a/src/packages/site/definitions/fearnopeer.ts
+++ b/src/packages/site/definitions/fearnopeer.ts
@@ -1,7 +1,8 @@
 import { type ISiteMetadata } from "../types";
-import { SchemaMetadata } from "../schemas/Unit3D.ts";
-import { buildCategoryOptionsFromDict, buildCategoryOptionsFromList } from "../utils";
+// import { SchemaMetadata } from "../schemas/Unit3D.ts";
+// import { buildCategoryOptionsFromDict, buildCategoryOptionsFromList } from "../utils";
 
+/*
 const categoryMap: Record<number, string> = {
   1: "Movie",
   2: "TV",
@@ -12,9 +13,10 @@ const categoryMap: Record<number, string> = {
   9: "Sport",
   11: "Assorted",
 };
+*/
 
 export const siteMetadata: ISiteMetadata = {
-  ...SchemaMetadata,
+  // ...SchemaMetadata,
   id: "fearnopeer",
   version: 1,
   name: "FearNoPeer",
@@ -29,6 +31,10 @@ export const siteMetadata: ISiteMetadata = {
 
   urls: ["uggcf://srneabcrre.pbz/"],
 
+  // refs: https://web.archive.org/web/20260511185534/https://old.reddit.com/r/trackers/comments/1tac6ry/fearnopeer_is_shutting_down/
+  isDead: true,
+
+  /*
   category: [
     {
       name: "类别",
@@ -221,6 +227,7 @@ export const siteMetadata: ISiteMetadata = {
       },
     },
   },
+  */
 
   levelRequirements: [
     {


### PR DESCRIPTION
## Summary by Sourcery

Mark FearNoPeer tracker as closed and update Empornium tracker domains.

Bug Fixes:
- Mark FearNoPeer as dead and disable its schema and category configuration to reflect its shutdown.
- Add the new Empornium primary domain while retaining existing domains as alternates.