### PR TITLE
fix(pkg/site): handle empty torrent results

### DIFF
--- a/src/packages/site/definitions/passthepopcorn.ts
+++ b/src/packages/site/definitions/passthepopcorn.ts
@@ -2,7 +2,7 @@ import Sizzle from "sizzle";
 import Gazelle, { SchemaMetadata } from "../schemas/Gazelle.ts";
 import { parseValidTimeString, parseSizeString, buildCategoryOptionsFromList } from "../utils";
 import type { ISiteMetadata, ITorrent, ISearchInput } from "../types";
-import { ETorrentStatus } from "../types";
+import { ETorrentStatus, NoTorrentsError } from "../types";
 
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,
@@ -387,14 +387,20 @@ export default class PassThePopcorn extends Gazelle {
       }
     }
 
-    if (pageData) {
+    if (Array.isArray(pageData?.Movies)) {
       const authKey = pageData.AuthKey;
       const torrentPass = pageData.TorrentPass;
-      pageData.Movies.map((movie: any) => {
+      pageData.Movies.forEach((movie: any) => {
         const torrent = this.parsePageData(movie, authKey, torrentPass) as ITorrent;
-        torrents.push(torrent);
+        if (torrent.id && torrent.title && torrent.link) {
+          torrents.push(torrent);
+        }
       });
     }
+    if (torrents.length === 0) {
+      throw new NoTorrentsError();
+    }
+
     return torrents;
   }
 }

--- a/src/packages/site/schemas/Unit3D.ts
+++ b/src/packages/site/schemas/Unit3D.ts
@@ -105,6 +105,16 @@ export const SchemaMetadata: Partial<ISiteMetadata> = {
           "div.torrent-search--list__results > table:first > tbody > tr", // 新版布局
           "div.table-responsive table > tbody > tr", // 旧版布局
         ],
+        filter: (rows: HTMLElement[] | null): HTMLElement[] | null => {
+          if (!Array.isArray(rows)) return rows;
+
+          return rows.filter((row) =>
+            Array.from(row.querySelectorAll<HTMLAnchorElement>("a[href*='/torrents/']")).some((link) => {
+              const href = link.getAttribute("href") || "";
+              return /\/torrents\/\d+/.test(href) && !href.includes("/download");
+            }),
+          );
+        },
       },
 
       /**


### PR DESCRIPTION
## Summary
- filter Unit3D search rows so empty-result placeholder rows are not parsed as torrents
- return no-results for PassThePopcorn when PageData or valid torrents are absent

## Verification
- GitHub Actions Build Action Release passed on fork master
- Checked empty-result pages for Aither, Blutopia, Seedpool, and PassThePopcorn in Chrome

## Summary by Sourcery

Handle empty or placeholder torrent search results for PassThePopcorn and Unit3D-based sites to avoid parsing invalid torrents.

Bug Fixes:
- Avoid treating PassThePopcorn pages without valid Movies data or torrents as successful searches by throwing a no-torrents error.
- Exclude Unit3D search result rows that represent empty-result placeholders rather than real torrents.

Enhancements:
- Guard PassThePopcorn page data parsing by validating Movies structure and torrent fields before adding them to results.