### PR TITLE
feat(useAdvanceFilter): 允许使用高级筛选的输入框使用regexp进行匹配

### DIFF
--- a/src/entries/options/directives/useAdvanceFilter.ts
+++ b/src/entries/options/directives/useAdvanceFilter.ts
@@ -70,10 +70,15 @@ const queryEscapeMap: Record<string, string> = {
   ",": "\\u002c",
   ":": "\\u003a",
 };
-const queryUnEscapeMap = Object.fromEntries(Object.entries(queryEscapeMap).map(([key, value]) => [value.toLowerCase(), key]));
-const escapedQueryValueRegex = /\\u(?:005c|0020|002c|003a)/gi;
+const queryUnEscapeMap = Object.fromEntries(
+  Object.entries(queryEscapeMap).map(([key, value]) => [value.toLowerCase(), key]),
+);
+const escapedQueryTokens = Object.values(queryEscapeMap).map((value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+const escapedQueryValueRegex = new RegExp(`(?:${escapedQueryTokens.join("|")})`, "gi");
 const queryReservedCharsRegex = /[\\ ,:]/g;
+// /pattern/[gimsuy]
 const regexLiteralPattern = /^\/((?:\\.|[^\\/])*)\/([gimsuy]*)$/;
+const regexCache = new Map<string, RegExp | null>();
 
 function escapeQueryValue(value: unknown): unknown {
   if (typeof value !== "string") return value;
@@ -82,24 +87,46 @@ function escapeQueryValue(value: unknown): unknown {
 
 function unEscapeQueryValue(value: unknown): unknown {
   if (typeof value !== "string") return value;
-  return value.replace(escapedQueryValueRegex, (escapedToken) => queryUnEscapeMap[escapedToken.toLowerCase()] ?? escapedToken);
+  return value.replace(
+    escapedQueryValueRegex,
+    (escapedToken) => queryUnEscapeMap[escapedToken.toLowerCase()] ?? escapedToken,
+  );
 }
 
+function normalizeFilterValue(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  return unEscapeQueryValue(value) as string;
+}
+
+/** 仅解析 /pattern/[gimsuy] 结构，失败时返回 null */
 function toRegexIfValid(value: unknown): RegExp | null {
-  if (typeof value !== "string") return null;
-  const matched = regexLiteralPattern.exec(unEscapeQueryValue(value) as string);
-  if (!matched) return null;
+  const normalizedValue = normalizeFilterValue(value);
+  if (typeof normalizedValue !== "string") return null;
+
+  if (regexCache.has(normalizedValue)) {
+    return regexCache.get(normalizedValue) ?? null;
+  }
+
+  const matched = regexLiteralPattern.exec(normalizedValue);
+  if (!matched) {
+    regexCache.set(normalizedValue, null);
+    return null;
+  }
 
   const [, pattern, flags] = matched;
   try {
-    return new RegExp(pattern, flags);
+    const regex = new RegExp(pattern, flags);
+    regexCache.set(normalizedValue, regex);
+    return regex;
   } catch {
+    regexCache.set(normalizedValue, null);
     return null;
   }
 }
 
 function matchFilterValue(itemValue: string, rawFilterValue: unknown): boolean {
-  const filterValue = unEscapeQueryValue(rawFilterValue) as string;
+  const filterValue = normalizeFilterValue(rawFilterValue);
+  if (typeof filterValue !== "string") return false;
   const regex = toRegexIfValid(filterValue);
   return regex ? regex.test(itemValue) : itemValue === filterValue;
 }
@@ -415,9 +442,10 @@ export function useTableCustomFilter<ItemType extends Record<string, any>>(
       const includeText = Array.isArray(text) ? text : [text];
       if (
         !includeText.every((keyword: string) => {
-          const unEscapedKeyword = unEscapeQueryValue(keyword) as string;
-          const regex = toRegexIfValid(unEscapedKeyword);
-          return regex ? regex.test(itemTitle) : itemTitleLowerCase.includes(unEscapedKeyword.toLowerCase());
+          const normalizedKeyword = normalizeFilterValue(keyword);
+          if (typeof normalizedKeyword !== "string") return false;
+          const regex = toRegexIfValid(normalizedKeyword);
+          return regex ? regex.test(itemTitle) : itemTitleLowerCase.includes(normalizedKeyword.toLowerCase());
         })
       ) {
         return false;
@@ -443,9 +471,10 @@ export function useTableCustomFilter<ItemType extends Record<string, any>>(
         const excludesText = Array.isArray(exText) ? exText : [exText];
         if (
           excludesText.some((keyword: string) => {
-            const unEscapedKeyword = unEscapeQueryValue(keyword) as string;
-            const regex = toRegexIfValid(unEscapedKeyword);
-            return regex ? regex.test(itemTitle) : itemTitleLowerCase.includes(unEscapedKeyword.toLowerCase());
+            const normalizedKeyword = normalizeFilterValue(keyword);
+            if (typeof normalizedKeyword !== "string") return false;
+            const regex = toRegexIfValid(normalizedKeyword);
+            return regex ? regex.test(itemTitle) : itemTitleLowerCase.includes(normalizedKeyword.toLowerCase());
           })
         ) {
           return false;

--- a/src/entries/options/directives/useAdvanceFilter.ts
+++ b/src/entries/options/directives/useAdvanceFilter.ts
@@ -64,6 +64,46 @@ const advanceFilterFormat: Record<TAdvanceFilterFormat, IValueFormat> = {
 
 type TFormat = Record<string, TAdvanceFilterFormat | IValueFormat>;
 
+const queryEscapeMap: Record<string, string> = {
+  "\\": "\\u005c",
+  " ": "\\u0020",
+  ",": "\\u002c",
+  ":": "\\u003a",
+};
+const queryUnEscapeMap = Object.fromEntries(Object.entries(queryEscapeMap).map(([key, value]) => [value.toLowerCase(), key]));
+const escapedQueryValueRegex = /\\u(?:005c|0020|002c|003a)/gi;
+const queryReservedCharsRegex = /[\\ ,:]/g;
+const regexLiteralPattern = /^\/((?:\\.|[^\\/])*)\/([gimsuy]*)$/;
+
+function escapeQueryValue(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  return value.replace(queryReservedCharsRegex, (char) => queryEscapeMap[char]);
+}
+
+function unEscapeQueryValue(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  return value.replace(escapedQueryValueRegex, (escapedToken) => queryUnEscapeMap[escapedToken.toLowerCase()] ?? escapedToken);
+}
+
+function toRegexIfValid(value: unknown): RegExp | null {
+  if (typeof value !== "string") return null;
+  const matched = regexLiteralPattern.exec(unEscapeQueryValue(value) as string);
+  if (!matched) return null;
+
+  const [, pattern, flags] = matched;
+  try {
+    return new RegExp(pattern, flags);
+  } catch {
+    return null;
+  }
+}
+
+function matchFilterValue(itemValue: string, rawFilterValue: unknown): boolean {
+  const filterValue = unEscapeQueryValue(rawFilterValue) as string;
+  const regex = toRegexIfValid(filterValue);
+  return regex ? regex.test(itemValue) : itemValue === filterValue;
+}
+
 const getRaw = (x: any) => x;
 function getValueFormat(key: string, format: TFormat = {}): Required<IValueFormat> {
   let valueFormatFn: IValueFormat = {};
@@ -135,12 +175,15 @@ export function checkKeywordValue(
 
     const valueFormat = getValueFormat(keyword as string, format);
     if (Array.isArray(itemValue)) {
-      const parsedSet = new Set(itemValue.map((v: any) => valueFormat.parse(v)) as string[]);
+      const parsedValues = itemValue.map((v: any) => valueFormat.parse(v) as string);
       const filterVals = filter[keyword] as string[];
       // 如果是正向关键词则要求全部包含，如果是排除关键词则要求有任意一个包含
-      return exclude ? filterVals.some((k) => parsedSet.has(k)) : filterVals.every((k) => parsedSet.has(k));
+      return exclude
+        ? filterVals.some((k) => parsedValues.some((v) => matchFilterValue(v, k)))
+        : filterVals.every((k) => parsedValues.some((v) => matchFilterValue(v, k)));
     } else {
-      return filter[keyword].includes(valueFormat.parse(itemValue) as string);
+      const itemParsedValue = valueFormat.parse(itemValue) as string;
+      return filter[keyword].some((k: string) => matchFilterValue(itemParsedValue, k));
     }
   }
 }
@@ -271,12 +314,12 @@ export function useTableCustomFilter<ItemType extends Record<string, any>>(
 
       const thisRequired = parsedFilter[key];
       if (Array.isArray(thisRequired) && thisRequired.length > 0) {
-        required = uniq(flattenDeep(thisRequired.map((v: any) => valueFormat.parse(v))));
+        required = uniq(flattenDeep(thisRequired.map((v: any) => valueFormat.parse(unEscapeQueryValue(v)))));
       }
 
       const thisExclude = parsedFilter.exclude?.[key];
       if (Array.isArray(thisExclude) && thisExclude.length > 0) {
-        exclude = uniq(flattenDeep(thisExclude.map((v: any) => valueFormat.parse(v))));
+        exclude = uniq(flattenDeep(thisExclude.map((v: any) => valueFormat.parse(unEscapeQueryValue(v)))));
       }
 
       advanceFilterDictRef.value[key] = { required, exclude };
@@ -302,8 +345,12 @@ export function useTableCustomFilter<ItemType extends Record<string, any>>(
     ["text", ...keywords].forEach((key) => {
       const valueFormat = getValueFormat(key, format);
       const { required, exclude } = advanceFilterDictRef.value[key] as unknown as ITextValue;
-      if (required?.length > 0) filters[key] = uniq(flattenDeep(required.map((v) => valueFormat.build(v))));
-      if (exclude?.length > 0) filters.exclude[key] = uniq(flattenDeep(exclude.map((v) => valueFormat.build(v))));
+      if (required?.length > 0) {
+        filters[key] = uniq(flattenDeep(required.map((v) => escapeQueryValue(valueFormat.build(v)))));
+      }
+      if (exclude?.length > 0) {
+        filters.exclude[key] = uniq(flattenDeep(exclude.map((v) => escapeQueryValue(valueFormat.build(v)))));
+      }
     });
 
     ranges.forEach((key) => {
@@ -361,11 +408,20 @@ export function useTableCustomFilter<ItemType extends Record<string, any>>(
     const itemTitle = flattenDeep(titleFields.map((key) => get(rawItem, key)))
       .filter(Boolean)
       .join("|$|")
-      .toLowerCase();
+      .toString();
+    const itemTitleLowerCase = itemTitle.toLowerCase();
 
     if (text) {
-      const includeText = (Array.isArray(text) ? text : [text]).map((x) => x.toLowerCase());
-      if (!includeText.every((keyword: string) => itemTitle.includes(keyword))) return false;
+      const includeText = Array.isArray(text) ? text : [text];
+      if (
+        !includeText.every((keyword: string) => {
+          const unEscapedKeyword = unEscapeQueryValue(keyword) as string;
+          const regex = toRegexIfValid(unEscapedKeyword);
+          return regex ? regex.test(itemTitle) : itemTitleLowerCase.includes(unEscapedKeyword.toLowerCase());
+        })
+      ) {
+        return false;
+      }
     }
 
     if (parseOptions.keywords) {
@@ -384,8 +440,16 @@ export function useTableCustomFilter<ItemType extends Record<string, any>>(
       const { text: exText } = exclude;
 
       if (exText) {
-        const excludesText = (Array.isArray(exText) ? exText : [exText]).map((x) => x.toLowerCase());
-        if (excludesText.some((keyword: string) => itemTitle.includes(keyword))) return false;
+        const excludesText = Array.isArray(exText) ? exText : [exText];
+        if (
+          excludesText.some((keyword: string) => {
+            const unEscapedKeyword = unEscapeQueryValue(keyword) as string;
+            const regex = toRegexIfValid(unEscapedKeyword);
+            return regex ? regex.test(itemTitle) : itemTitleLowerCase.includes(unEscapedKeyword.toLowerCase());
+          })
+        ) {
+          return false;
+        }
       }
 
       if (parseOptions.keywords) {


### PR DESCRIPTION
在目前启用高级筛选功能的页面中（如 SetSite、SetDownloader、SearchEntity、MyData、DownloadHistory 页面），
允许用户使用正则的形式拓展目前的筛选功能。

**在使用前请先了解 [search-query-parser](https://github.com/nepsilon/search-query-parser) 以及 [正则表达式](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions) 的语法规则。**

本PR在原先的基础上，允许 text 和 keywords 类型的匹配使用正则功能。以便于在不改变之前各搜索字段 ***与逻辑*** 的匹配基础上，允许使用 ***或逻辑匹配或更高级的匹配方式*** 。
即使用 `/regex/[gimsuy]?`写法（不建议使用 `g` 或 `y` 修饰，因为没有意义），向助手指示该部分使用正则的形式进行匹配，而不是简单的 `<String|Array>.include()` 方法进行判断。

简单举例如下：

| filter input | filter logic |
| --- | --- |
| `title tags:tag1` | `title AND tags:tag1` |
| `title tags:tag1,tag2` | `title AND (tags:tag1 AND tags:tag2)` | 
| `title tags:/tag1\|tag2/` | `title AND (tags:tag1 OR tags:tag2)` |
| `title tags:/tag1\|tag2/,tag3` | `title AND ((tags:tag1 OR tags:tag2) AND tags:tag3)` |
| `title1 title2 tags:tag1` | `title1 AND title2 AND tags:tag1` |
| `/title1\|title2/ tags:tag1` | `(title1 OR title2) AND tags:tag1` |
| `/ti[tx]le/` | `title OR tixle` |

<img width="1442" height="367" alt="image" src="https://github.com/user-attachments/assets/fc323956-26cf-4ed6-94a7-9cf90148ec29" />

<img width="1523" height="391" alt="image" src="https://github.com/user-attachments/assets/ca9da7a3-6bc5-4f2d-b606-77ff7732485c" />


**注意，目前该功能并没有前端生成方式，需要用户手动输入相关 input。**

closed: #1248

Agent-Logs-Url: https://github.com/Rhilip/PT-depiler/sessions/7bfa64d0-0d49-4763-8d4e-2a027bb8b153

## Summary by Sourcery

Enable regex-based matching in advanced table filters while preserving existing text and keyword semantics.

New Features:
- Allow advanced filter text and keyword fields to use /pattern/[flags] style regular expressions for matching.

Enhancements:
- Introduce escaping and unescaping of reserved characters in filter queries to support regex literals without breaking parsing.
- Use a shared normalization and matching helper so keyword and text filters consistently support both exact and regex-based comparisons.