### PR TITLE
fix(pkg/site/ubits): fix bonus selector.

### DIFF
--- a/src/packages/site/definitions/ubits.ts
+++ b/src/packages/site/definitions/ubits.ts
@@ -1,7 +1,7 @@
 import { set } from "es-toolkit/compat";
 import type { IAdvancedSearchRequestConfig, ISiteMetadata, TSelectSearchCategoryValue } from "../types";
 import { GB, TB } from "../utils";
-import { CategoryIncldead, CategorySpstate, CategoryInclbookmarked, SchemaMetadata } from "../schemas/NexusPHP";
+import { CategoryIncldead, CategorySpstate, CategoryInclbookmarked, SchemaMetadata, createUserBonusSelectorFn } from "../schemas/NexusPHP";
 
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,
@@ -210,6 +210,16 @@ export const siteMetadata: ISiteMetadata = {
       },
     },
   },
+
+  userInfo: {
+    ...SchemaMetadata.userInfo!,
+    selectors: {
+      ...SchemaMetadata.userInfo!.selectors!,
+      bonus: createUserBonusSelectorFn(["U币", "UBits Coin", "魔力值"]),
+      seedingBonus: createUserBonusSelectorFn(["做种积分", "Seed points", "做種積分", "保种积分"]),
+    },
+  },
+
   levelRequirements: [
     {
       id: 0,


### PR DESCRIPTION
close: #1262

## Summary by Sourcery

Bug Fixes:
- Correct bonus and seeding bonus selectors in the UBits site metadata so user bonus information is parsed reliably across different label variants.