### PR TITLE
feat(pkg/site/animebytes): support company & seiyuu & characters pages

### DIFF
--- a/src/packages/site/definitions/animebytes.ts
+++ b/src/packages/site/definitions/animebytes.ts
@@ -305,12 +305,18 @@ export const siteMetadata: ISiteMetadata = {
       },
     },
     {
-      urlPattern: ["/collage\\.php\\?id=\\d+"],
+      urlPattern: [
+        "/collage\\.php.*?[&?]id=\\d+",
+        "/company\\.php.*?[&?]id=\\d+",
+        "/seiyuu\\.php.*?[&?]id=\\d+",
+        "/characters\\.php.*?[&?]id=\\d+",
+      ],
       mergeSearchSelectors: false,
       selectors: {
         ...SchemaMetadata.search!.selectors!,
         ...commonListSelectors,
         title: { selector: "td > strong:has(a[title='View Torrent'])" },
+        category: { selector: "img[src^='/static/common/caticons/']", attr: "title" },
 
         rows: {
           ...SchemaMetadata.search!.selectors!.rows!,
@@ -320,7 +326,7 @@ export const siteMetadata: ISiteMetadata = {
       },
     },
     {
-      urlPattern: ["/series\\.php\\?id=\\d+", "/artist\\.php\\?id=\\d+"],
+      urlPattern: ["/series\\.php.*?[&?]id=\\d+", "/artist\\.php.*?[&?]id=\\d+"],
       mergeSearchSelectors: false,
       selectors: {
         ...SchemaMetadata.search!.selectors!,


### PR DESCRIPTION
## Summary by Sourcery

Extend AnimeBytes site metadata to handle additional collage-like pages and more flexible ID query patterns for entity pages.

New Features:
- Add support for company, seiyuu, and characters pages to the AnimeBytes site definition.

Enhancements:
- Relax URL matching patterns for collage, series, and artist pages to handle IDs with arbitrary query parameters.
- Include category extraction from collage-style listing pages via caticon image titles.