### PR TITLE
feat(download): 允许为下载器设置排除站点

### DIFF
--- a/src/entries/content-script/app/pages/SiteDetailPage.vue
+++ b/src/entries/content-script/app/pages/SiteDetailPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { inject } from "vue";
+import { computed, inject } from "vue";
 import { useI18n } from "vue-i18n";
 
 import { sendMessage } from "@/messages.ts";
@@ -7,13 +7,18 @@ import { useRuntimeStore } from "@/options/stores/runtime.ts";
 import { useMetadataStore } from "@/options/stores/metadata.ts";
 
 import type { IRemoteDownloadDialogData } from "../types.ts";
-import { copyTextToClipboard, doKeywordSearch, siteInstance } from "../utils.ts";
+import { copyTextToClipboard, doKeywordSearch, siteInstance, type IPtdData } from "../utils.ts";
 
 import SpeedDialBtn from "../components/SpeedDialBtn.vue";
 
 const metadataStore = useMetadataStore();
 const runtimeStore = useRuntimeStore();
 const { t } = useI18n();
+
+const ptdData = inject<IPtdData>("ptd_data", {});
+const enabledDownloadersBySite = computed(() => {
+  return metadataStore.getEnabledDownloadersBySite(ptdData.siteId ?? "");
+});
 
 async function parseDetailPage() {
   const parsedResult = await siteInstance.value?.transformDetailPage(document);
@@ -59,10 +64,16 @@ function handleSearch() {
 </script>
 
 <template>
-  <SpeedDialBtn key="copy" color="light-blue" icon="mdi-content-copy" :title="t('contentScript.copyLink')" @click="handleLinkCopy" />
+  <SpeedDialBtn
+    key="copy"
+    color="light-blue"
+    icon="mdi-content-copy"
+    :title="t('contentScript.copyLink')"
+    @click="handleLinkCopy"
+  />
   <SpeedDialBtn
     key="download"
-    :disabled="metadataStore.getEnabledDownloaders.length === 0"
+    :disabled="enabledDownloadersBySite.length === 0"
     color="light-blue"
     icon="mdi-cloud-download"
     :title="t('contentScript.pushTo')"
@@ -71,13 +82,19 @@ function handleSearch() {
   <SpeedDialBtn
     key="download_default"
     v-if="metadataStore.defaultDownloader?.id"
-    :disabled="metadataStore.getEnabledDownloaders.length === 0"
+    :disabled="enabledDownloadersBySite.length === 0"
     color="light-blue"
     icon="mdi-download"
     :title="t('contentScript.pushToDefault')"
     @click="handleRemoteDownload(true)"
   />
-  <SpeedDialBtn key="search" color="indigo" icon="mdi-home-search" :title="t('contentScript.quickSearch')" @click="handleSearch" />
+  <SpeedDialBtn
+    key="search"
+    color="indigo"
+    icon="mdi-home-search"
+    :title="t('contentScript.quickSearch')"
+    @click="handleSearch"
+  />
 </template>
 
 <style scoped lang="scss"></style>

--- a/src/entries/content-script/app/pages/SiteListPage.vue
+++ b/src/entries/content-script/app/pages/SiteListPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { inject, ref, shallowRef } from "vue";
+import { computed, inject, ref, shallowRef } from "vue";
 import { useI18n } from "vue-i18n";
 import { type ITorrent } from "@ptd/site";
 
@@ -8,7 +8,7 @@ import { useRuntimeStore } from "@/options/stores/runtime.ts";
 import { useMetadataStore } from "@/options/stores/metadata.ts";
 
 import type { IRemoteDownloadDialogData } from "../types.ts";
-import { copyTextToClipboard, doKeywordSearch, siteInstance, wrapperConfirmFn } from "../utils.ts";
+import { copyTextToClipboard, doKeywordSearch, siteInstance, wrapperConfirmFn, type IPtdData } from "../utils.ts";
 
 import AdvanceListModuleDialog from "../components/AdvanceListModuleDialog.vue";
 import SpeedDialBtn from "../components/SpeedDialBtn.vue";
@@ -16,6 +16,11 @@ import SpeedDialBtn from "../components/SpeedDialBtn.vue";
 const metadataStore = useMetadataStore();
 const runtimeStore = useRuntimeStore();
 const { t } = useI18n();
+
+const ptdData = inject<IPtdData>("ptd_data", {});
+const enabledDownloadersBySite = computed(() => {
+  return metadataStore.getEnabledDownloadersBySite(ptdData.siteId ?? "");
+});
 
 async function parseListPage(showNoTorrentError = true) {
   // 使用克隆的文档，避免污染原始文档
@@ -127,7 +132,7 @@ async function handleSearch() {
   />
   <SpeedDialBtn
     key="download"
-    :disabled="metadataStore.getEnabledDownloaders.length === 0"
+    :disabled="enabledDownloadersBySite.length === 0"
     color="light-blue"
     icon="mdi-cloud-download"
     :title="t('contentScript.pushTo')"
@@ -136,7 +141,7 @@ async function handleSearch() {
   <SpeedDialBtn
     key="download_default"
     v-if="metadataStore.defaultDownloader?.id"
-    :disabled="metadataStore.getEnabledDownloaders.length === 0"
+    :disabled="enabledDownloadersBySite.length === 0"
     color="light-blue"
     icon="mdi-download"
     :title="t('contentScript.pushToDefault')"
@@ -150,7 +155,13 @@ async function handleSearch() {
     :title="t('contentScript.advanceList')"
     @click="handleAdvanceListModule"
   />
-  <SpeedDialBtn key="search" color="indigo" icon="mdi-home-search" :title="t('contentScript.quickSearch')" @click="handleSearch" />
+  <SpeedDialBtn
+    key="search"
+    color="indigo"
+    icon="mdi-home-search"
+    :title="t('contentScript.quickSearch')"
+    @click="handleSearch"
+  />
 
   <AdvanceListModuleDialog v-model="showAdvanceListModuleDialog" :torrent-items="parsedTorrents" />
 </template>

--- a/src/entries/options/components/SentToDownloaderDialog/Index.vue
+++ b/src/entries/options/components/SentToDownloaderDialog/Index.vue
@@ -48,6 +48,18 @@ const addTorrentOptions = ref<Required<Omit<CAddTorrentOptions, "localDownloadOp
 const suggestFolders = computed(() => selectedDownloader.value?.suggestFolders ?? []);
 const suggestTags = computed(() => selectedDownloader.value?.suggestTags ?? []);
 
+const currentSiteIds = computed(() => [...new Set(torrentItems.map((t) => t.site).filter(Boolean))]);
+const enabledDownloadersBySite = computed(() => {
+  const ids = currentSiteIds.value;
+  if (ids.length === 0) return metadataStore.getEnabledDownloaders;
+  const sets = ids.map((id) => new Set(metadataStore.getEnabledDownloadersBySite(id).map((d) => d.id)));
+  const intersection = sets.reduce((acc, s) => new Set([...acc].filter((x) => s.has(x))));
+  return metadataStore.getEnabledDownloaders.filter((d) => intersection.has(d.id));
+});
+const sortedEnabledDownloadersBySite = computed(() =>
+  [...enabledDownloadersBySite.value].sort((a, b) => (b.sortIndex ?? 0) - (a.sortIndex ?? 0)),
+);
+
 const downloaderTitle = (downloader: IDownloaderMetadata) => `${downloader.name} [${downloader.address}]`;
 const getDownloaderIcon = (x: string) => chrome.runtime.getURL(getDownloaderIconRaw(x));
 
@@ -132,8 +144,8 @@ function dialogEnter() {
       const lastDownloaderId = metadataStore.lastDownloader?.id;
       selectedDownloader.value = lastDownloaderId // 如果有上次选择的下载器，则直接使用
         ? metadataStore.downloaders[lastDownloaderId]
-        : metadataStore.getEnabledDownloaders.length === 1 // 如果只有一个启用的下载器，则直接使用
-          ? metadataStore.getEnabledDownloaders[0]
+        : sortedEnabledDownloadersBySite.value.length === 1 // 如果只有一个启用的下载器，则直接使用
+          ? sortedEnabledDownloadersBySite.value[0]
           : null;
 
       // 将上一次的下载器选项通过 toMerged 合并到当前选项中，而不是直接覆盖
@@ -172,14 +184,19 @@ function dialogLeave() {
 
       <v-card-text>
         <v-alert v-if="isSending" type="info" variant="tonal">
-          {{ t("SentToDownloaderDialog.isSending", { name: selectedDownloader?.name, address: selectedDownloader?.address }) }}
+          {{
+            t("SentToDownloaderDialog.isSending", {
+              name: selectedDownloader?.name,
+              address: selectedDownloader?.address,
+            })
+          }}
         </v-alert>
 
         <v-form v-else>
           <!-- 快速下载选项 -->
           <v-container v-if="quickSendToClient" class="pa-0">
-            <v-list v-if="metadataStore.getEnabledDownloaders.length > 0">
-              <template v-for="downloader in metadataStore.getSortedEnabledDownloaders" :key="downloader.id">
+            <v-list v-if="sortedEnabledDownloadersBySite.length > 0">
+              <template v-for="downloader in sortedEnabledDownloadersBySite" :key="downloader.id">
                 <v-list-item
                   v-for="path in ['', ...(downloader.suggestFolders ?? [])]"
                   :key="path"
@@ -201,7 +218,13 @@ function dialogLeave() {
                 </v-list-item>
               </template>
             </v-list>
-            <v-alert v-else type="warning" variant="tonal"> {{ t("SentToDownloaderDialog.noDownloader") }} </v-alert>
+            <v-alert v-else type="warning" variant="tonal">
+              {{
+                currentSiteIds.length > 0 && configStore.download.allowDownloaderFilterForSite
+                  ? t("SentToDownloaderDialog.noDownloaderForSite")
+                  : t("SentToDownloaderDialog.noDownloader")
+              }}
+            </v-alert>
           </v-container>
 
           <!-- 普通下载选项 -->
@@ -210,7 +233,7 @@ function dialogLeave() {
               <v-autocomplete
                 v-model="selectedDownloader"
                 :filter-keys="['raw.name', 'raw.address', 'raw.username']"
-                :items="metadataStore.getSortedEnabledDownloaders"
+                :items="sortedEnabledDownloadersBySite"
                 clearable
                 :placeholder="t('SentToDownloaderDialog.selectDownloader')"
                 @update:model-value="restoreAddTorrentOptions"
@@ -268,7 +291,12 @@ function dialogLeave() {
                 />
               </v-col>
               <v-col>
-                <v-switch v-model="addTorrentOptions.addAtPaused" color="success" hide-details :label="t('SentToDownloaderDialog.pauseOnAdd')" />
+                <v-switch
+                  v-model="addTorrentOptions.addAtPaused"
+                  color="success"
+                  hide-details
+                  :label="t('SentToDownloaderDialog.pauseOnAdd')"
+                />
               </v-col>
             </v-row>
             <v-row>
@@ -297,7 +325,11 @@ function dialogLeave() {
       </v-card-text>
       <v-divider />
       <v-card-actions>
-        <v-btn :title="t('SentToDownloaderDialog.moreOptions')" icon="mdi-cards" @click="quickSendToClient = !quickSendToClient" />
+        <v-btn
+          :title="t('SentToDownloaderDialog.moreOptions')"
+          icon="mdi-cards"
+          @click="quickSendToClient = !quickSendToClient"
+        />
 
         <v-spacer />
         <v-btn

--- a/src/entries/options/stores/config.ts
+++ b/src/entries/options/stores/config.ts
@@ -261,6 +261,7 @@ export const useConfigStore = defineStore("config", {
 
     download: {
       saveDownloadHistory: true,
+      allowDownloaderFilterForSite: false,
       initDownloaderTorrentOnEnter: false,
       saveLastDownloader: false,
       allowDirectSendToClient: false,

--- a/src/entries/options/stores/metadata.ts
+++ b/src/entries/options/stores/metadata.ts
@@ -323,7 +323,6 @@ export const useMetadataStore = defineStore("metadata", {
           return (b.sortIndex ?? 0) - (a.sortIndex ?? 0);
         });
       };
-    }
     },
 
     getMediaServerIds(state) {

--- a/src/entries/options/stores/metadata.ts
+++ b/src/entries/options/stores/metadata.ts
@@ -25,6 +25,7 @@ import {
   ISearchSolutionMetadata,
 } from "@/shared/types.ts";
 import { sendMessage } from "@/messages.ts";
+import { useConfigStore } from "@/options/stores/config.ts";
 import { useRuntimeStore } from "@/options/stores/runtime.ts";
 
 type TSimplePatchFieldKey = keyof Pick<
@@ -304,6 +305,24 @@ export const useMetadataStore = defineStore("metadata", {
       return this.getEnabledDownloaders.sort((a, b) => {
         return (b.sortIndex ?? 0) - (a.sortIndex ?? 0);
       });
+    },
+
+    getEnabledDownloadersBySite(state) {
+      return (siteId: string): IDownloaderMetadata[] => {
+        const configStore = useConfigStore();
+        if (!configStore.download.allowDownloaderFilterForSite) {
+          return this.getEnabledDownloaders;
+        }
+        return this.getEnabledDownloaders.filter((d) => !d.excludedSites?.includes(siteId));
+      };
+    },
+
+    getSortedEnabledDownloadersBySite(state) {
+      return (siteId: string): IDownloaderMetadata[] => {
+        return this.getEnabledDownloadersBySite(siteId).sort((a, b) => {
+          return (b.sortIndex ?? 0) - (a.sortIndex ?? 0);
+        });
+      };
     },
 
     getMediaServerIds(state) {

--- a/src/entries/options/stores/metadata.ts
+++ b/src/entries/options/stores/metadata.ts
@@ -319,10 +319,11 @@ export const useMetadataStore = defineStore("metadata", {
 
     getSortedEnabledDownloadersBySite(state) {
       return (siteId: string): IDownloaderMetadata[] => {
-        return this.getEnabledDownloadersBySite(siteId).sort((a, b) => {
+        return [...this.getEnabledDownloadersBySite(siteId)].sort((a, b) => {
           return (b.sortIndex ?? 0) - (a.sortIndex ?? 0);
         });
       };
+    }
     },
 
     getMediaServerIds(state) {

--- a/src/entries/options/views/Settings/SetBase/DownloadWindow.vue
+++ b/src/entries/options/views/Settings/SetBase/DownloadWindow.vue
@@ -77,6 +77,13 @@ async function clearLastDownloader(v: boolean) {
       <v-alert type="info" variant="tonal" v-html="t('SetBase.download.quickSendToClientNote')" />
 
       <v-switch
+        v-model="configStore.download.allowDownloaderFilterForSite"
+        color="success"
+        hide-details
+        :label="t('SetBase.download.enableSiteFilter')"
+      />
+
+      <v-switch
         v-model="configStore.download.saveLastDownloader"
         :label="t('SetBase.download.saveLastDownloader')"
         color="success"

--- a/src/entries/options/views/Settings/SetBase/UiWindow.vue
+++ b/src/entries/options/views/Settings/SetBase/UiWindow.vue
@@ -93,7 +93,12 @@ defineExpose({
       <div class="d-flex align-center">
         <v-label>{{ t("SetBase.ui.contentScript") }}</v-label>
         <v-spacer />
-        <v-switch v-model="configStore.contentScript.enabled" color="success" hide-details :label="t('common.enable')" />
+        <v-switch
+          v-model="configStore.contentScript.enabled"
+          color="success"
+          hide-details
+          :label="t('common.enable')"
+        />
       </div>
 
       <template v-if="configStore.contentScript.enabled">

--- a/src/entries/options/views/Settings/SetDownloader/Index.vue
+++ b/src/entries/options/views/Settings/SetDownloader/Index.vue
@@ -15,6 +15,7 @@ import { useTableCustomFilter } from "@/options/directives/useAdvanceFilter.ts";
 import AddDialog from "./AddDialog.vue";
 import EditDialog from "./EditDialog.vue";
 import PathAndTagSuggestDialog from "./PathAndTagSuggestDialog.vue";
+import SiteFilterDialog from "./SiteFilterDialog.vue";
 import DefaultDownloaderEditDialog from "./DefaultDownloaderEditDialog.vue";
 
 import DeleteDialog from "@/options/components/DeleteDialog.vue";
@@ -27,6 +28,7 @@ const configStore = useConfigStore();
 const showAddDialog = ref<boolean>(false);
 const showEditDialog = ref<boolean>(false);
 const showDefaultDownloaderEditDialog = ref<boolean>(false);
+const showSiteFilterDialog = ref<boolean>(false);
 const showPathAndTagSuggestDialog = ref<boolean>(false);
 const showDeleteDialog = ref<boolean>(false);
 
@@ -87,6 +89,11 @@ function editDownloader(downloaderId: TDownloaderKey) {
 function editDownloaderPathAndTag(downloaderId: TDownloaderKey) {
   toEditDownloaderId.value = downloaderId;
   showPathAndTagSuggestDialog.value = true;
+}
+
+function editDownloaderSiteFilter(downloaderId: TDownloaderKey) {
+  toEditDownloaderId.value = downloaderId;
+  showSiteFilterDialog.value = true;
 }
 
 const toDeleteIds = ref<TDownloaderKey[]>([]);
@@ -276,6 +283,17 @@ async function confirmDeleteDownloader(downloaderId: TDownloaderKey) {
             @click="editDownloaderPathAndTag(item.id)"
           ></v-btn>
 
+          <!-- 该下载服务器站点过滤设置 -->
+          <v-btn
+            v-if="configStore.download.allowDownloaderFilterForSite"
+            :disabled="!item.enabled"
+            :title="t('SetDownloader.index.table.action.setSiteFilter')"
+            color="cyan"
+            icon="mdi-filter-variant"
+            size="small"
+            @click="editDownloaderSiteFilter(item.id)"
+          ></v-btn>
+
           <v-btn
             :title="t('common.remove')"
             :disabled="item.id == metadataStore.defaultDownloader?.id /* 默认下载器不允许删除 */"
@@ -292,6 +310,7 @@ async function confirmDeleteDownloader(downloaderId: TDownloaderKey) {
   <AddDialog v-model="showAddDialog" />
   <EditDialog v-model="showEditDialog" :client-id="toEditDownloaderId!" />
   <DefaultDownloaderEditDialog v-model="showDefaultDownloaderEditDialog" />
+  <SiteFilterDialog v-model="showSiteFilterDialog" :client-id="toEditDownloaderId!" />
   <PathAndTagSuggestDialog v-model="showPathAndTagSuggestDialog" :client-id="toEditDownloaderId!" />
   <DeleteDialog v-model="showDeleteDialog" :to-delete-ids="toDeleteIds" :confirm-delete="confirmDeleteDownloader" />
 </template>

--- a/src/entries/options/views/Settings/SetDownloader/SiteFilterDialog.vue
+++ b/src/entries/options/views/Settings/SetDownloader/SiteFilterDialog.vue
@@ -1,0 +1,125 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { useI18n } from "vue-i18n";
+
+import { useMetadataStore } from "@/options/stores/metadata.ts";
+import type { IDownloaderMetadata, TDownloaderKey } from "@/shared/types.ts";
+
+import SiteFavicon from "@/options/components/SiteFavicon/Index.vue";
+import CheckSwitchButton from "@/options/components/CheckSwitchButton.vue";
+import { useConfigStore } from "@/options/stores/config.ts";
+
+const showDialog = defineModel<boolean>();
+const { clientId } = defineProps<{
+  clientId: TDownloaderKey;
+}>();
+
+const { t } = useI18n();
+const metadataStore = useMetadataStore();
+const configStore = useConfigStore();
+
+const clientConfig = ref<IDownloaderMetadata>();
+const excludedSites = ref<string[]>([]);
+
+const addedSites = computed(() =>
+  Object.entries(metadataStore.sites)
+    .filter(([id, site]) => (configStore.contentScript.allowExceptionSites ? (site.allowContentScript ?? true) : true))
+    .map(([id]) => ({ id, name: metadataStore.siteNameMap[id] ?? id }))
+    .sort((a, b) => a.name.localeCompare(b.name)),
+);
+
+const allSiteIds = computed(() => addedSites.value.map((s) => s.id));
+
+function onEnter() {
+  if (clientId) {
+    clientConfig.value = { excludedSites: [], ...metadataStore.downloaders[clientId] };
+    excludedSites.value = [...(clientConfig.value.excludedSites ?? [])];
+  }
+}
+
+function save() {
+  metadataStore.simplePatch("downloaders", clientId, "excludedSites", excludedSites.value);
+  showDialog.value = false;
+}
+</script>
+
+<template>
+  <v-dialog v-model="showDialog" scrollable max-width="1000" @afterEnter="onEnter">
+    <v-card>
+      <v-card-title class="pa-0">
+        <v-toolbar
+          :title="t('SetDownloader.siteFilter.title', [clientConfig?.name ?? clientId])"
+          color="blue-grey-darken-2"
+        >
+          <template #append>
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
+          </template>
+        </v-toolbar>
+      </v-card-title>
+      <v-divider />
+      <v-card-text>
+        <v-alert class="mb-3 py-2" color="info" variant="tonal">
+          <template #text>
+            {{ t("SetDownloader.siteFilter.excludedSitesHint") }}
+          </template>
+          <template #append>
+            <CheckSwitchButton v-model="excludedSites" :all="allSiteIds" color="blue-lighten-1" variant="tonal" />
+          </template>
+        </v-alert>
+
+        <v-skeleton-loader v-if="addedSites.length === 0" type="image" />
+
+        <v-list v-else class="overflow-x-hidden overflow-y-hidden px-3 pt-3">
+          <v-row>
+            <v-col v-for="site in addedSites" :key="site.id" cols="12" md="4" sm="6" class="pa-1">
+              <v-list-item border class="bg-grey-lighten-4">
+                <template #prepend>
+                  <SiteFavicon :site-id="site.id" class="mr-2" flush-on-click />
+                </template>
+
+                <template #title>
+                  <v-list-item-title>
+                    <b>{{ site.name }}</b>
+                  </v-list-item-title>
+                </template>
+
+                <template #subtitle>
+                  <v-chip label size="x-small" class="mt-1">
+                    {{ site.id }}
+                  </v-chip>
+                </template>
+
+                <template #append>
+                  <v-list-item-action>
+                    <v-checkbox
+                      v-model="excludedSites"
+                      :value="site.id"
+                      :color="excludedSites.includes(site.id) ? 'error' : ''"
+                      hide-details
+                      base-color="green"
+                      multiple
+                      true-icon="mdi-eye-off"
+                      false-icon="mdi-eye"
+                    />
+                  </v-list-item-action>
+                </template>
+              </v-list-item>
+            </v-col>
+          </v-row>
+        </v-list>
+      </v-card-text>
+      <v-divider />
+      <v-card-actions>
+        <v-spacer />
+        <v-btn color="error" prepend-icon="mdi-close-circle" variant="text" @click="showDialog = false">
+          {{ t("common.dialog.cancel") }}
+        </v-btn>
+        <v-btn color="success" prepend-icon="mdi-check-circle-outline" variant="text" @click="save">
+          {{ t("common.dialog.ok") }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<style scoped lang="scss"></style>

--- a/src/entries/shared/types/storages/config.ts
+++ b/src/entries/shared/types/storages/config.ts
@@ -183,6 +183,8 @@ export interface IConfigPiniaStorageSchema {
     // 是否保存下载记录
     saveDownloadHistory: boolean;
 
+    allowDownloaderFilterForSite: boolean; // 是否启用站点过滤器，启用后可在下载器设置中配置每个下载器可使用的站点
+
     // 当使用本地方法下载时，如何下载种子
     localDownloadMethod: TLocalDownloadMethod;
     // 当使用本地方法下载时，是否忽略站点的下载间隔设置；

--- a/src/entries/shared/types/storages/metadata.ts
+++ b/src/entries/shared/types/storages/metadata.ts
@@ -54,6 +54,7 @@ export interface IDownloaderMetadata extends DownloaderBaseConfig {
   suggestTags?: string[];
 
   sortIndex?: number; // 排序索引，默认值取 100
+  excludedSites?: string[]; // 排除的站点列表，在该列表中的站点不会显示该下载器
   autoFlushStatus?: number; // 自动刷新状态，0: 关闭，其他数值表示刷新间隔的秒数
 
   [key: string]: any; // 其他配置项

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,226 +1,818 @@
 {
-  "common": {
-    "action": "Action",
-    "btn": {
-      "add": "Add"
+  "ContextMenuLinkPush": {
+    "invalidLink": "Invalid download link",
+    "keywordWarning": "When pushing links via right-click, some keyword features for download paths or labels may not work correctly!"
+  },
+  "Debugger": {
+    "addServerFirst": "Please add a server on the Set{serverType} page first",
+    "confirmReset": "Are you sure you want to reset?",
+    "consoleOutput": "All output is in the console panel!!!",
+    "dangerWarning": "EXTREMELY DANGEROUS!!!!",
+    "debug": "Debug {serverType}",
+    "debugBuiltinSite": "Debug Built-in Site",
+    "debugPinia": "Debug Pinia",
+    "enableLibrary": "Enable Dev Library",
+    "libraryList": "Enable sendMessage, axios, Sizzle, es-toolkit (as _), datefns in console",
+    "mergeUserConfig": "Merge User Config",
+    "outputConfig": "Output User Config",
+    "outputFavicon": "Output Favicon",
+    "outputInstance": "Output {serverType} Instance",
+    "outputPinia": "Output Pinia Info",
+    "outputSiteDefinition": "Output Site Definition",
+    "outputSiteInstance": "Output Site Instance",
+    "outputUserConfig": "Output User Config",
+    "pluginReset": "Plugin Reset",
+    "resetItems": {
+      "clearDownloadHistory": "Clear Download History",
+      "clearFaviconCache": "Clear Site Favicon Cache",
+      "clearMediaCache": "Clear media summary cache from Douban, IMDb, etc.",
+      "clearSearchSnapshot": "Clear Search Snapshots",
+      "clearSearchSnapshotDesc": "Clear all search snapshot data",
+      "clearSiteData": "Clear Site Data",
+      "clearSiteDataDesc": "Clear user-fetched site data (including user info history and latest user info)",
+      "clearUserConfig": "Clear User Config",
+      "clearUserConfigDesc": "Clear all user configs (including sites, downloaders, search plans, snapshot metadata, latest user info)",
+      "resetSystemSettings": "Reset System Settings",
+      "resetSystemSettingsDesc": "Reset all system settings (including language, theme, table display, image style, etc.) to defaults"
     },
-    "checkbox": {
-      "all": "ALL",
-      "none": "Select None",
-      "invert": "Invert Selection"
-    },
-    "default": "default",
-    "date": "Date",
-    "time": {
-      "year": "Year",
-      "month": "Month",
-      "week": "Week",
-      "day": "Day",
-      "hour": "Hour",
-      "minute": "Minute",
-      "second": "Second",
-      "lessThanAWeek": "Less than a week",
-      "ago": " Ago"
-    },
-    "dialog": {
-      "cancel": "Cancel",
-      "next": "Next",
-      "ok": "Complete",
-      "confirm": "Confirm",
-      "prev": "Prev",
-      "reset": "Reset",
-      "title": {
-        "confirmAction": "Confirm Action"
-      },
-      "deleteText": "Are you sure to delete these {0} item?",
-      "close": "Close"
-    },
-    "edit": "Edit",
-    "language": "Language",
-    "name": "Name",
-    "project": "PT Depiler",
-    "remove": "Delete",
-    "save": "Save",
-    "search": "Search",
-    "sortIndex": "Priority",
-    "test": "Test",
-    "visit": "Visit",
-    "version": "Version",
-    "howToUse": "How To Use",
-    "import": "Import",
-    "export": "Export",
-    "saveSuccess": "Saved successfully",
-    "advancedSettings": "Advanced Settings",
-    "back": "Back",
-    "exportImage": "Export Image",
-    "saveSettings": "Save Settings",
-    "enable": "Enable",
-    "basicInfo": "Basic Information",
-    "count": "Count",
-    "site": "Site",
-    "type": "Type",
-    "username": "Username",
+    "resetSuccess": "Reset successful",
+    "selectSite": "Select Site",
+    "siteAll": "All",
+    "title": "Debug Page!!!!"
+  },
+  "DownloadHistory": {
     "AdvanceFilterGenerateDialog": {
-      "title": "Generate Advanced Filter",
-      "keywords": "Keywords",
-      "required": "Required",
-      "exclude": "Exclude",
-      "site": "@:common.site",
-      "date": "Date",
-      "dateUnit": {
-        "day": "Today",
-        "week": "This Week",
-        "month": "This Month",
-        "quarter": "This Quarter",
-        "year": "This Year",
-        "custom": "Custom"
-      },
-      "reset": "Reset Filter",
-      "generate": "Generate"
+      "downloader": "Downloader"
+    },
+    "ReDownloadSelectDialog": {
+      "oldMethod": "Retry with original method",
+      "selectDownloader": "Select Downloader",
+      "title": "Re-download {0} records"
+    },
+    "filterPlaceholder": "Filter download history",
+    "reDownload": "Re-download",
+    "refresh": "Refresh download history list",
+    "searchTorrent": "Search this torrent across all sites",
+    "table": {
+      "downloadAt": "Download Time",
+      "downloader": "Downloader",
+      "status": "Download Status",
+      "title": "Torrent"
     }
   },
-  "layout": {
-    "header": {
-      "emptySearchNotice": "Get the first page of each tracker",
-      "home": "Home",
-      "navBarTip": "Click to show/hide the navigation bar",
-      "searchPlan": {
-        "all": "@:manifest.searchPlanAll",
-        "singleSite": "@:manifest.searchPlanSingleSite",
-        "default": "@:manifest.searchPlanDefault"
-      },
-      "searchTip": "Input keyword, IMDb numbers to search",
-      "wiki": "Wiki",
-      "wrongPixelRatioNotice": "Your page display may be affected by zooming. It is recommended to zoom at 100% to ensure your browsing experience~",
-      "expand": "Expand More",
-      "hotRecommendations": {
-        "title": "Hot Recommendations",
-        "refresh": "Refresh hot recommendations",
-        "loading": "Loading hot recommendations...",
-        "empty": "No hot recommendations",
-        "loadFailed": "Failed to load hot recommendations. Please try again later.",
-        "noRating": "No rating",
-        "noSummary": "No summary",
-        "category": {
-          "movie": "Movies",
-          "tv": "TV",
-          "variety": "Variety",
-          "anime": "Anime"
-        }
-      }
+  "KeepUploadTask": {
+    "clearAll": "Clear All",
+    "clearConfirm": "Confirm clearing all reseed tasks?",
+    "clearError": "Clear failed",
+    "clearSuccess": "Cleared successfully",
+    "copyError": "Copy failed",
+    "copyLinks": "Copy download links",
+    "copySuccess": "Copied {count} download links",
+    "defaultPath": "Default Path",
+    "deleteConfirm": "Confirm deleting this reseed task?",
+    "deleteError": "Delete failed",
+    "deleteSelectedConfirm": "Confirm deleting {count} selected reseed tasks?",
+    "deleteSuccess": "Deleted successfully",
+    "editSavePath": "Edit save path",
+    "emptyNotice": "No reseed tasks yet. Select torrents from search results and click reseed check button.",
+    "leechers": "Leechers: ",
+    "savePath": "Save Path: ",
+    "seeders": "Seeders: ",
+    "sendAllTorrents": "Send all torrents",
+    "sendBaseTorrent": "Send base torrent",
+    "sendConfirm": "Confirm sending {count} torrents to downloader?",
+    "sendError": "Send failed",
+    "sendOtherTorrents": "Send other torrents",
+    "sendSingleError": "Failed to send",
+    "sendSingleSuccess": "Sent",
+    "sendSuccess": "Sent successfully",
+    "setAsBaseTorrent": "Set as base torrent",
+    "setBaseError": "Failed to set as base torrent",
+    "setBaseSuccess": "Set as base torrent successfully",
+    "table": {
+      "count": "Count",
+      "site": "Site",
+      "size": "Size",
+      "time": "Created At",
+      "title": "Title"
     },
-    "init": "Please wait patiently for the page to load.....",
-    "releaseNote": {
-      "title": "Welcome to {extName}",
-      "currentVersion": " (current version)",
-      "changelog": "Changelog",
-      "wiki": "Wiki Help",
-      "faq": "FAQ",
-      "startUsing": "Get Started"
+    "title": "Reseed Tasks",
+    "torrentCount": "Torrents: ",
+    "updateError": "Update failed",
+    "updateSuccess": "Updated successfully",
+    "warning": {
+      "item1": "Please confirm that the download client has disabled 'auto start download' option before reseeding.",
+      "item2": "The assistant only performs simple verification on torrent files, reseeding success is not guaranteed!",
+      "item3": "Users are responsible for any issues caused by failed reseeding!",
+      "title": "Warning:"
     }
-  },
-  "manifest": {
-    "extDesc": "PT Depiler",
-    "extName": "PT Depiler",
-    "searchPlanAll": "All Sites",
-    "searchPlanSingleSite": "Single Site",
-    "searchPlanDefault": "Default",
-    "omniboxSearch": "Search $2 in [ $1 ]",
-    "contextMenuSearch": "Using PT Depiler to Search for \"%s\" related torrents",
-    "contextMenuSearchWithDouban": "Using PT Depiler to Search This Douban ID",
-    "contextMenuSearchWithIMDb": "Using PT Depiler to Search This IMDb ID",
-    "contextMenuSearchInDefault": "Search in the default plan",
-    "contextMenuSearchInSolution": "Search in the specified plan",
-    "contextMenuSearchInSite": "Search in the specified site",
-    "contextMenuSearchInThisSite": "Search in this site",
-    "contextMenuSendToDownloader": "Using PT Depiler to Download link",
-    "contextMenuSendToDownloaderAdvanced": "Advanced push",
-    "contextMenuSendToDownloaderIn": "Push to $1 -> $2",
-    "contextMenuSendToDownloaderDefaultFolder": "Default path",
-    "notificationSendLinkToDownloaderSuccess": "Successfully sent the link to the downloader [$1]",
-    "notificationSendLinkToDownloaderFailure": "Failed to send the link to the downloader [$1]"
-  },
-  "route": {
-    "About": {
-      "Logger": "Runtime Log",
-      "SpecialThank": "Special Thanks",
-      "TechnologyStack": "Project Reference",
-      "default": "About"
-    },
-    "Devtools": {
-      "Debugger": "Debugger",
-      "SystemLog": "System Log",
-      "default": "Devtools"
-    },
-    "Overview": {
-      "DownloadHistory": "Download History",
-      "MediaServerEntity": "Media Library",
-      "KeepUploadTask": "Reseed Task",
-      "MyClient": "My BtClient",
-      "MyCollection": "Collection",
-      "MyData": "My Data",
-      "SearchEntity": "Search Results",
-      "SearchResultSnapshot": "Search Snapshot",
-      "default": "Overview"
-    },
-    "Settings": {
-      "default": "Settings",
-      "SetBackup": "Backup & Restore",
-      "SetBase": "General",
-      "SetDownloader": "Download Server",
-      "SetMediaServer": "Media Server",
-      "SetSearchSolution": "Search Solution",
-      "SetSite": "Sites"
-    }
-  },
-  "connectCheck": {
-    "default": "Check Connect",
-    "error": "Connect Failed! Check Form Input or Remote Server",
-    "success": "Connect Successful! You can enter next step."
-  },
-  "downloaderLabel": {
-    "localDownload": "Local Download"
-  },
-  "levelRequirement": {
-    "interval": "Required Waiting Days",
-    "totalTraffic": "Total Traffic",
-    "downloaded": "Downloaded",
-    "trueDownloaded": "True Downloaded",
-    "uploaded": "Uploaded",
-    "trueUploaded": "True Uploaded",
-    "ratio": "Ratio",
-    "trueRatio": "True Ratio",
-    "seeding": "Seeding Count",
-    "seedingSize": "Seeding Size",
-    "seedingTime": "Seeding Time",
-    "averageSeedingTime": "Average Seeding Time",
-    "bonus": "Bonus",
-    "seedingBonus": "Seed Points",
-    "bonusPerHour": "Bonus Gained Per Hour",
-    "uploads": "Uploaded Torrents",
-    "leeching": "Leeching Torrents",
-    "snatches": "Completed Torrents",
-    "posts": "Posted Threads",
-    "hnrPreWarning": "PreWarning H&R Count",
-    "hnrUnsatisfied": "Unsatisfied H&R Count",
-    "adoptions": "Adopted Torrents"
-  },
-  "resultParseStatus": {
-    "unknownError": "Unknown Error!",
-    "waiting": "Waiting in Queue...",
-    "working": "Fetching...",
-    "success": "Fetch Successful!",
-    "parseError": "Parse Error!",
-    "passParse": "Passed!",
-    "CFBlocked": "Cloudflare Error!",
-    "CFBlockedNotes": "It may be because the site has enabled CloudFlare's security protection, which makes it impossible to retrieve data. You can first try to manually access the site once to pass the verification. If that doesn't work, just wait for the site to recover on its own.",
-    "needLogin": "Login Required!",
-    "noResults": "No Results!",
-    "unknown": "Unknown Status!"
   },
   "Logger": {
     "action": {
       "details": "Details"
+    }
+  },
+  "MediaServerEntity": {
+    "ItemInformationDialog": {
+      "duration": "Duration: ",
+      "mediaInfo": "Media Info: ",
+      "size": "Size: ",
+      "title": "Media Details",
+      "type": "Type: "
+    },
+    "detail": "Details",
+    "loadMore": "Load More",
+    "noItems": "No Items, use Search Input or Load More Button to Load",
+    "searchPlaceholder": "Search term"
+  },
+  "MyClient": {
+    "action": {
+      "delete": "Delete",
+      "pause": "Pause",
+      "pauseError": "Failed to pause",
+      "pauseSelectedSuccess": "Paused {count} torrent(s)",
+      "pauseSuccess": "Paused successfully",
+      "resume": "Resume",
+      "resumeError": "Failed to resume",
+      "resumeSelectedSuccess": "Resumed {count} torrent(s)",
+      "resumeSuccess": "Resumed successfully",
+      "viewRaw": "View Raw"
+    },
+    "autoRefresh": {
+      "btnTitle": "Auto-Refresh",
+      "clientSuspended": "{name} failed 3 times in a row. Auto-refresh suspended. Click the chip to resume.",
+      "downloaderFilter": "Downloader Filter",
+      "intervalLabel": "Refresh interval",
+      "intervalUnit": "seconds (0 = off)",
+      "resumeDownloader": "Resume auto-refresh for this downloader",
+      "start": "Start auto-refresh",
+      "stop": "Stop auto-refresh",
+      "stopDownloader": "Stop auto-refresh for this downloader",
+      "suspendedTip": "This client has been suspended due to 3 consecutive failures. Click the alert icon to resume."
+    },
+    "clientStatusDialog": {
+      "openBtn": "All Downloaders Status",
+      "openClient": "Open Downloader",
+      "title": "Downloader Status",
+      "torrentCount": "{count} torrent(s)"
+    },
+    "columnSelector": "Columns",
+    "deleteSelected": "Delete",
+    "dialog": {
+      "removeData": "Also remove data"
+    },
+    "pauseSelected": "Pause",
+    "pushToDownloader": {
+      "fileInputHint": "Select one or more .torrent files to push",
+      "fileInputLabel": "Torrent Files",
+      "modeFile": "Torrent File",
+      "modeUrl": "Link / Magnet",
+      "navBtn": "Push to Downloader",
+      "title": "Push to Downloader",
+      "urlInputHint": "One URL or magnet link per line",
+      "urlInputLabel": "URLs / Magnet Links"
+    },
+    "refresh": "Refresh",
+    "resumeSelected": "Resume",
+    "searchPlaceholder": "Search by name, hash, label, or path",
+    "state": {
+      "checking": "Checking",
+      "downloading": "Downloading",
+      "error": "Error",
+      "paused": "Paused",
+      "queued": "Queued",
+      "seeding": "Seeding",
+      "unknown": "Unknown"
+    },
+    "table": {
+      "addedAt": "Added At",
+      "client": "Client",
+      "dlSpeed": "Download Speed",
+      "name": "Torrent Name",
+      "progress": "Progress",
+      "ratio": "Ratio",
+      "savePath": "Save Path",
+      "size": "Size",
+      "status": "Status",
+      "totalDownloaded": "Total Download",
+      "totalUploaded": "Total Upload",
+      "upSpeed": "Upload Speed"
+    }
+  },
+  "MyData": {
+    "HistoryDataView": {
+      "action": {
+        "viewRaw": "View Raw Data"
+      },
+      "deleteConfirm": "Confirm to delete this history data?",
+      "title": "User History Data @ "
+    },
+    "UserLevelRequirementsTd": {
+      "levelList": "User Level List"
+    },
+    "index": {
+      "filter": {
+        "lastUpdateError": "Last update error",
+        "todayNotUpdated": "Not updated today",
+        "unreadMessage": "Unread messages"
+      },
+      "flushCancel": "Refresh canceled",
+      "flushSelectSite": "Refresh selected",
+      "joinTimeFormat": "Display join time",
+      "joinTimeFormatOptions": {
+        "added": "Absolute Date",
+        "alive": "Relative Time",
+        "aliveWeek": "Relative Weeks"
+      },
+      "multiOpen": "Open in batch",
+      "noSiteSelectedCancelRefresh": "No site selected, refresh cancelled",
+      "noSiteSelectedRefreshAll": "No site selected, refreshing all sites by default",
+      "normalizeLevelName": "Use Site-defined Level Name",
+      "onlyShowUserLevelRequirement": "Only show the upgrade queue in level requirements",
+      "setting": "Settings",
+      "showBonusNeededInterval": "Show estimated bonus time in level requirements",
+      "showHnR": "Show H&R",
+      "showIntervalAsDate": "Display level requirement time as date format",
+      "showLevelRequirement": "Show Level Requirement",
+      "showNextLevelInDialog": "Show next level requirements in Level Requirement Dialog",
+      "showNextLevelInTable": "Show next level requirements in Table",
+      "showSeedingBonus": "Show Seeding Bonus",
+      "showSiteName": "Show Site Name",
+      "showUnreadMessage": "Show Unread Messages",
+      "showUserName": "Show Username",
+      "simplifyBonusNumbers": "Simplify Bonus Numbers",
+      "siteCategory": "Site Category",
+      "siteStatus": "Site Status",
+      "updateAtFormatAsAlive": "Display update At as Relative Time",
+      "viewStatistic": "Data Chart",
+      "viewTimeline": "Timeline"
+    },
+    "table": {
+      "action": {
+        "flushData": "Refresh Data",
+        "viewHistoryData": "View History Data"
+      },
+      "invites": "Invites",
+      "joinTime": "Join Time",
+      "lastAccessAt": "Last Access At",
+      "lastAccessDurationNote": "Not Access for {0} days",
+      "levelName": "Level",
+      "trueUserData": "True Data",
+      "updateAt": "Updated At",
+      "userData": "Data"
+    }
+  },
+  "SearchEntity": {
+    "ActionTd": {
+      "copyLink": "Copy Download Link",
+      "copyLinkFailed": "Failed to copy download link",
+      "copyLinkSuccess": "Download link copied to clipboard",
+      "localDownload": "Download Torrent File Locally",
+      "sendToDefault": "Send to Default Downloader",
+      "sendToDownloader": "Send to Downloader"
+    },
+    "AdvanceFilterGenerateDialog": {
+      "completed": "Completed",
+      "leechers": "Leechers",
+      "seeders": "Seeders",
+      "size": "Torrent Size",
+      "status": "Torrent Status",
+      "tags": "Tags"
+    },
+    "KeepUploadDialog": {
+      "addToKeepUpload": "Add to reseed list",
+      "addToKeepUploadConfirm": "Confirm adding this torrent to reseed list?",
+      "baseTorrent": "Base Torrent",
+      "create": "Create Task",
+      "createError": "Failed to create reseed task",
+      "createSuccess": "Reseed task created successfully",
+      "fileCount": "Files: ",
+      "keepUpload": "Reseed Check",
+      "noVerifiedItem": "No verified torrents",
+      "otherTorrent": "Other Torrents",
+      "redownload": "Re-download torrent info",
+      "removeFromKeepUpload": "Remove from list",
+      "setSavePath": "Set save path",
+      "size": "Size: ",
+      "status": {
+        "downloadFailed": "Failed to download torrent",
+        "downloaded": "Torrent info downloaded",
+        "downloading": "Downloading torrent info...",
+        "failed": "Verification failed",
+        "label": "Status: ",
+        "missingFiles": "Missing files",
+        "success": "Verification passed",
+        "waiting": "Waiting for verification..."
+      },
+      "title": "Reseed Verification"
+    },
+    "SaveSnapshotDialog": {
+      "snapshotName": "Snapshot Name"
+    },
+    "SearchStatusDialog": {
+      "moveUp": "Move Up in the Queue",
+      "searchAgain": "Search Again",
+      "statusMsg": {
+        "noAdvanceParams": "Advance parameter not supported",
+        "noEmptyKeywords": "Empty keywords not supported",
+        "noNonLatin": "Non-Latin characters not supported",
+        "searchEntityNotEnabled": "The search entry not enabled",
+        "siteNotEnabled": "The site not enabled",
+        "userCancel": "You Cancel this search"
+      },
+      "successMsg": "Find {0} results in {0}s",
+      "title": "Search Status of [{0}]"
+    },
+    "index": {
+      "action": {
+        "cancel": "Cancel current waiting search",
+        "displayPreferences": "Search Results Display Preferences",
+        "pause": "Pause search queue",
+        "retry": "Retry Search",
+        "retryFailed": "Retry the failed search plans (such as @:resultParseStatus.unknownError, @:resultParseStatus.parseError, @:resultParseStatus.CFBlocked, @:resultParseStatus.needLogin)",
+        "saveSnapshot": "Save Search Snapshot",
+        "start": "Start search queue"
+      },
+      "alert": {
+        "duration": "Duration: {0} seconds.",
+        "enterKeyword": "Please enter keywords to start searching",
+        "keyword": "Keyword",
+        "paused": "Search paused...",
+        "plan": "Search Plan",
+        "results": "Total {0} results, ",
+        "searchProgress": "Received {0} results, search is still in progress...",
+        "searchStatus": "Search Status",
+        "searching": "Searching...",
+        "snapshot": "Search Snapshot"
+      },
+      "filterLabel": "Filter search results",
+      "limitTorrentTitleTdWidth": "Limit torrent title column width",
+      "selectedTorrents": "Selected {0} torrents",
+      "showSiteName": "Show Site Name",
+      "showSocialInformation": "Show Media Rating Information",
+      "showTorrentSubtitle": "Show Torrent Subtitle",
+      "showTorrentTag": "Show Torrent Tags",
+      "socialInformationSearchOnNewTab": "Open Media Rating Search in a New Tab",
+      "table": {
+        "category": "Category",
+        "comments": "Comments",
+        "completed": "Completed",
+        "leechers": "Leechers",
+        "seeders": "Seeders",
+        "size": "Size",
+        "time": "Published(≈)",
+        "title": "Title"
+      },
+      "uploadAtFormatAsAlive": "Display Upload Time as Relative Time"
+    },
+    "siteFilter": {
+      "all": "All Site"
+    }
+  },
+  "SearchResultSnapshot": {
+    "EditNameDialog": {
+      "snapshotName": "Snapshot Name",
+      "title": "Rename Search Snapshot"
+    },
+    "table": {
+      "action": {
+        "editTitle": "Edit Title",
+        "view": "View"
+      },
+      "filterLabel": "Filter by snapshot name",
+      "header": {
+        "createdAt": "Created At",
+        "name": "Snapshot Name",
+        "recordCount": "Torrent Count"
+      }
+    }
+  },
+  "SentToDownloaderDialog": {
+    "isSending": "Sending torrents to downloader {name} [{address}], please wait...",
+    "label": "Torrent Label",
+    "labelHint": "(If supported by the downloader)",
+    "localRelay": "Local Relay",
+    "moreOptions": "More Options",
+    "noDownloader": "No downloaders available. Please add a downloader in settings.",
+    "noDownloaderForSite": "No downloaders available for this site. Check the site filter settings in downloader configuration.",
+    "pauseOnAdd": "Pause on add by default",
+    "savePath": "Save Path",
+    "savePathHint": "Leave empty to use the downloader's default path",
+    "selectDownloader": "Select Downloader",
+    "selectDownloaderFirst": "Please select a downloader first",
+    "title": "Select downloader for {0} torrents"
+  },
+  "SetBackup": {
+    "AddDialog": {
+      "title": "Add Backup Server"
+    },
+    "Editor": {
+      "backupConfig": "Backup Configuration",
+      "serverConfig": "Server Configuration"
+    },
+    "HistoryDialog": {
+      "deleteFailure": "Failed to delete backup history [{name}]",
+      "deleteSuccess": "Deleted backup history [{name}] successfully",
+      "restore": "Restore Backup",
+      "table": {
+        "filename": "Backup Filename",
+        "size": "Backup Size",
+        "time": "Backup Time"
+      },
+      "title": "Backup History for {name}"
+    },
+    "LocalExportConfirmDialog": {
+      "title": "Select content to export locally"
+    },
+    "RestoreDialog": {
+      "decryptKey": "Decryption Key",
+      "expandCookieMinutes": "Try to extend Cookies expiry (minutes)",
+      "failure": "Restore failed: {error}",
+      "keepExistUserInfo": "Keep locally fetched user information",
+      "loadFailure": "Load failed: {error}",
+      "missingVersion": "Backup data is missing version info, cannot restore",
+      "ptppImport": "PT-Plugin-Plus Backup Import",
+      "ptppPrompt": "Need to import PT-Plugin-Plus backup?",
+      "restoreOptions": "Restore Options",
+      "retry": "Retry",
+      "selectFile": "Select Backup File",
+      "success": "Restored successfully",
+      "title": "Restore from Backup File",
+      "versionWarning": "Backup data version is higher than the current extension version. Restoring may cause data incompatibility or loss. Continue?"
+    },
+    "localExport": "Local Export",
+    "localImport": "Local Import",
+    "snackbar": {
+      "failure": "Backup failed",
+      "success": "Backup successful"
+    },
+    "table": {
+      "action": {
+        "backupNow": "Backup Now",
+        "viewHistoryBackup": "View History Backups"
+      },
+      "backupFields": "Backup Content",
+      "lastBackupAt": "Last Backup Time",
+      "notBackup": "Not Backed Up"
+    }
+  },
+  "SetBase": {
+    "download": {
+      "MyClientTitle": "My Downloader",
+      "allowDirectSendToClient": "Allow sending links directly (instead of torrent files) to the download server (Do not enable unless necessary)",
+      "enableSiteFilter": "Enable site filter (configure per-downloader site filtering in downloader settings)",
+      "initDownloaderTorrentOnEnter": "Automatically load torrents from the downloader when entering the My Downloader page",
+      "localDownloadIgnoreInterval": "Ignore site download interval limit for local downloads",
+      "localDownloadMethod": "Local Download Method",
+      "localDownloadMethodOptions": {
+        "browser": "Browser Method",
+        "browserTip": "(RECOMMEND) Use the browser's download method provided by the extension to download directly",
+        "extension": "Extension Proxy",
+        "extensionTip": "The extension downloads the torrent in the background and proxies it to @:SetBase.download.localDownloadMethodOptions.browser for downloading",
+        "web": "Web Page",
+        "webTip": "Open the page corresponding to the download link (only applicable to the simplest method; if conditions are not met, it will fall back to @:SetBase.download.localDownloadMethodOptions.extension )"
+      },
+      "localDownloadTitle": "Local Download",
+      "pushDownloadServerTitle": "Push to Download Server",
+      "quickSendToClientNote": "When quick push is enabled, the plugin will perform the following default actions when pushing download tasks:<br />1. Flatten the downloader and download directory options for direct click-to-push.<br />2. When hovering over an option, the label list will temporarily open; clicking will additionally add label information.<br />3. All use local relay mode to push torrents, and basic settings like 'auto-start download' and downloader-specific configs are determined by downloader and site settings.",
+      "saveDownloadHistory": "Save download history (Please do not disable this function unless necessary)",
+      "saveLastDownloader": "Save the last used download server settings",
+      "useQuickSendToClient": "Use quick push by default"
+    },
+    "searchEntity": {
+      "allowSingleSiteSearch": "Allow single-site search",
+      "autoDetectOfficialGroupFromTitle": "Auto Detect Official Tag From Torrent Title",
+      "autoLoadInitialMediaWall": "Automatically load the initial media wall",
+      "autoLoadMoreMediaOnScroll": "Automatically load more media when scrolling to the bottom of the page",
+      "filterLabel": "Result Filter",
+      "forceImdbIdMatchFilter": "When searching by IMDb, filter out results whose IMDb ID returned by the site does not match",
+      "imdbTip": "When disabled, you need to use the `imdb|tt12345678` format for IMDb searches.",
+      "mediaQueueConcurrency": "Request Queue Concurrency",
+      "mediaSearchLimit": "Number of search results per request",
+      "mediaSearchLimitMessage": "Please do not load too many search results at once. It's not optimized with virtual-scroll, which may cause the browser to freeze and affect the performance of the media server.",
+      "mediaServerSearchConfig": "Media Server Search Configuration",
+      "quickSiteFilter": "Quick Site Filter In Search Page",
+      "saveLastSearchFilter": "Save last used search filter",
+      "searchPlanLabel": "Search Plan",
+      "showHotRecommendations": "Show hot recommendations button in the search box",
+      "siteQueueConcurrency": "Request Queue Concurrency",
+      "siteSearchConfig": "Site Search Configuration",
+      "treatTTQueryAsImdbSearch": "Treat tt\\d\\{7,8\\} search terms directly as IMDb search"
+    },
+    "tab": {
+      "backup": "Backup & Restore",
+      "download": "Download",
+      "native-bridge": "Native Bridge",
+      "search-entity": "@:common.search",
+      "social-information": "Social Rating",
+      "ui": "Option UI",
+      "user-info": "UserInfo"
+    },
+    "ui": {
+      "allowDragLink": "Allow dragging links to the sidebar button",
+      "allowExceptionSites": "Allow setting exception sites without sidebar (enable in site settings)",
+      "basicSettings": "Basic Settings",
+      "changeLanguage": "Switch Language",
+      "confirmTwoStep": "Require two-step confirmation for batch copy, local download, etc. on torrent list pages",
+      "contentScript": "Content Script (Site Sidebar, etc.)",
+      "contentScriptWarning": "After enabling or disabling related features, save settings and refresh the site page for changes to take effect.",
+      "contextMenu": "Context Menu",
+      "contextMenuLinkPush": "Enable (download) link push",
+      "contextMenuSocialSearch": "Enable social link (douban, imdb) search",
+      "contextMenuTextSearch": "Enable selected text search",
+      "displayMode": {
+        "auto": "Auto (Follow Browser or System)",
+        "dark": "Dark Mode",
+        "index": "UI display mode",
+        "light": "Light Mode"
+      },
+      "dragNote": "Dragged download links may not always be correctly recognized!",
+      "enableFadeEffect": "Enable fade-in effect (semi-transparent by default, shows on hover)",
+      "enableOnSocialSite": "Enable sidebar on social sites (e.g. Douban, IMDb)",
+      "enableTableMultiSort": "Enable multi-column sorting for some tables",
+      "expandByDefault": "Expand sidebar button by default",
+      "respondDisplayMode": "Respond to plugin setting ",
+      "saveTableBehavior": "Remember table header columns, sorting, pagination, etc.",
+      "showReleaseNote": "Show changelog window when plugin updates",
+      "sidebarFunctions": "Sidebar Functions",
+      "sidebarStyle": "Sidebar Style",
+      "socialSiteSearchBy": {
+        "chosen": "Let me choose",
+        "id": "Search by ID",
+        "imdb": "Search by IMDb Number",
+        "title": "Search by Main Title"
+      },
+      "socialSiteSearchLabel": "Social site search method",
+      "tableMultiSortNote": "Multi-column sorting: Click any table header field to start sorting, which will display the number \\\"1\\\" on the field. Click other fields sequentially to display \\\"2\\\", \\\"3\\\", indicating sorting priority. Click the same field again to toggle between ascending, descending, or cancel sorting. The sorting order is determined by these numbers, with smaller numbers having higher priority.",
+      "useLargeIcon": "Use large icon buttons"
+    },
+    "userInfo": {
+      "afterTime": "Earliest daily refresh time",
+      "userDataRefresh": "User Data Refresh",
+      "userInfoDisplay": "User Info Display"
+    }
+  },
+  "SetDownloader": {
+    "PathAndTag": {
+      "downloadPath": {
+        "addInputLabel": "Added @:SetDownloader.PathAndTag.downloadPath.title",
+        "addTitle": "Added @:SetDownloader.PathAndTag.downloadPath.title @:SetDownloader.PathAndTag.supportDragNote",
+        "autoImport": "One-click to import of existing @:SetDownloader.PathAndTag.downloadPath.title from the downloader",
+        "autoImportFail": "@:SetDownloader.PathAndTag.downloadPath.autoImport failed, please add manually.",
+        "clear": "Clear @:SetDownloader.PathAndTag.downloadPath.title",
+        "title": "Download Paths"
+      },
+      "note": {
+        "index": "The @:SetDownloader.PathAndTag.downloadPath.title or @:SetDownloader.PathAndTag.tags.title can include the following keywords:",
+        "replaceNote": {
+          "custom": "Custom text",
+          "dateDay": "current day",
+          "dateMonth": "current month",
+          "dateYear": "current year",
+          "searchKeyword": "Search Keywords",
+          "searchPlan": "Search Plan Name",
+          "torrentSite": "The Site ID of torrent",
+          "torrentSiteName": "The Site name of torrent",
+          "torrentSubTitle": "The subtitle of torrent",
+          "torrentTitle": "The title of torrent"
+        },
+        "table": {
+          "example": "Example",
+          "keywords": "Keywords",
+          "note": "Note"
+        },
+        "title": "Note"
+      },
+      "supportDragNote": "(Support drag to sort)",
+      "tags": {
+        "addInputLabel": "Added @:SetDownloader.PathAndTag.tags.title",
+        "addTitle": "Added @:SetDownloader.PathAndTag.tags.title @:SetDownloader.PathAndTag.supportDragNote",
+        "autoImport": "One-click to import of existing @:SetDownloader.PathAndTag.tags.title from the downloader",
+        "autoImportFail": "@:SetDownloader.PathAndTag.tags.autoImport failed, please add manually.",
+        "clear": "Clear @:SetDownloader.PathAndTag.tags.title",
+        "title": "Tags"
+      },
+      "title": "@:SetDownloader.index.table.action.setPathAndTag for downloader [{0}]"
+    },
+    "add": {
+      "NoneSelectNotice": "Please select a server type",
+      "newType": "Come here to add the server type you want!",
+      "selectPlaceholder": "@:SetDownloader.add.NoneSelectNotice ( Support Search )",
+      "step": {
+        "selectType": "Select server type",
+        "setOptions": "Configuration"
+      },
+      "title": "Add Download Client"
+    },
+    "common": {
+      "address": "Server Address",
+      "name": "Server Name",
+      "status": "Status",
+      "uid": "Server Id"
+    },
+    "delete": {
+      "text": "Are you sure to delete these {0} Download Servers?"
+    },
+    "edit": {
+      "title": "Edit Download Server"
+    },
+    "editor": {
+      "addressTip": "Full Server Address (may include port or path), Like: http://192.168.1.1:5000/",
+      "autoStart": "Automatically start downloading when sending a torrent",
+      "nameTip": "Pick a nice and recognizable name for this Download Server",
+      "password": "Password",
+      "timeout": "Timeout (seconds)",
+      "uidPlaceholder": " (Generate automatically)"
+    },
+    "index": {
+      "changeDefaultDownloader": "Default downloader updated successfully. If necessary, please further configure the download path and tags.",
+      "editDefaultDownloaderBtn": "Edit Default Downloader",
+      "emptyNotice": "Before using the download service, you need to add at least one download server.",
+      "remove": {
+        "multi": "Are you sure to delete these {count} download servers?",
+        "single": "Are you sure to delete this download server?"
+      },
+      "table": {
+        "action": {
+          "deleteDownloader": "Delete this downloader server",
+          "setDefault": "Set this downloader server as Default Downloader.",
+          "setPathAndTag": "Set Suggest Download Path and Tags",
+          "setSiteFilter": "Set Site Filter",
+          "status": "Status"
+        },
+        "autodl": "Auto DL ?",
+        "downloaderCategory": "Downloader Category",
+        "enabled": "Enabled ?"
+      }
+    },
+    "siteFilter": {
+      "excludedSites": "Excluded Sites",
+      "excludedSitesHint": "If a site is excluded, this downloader will not be shown on the site page (does not apply to the aggregated search page)",
+      "noSites": "No sites added yet",
+      "title": "Set site filter for downloader [{0}] (exclusion)"
+    }
+  },
+  "SetMediaServer": {
+    "Editor": {
+      "authInfo": "Authentication Info"
+    },
+    "add": {
+      "title": "Add Media Server"
+    }
+  },
+  "SetNativeBridge": {
+    "bridge": {
+      "enabled": "Enable Native Bridge",
+      "status": {
+        "connected": "Connected",
+        "connecting": "Connecting...",
+        "disabled": "Disabled",
+        "error": "Error",
+        "no-permission": "No Permission",
+        "retrying": "Retrying..."
+      },
+      "testConnection": "Test Connection",
+      "title": "Bridge Control"
+    },
+    "info": {
+      "cliLink": "ptd-cli",
+      "cliRequired": "The external CLI tool must be installed for this feature to work. Native bridge is not available on mobile platforms. See {0} for installation instructions.",
+      "description": "The native bridge allows the PT-Depiler CLI tool to communicate with this extension. It requires the CLI tool to be installed separately on your computer.",
+      "privacy": "When enabled, the native bridge allows the locally installed CLI tool to access extension data including site configuration, search results, download history, user info, and downloader status. All communication is local (between browser and local process) — no data is sent to remote servers. You can disable this feature or revoke the permission at any time.",
+      "setupCommand": "Run the following command to register this extension with the CLI tool:",
+      "setupHint": "After running the command, restart the browser or click Test Connection.",
+      "title": "About Native Bridge"
+    },
+    "permission": {
+      "grant": "Grant Permission",
+      "grantFailed": "Permission request was denied",
+      "granted": "Permission Granted",
+      "notGranted": "Permission Not Granted",
+      "revoke": "Revoke Permission",
+      "title": "Permission"
+    }
+  },
+  "SetSearchSolution": {
+    "CustomSolutionDialog": {
+      "requestConfig": "Request Config",
+      "requestConfigHint": "Please configure request parameters in JSON format",
+      "requestConfigJsonError": "Must be valid JSON format",
+      "solutionName": "Plan Name",
+      "title": "Custom Search Plan"
+    },
+    "copy": "Duplicate",
+    "delete": {
+      "text": "Are you sure to delete these {0} @:SetSearchSolution.solution ?"
+    },
+    "edit": {
+      "addCount": "Added {0} @:SetSearchSolution.solution",
+      "cantAddByDuplicateNote": "A duplicate @:SetSearchSolution.solution already exists and cannot be added again.",
+      "filterPlaceholder": "Filter by site name or url",
+      "title": "Customize @:SetSearchSolution.solution"
+    },
+    "newSolutionNamePrompt": "Please enter the new search plan name",
+    "solution": "Search Solution",
+    "spDialog": {
+      "action": {
+        "add": "Add this @:SetSearchSolution.solution",
+        "create": "Create a custom @:SetSearchSolution.solution based on this",
+        "reset": "Reset this @:SetSearchSolution.solution"
+      },
+      "noDefNotice": "This site does not define any search categories, please go to help!",
+      "notice": "It is not recommended to set it here, and it is recommended to configure your user CP in site or use search solution",
+      "selectAllNotice": "(Notice: In most cases, you don't need to select all search terms! )",
+      "title": "Set default search params for Site {name}"
+    },
+    "table": {
+      "autoGenerate": "Auto Generate",
+      "default": "Default ?",
+      "enable": "Enabled ?"
+    }
+  },
+  "SetSite": {
+    "AddDialog": {
+      "showDeadSite": "Show dead sites"
+    },
+    "Editor": {
+      "downloadInterval": "Download Interval",
+      "downloadIntervalHint": "Affects the download interval for this site (for safety, the plugin will not strictly follow this setting; the actual interval is always slightly greater than or equal to the set interval)",
+      "downloadLinkSuffix": "Download Link Suffix",
+      "downloadLinkSuffixExample": "E.g. if the plugin gets https://example.com/download.php?id=1 and you set &passkey=xxxx, the final download link will be https://example.com/download.php?id=1&passkey=xxxx. Leave this empty by default, and only fill in the passkey if the correct download link cannot be obtained.",
+      "downloadLinkSuffixHint": "This field will be automatically appended to the site's download links",
+      "otherSettings": "Other Settings",
+      "requestTimeout": "Request Timeout",
+      "requestTimeoutHint": "Affects the timeout for site requests (torrent search, user info retrieval)",
+      "siteSettings": "Site Settings"
+    },
+    "ReBuildMapDialog": {
+      "doRebuildBtn": "Rebuild",
+      "rebuildSiteHostMap": "Rebuild site host mapping cache",
+      "rebuildSiteNameMap": "Rebuild site name mapping cache",
+      "title": "Rebuild Site Mapping Cache"
+    },
+    "SiteCategoryPanel": {
+      "siteDefault": "Site Default"
+    },
+    "add": {
+      "selectSitePlaceholder": "Please Select a site to add (support search in url and site name)",
+      "title": "Add Site"
+    },
+    "common": {
+      "aka": "AKA",
+      "allowContentScript": "Load Content Script",
+      "allowQueryUserInfo": "Allow access USP",
+      "allowSearch": "Allow Search",
+      "groups": "Site Groups",
+      "isOffline": "Offline",
+      "name": "Site Name",
+      "open": "Open",
+      "showMessageCount": "Show Notice",
+      "tags": "Tags",
+      "url": "URL"
+    },
+    "delete": {
+      "text": "Are you sure to delete these {0} Site?"
+    },
+    "edit": {
+      "title": "Edit Site Config"
+    },
+    "editor": {
+      "addUrlTip": "Add a site url which you current used, for example: https://example.com/",
+      "customUrlPlaceholder": "Custom site url",
+      "description": "Site description",
+      "sortIndexTip": "Can be used for search sorting",
+      "tagTip": "Press Enter to add a tag after typing. (Only the first 4 will be displayed on the list page)",
+      "timezone": "Timezone",
+      "uploadSpeedLimit": "Upload Speed",
+      "uploadSpeedLimitHint": "Set upload speed limit (MiB/s) when pushing torrents to downloader, 0 or empty means unlimited"
+    },
+    "index": {
+      "flushFaviconFinish": "The selected site favicon has been refreshed successfully!",
+      "oneClickImport": "One-Click Import Sites",
+      "reBuildMap": "Rebuild Site Cache",
+      "settingNote": [
+        "Only the configured site will display the plugin icon and the corresponding function;",
+        "the offline site will no longer participate in the search and information acquisition;"
+      ],
+      "table": {
+        "flushFavicon": "Refresh Site Favicon",
+        "searchEntries": "Search Entries"
+      }
+    },
+    "oneClickImportDialog": {
+      "alert1": "This operation will attempt to import the sites you select with default configurations. Please ensure you have logged into these sites in your browser. The import process cannot be interrupted, please wait patiently.",
+      "alert2": "List of unadded sites",
+      "importComplete": "One-click import complete, successfully added {count} sites",
+      "stats": "Selected {count} sites, added {success} sites, failed to add {failed} sites.",
+      "status": {
+        "failed": "Failed to add",
+        "manual": "This site needs to be added manually",
+        "selected": "Selected",
+        "success": "Added successfully",
+        "trying": "Trying"
+      },
+      "title": "One-Click Import Sites",
+      "trying": "Trying to import site [{name}] ..."
     }
   },
   "SpecialThank": {
@@ -243,987 +835,404 @@
     },
     "thankNote": "The birth of 'PT Plugin Plus' is established on the base of these projects. Thanks all the participants of the project, thanks for your contribution!"
   },
-  "DownloadHistory": {
-    "refresh": "Refresh download history list",
-    "reDownload": "Re-download",
-    "searchTorrent": "Search this torrent across all sites",
-    "filterPlaceholder": "Filter download history",
-    "table": {
-      "title": "Torrent",
-      "downloader": "Downloader",
-      "downloadAt": "Download Time",
-      "status": "Download Status"
-    },
-    "AdvanceFilterGenerateDialog": {
-      "downloader": "Downloader"
-    },
-    "ReDownloadSelectDialog": {
-      "title": "Re-download {0} records",
-      "oldMethod": "Retry with original method",
-      "selectDownloader": "Select Downloader"
-    }
-  },
-  "KeepUploadTask": {
-    "title": "Reseed Tasks",
-    "savePath": "Save Path: ",
-    "defaultPath": "Default Path",
-    "torrentCount": "Torrents: ",
-    "clearConfirm": "Confirm clearing all reseed tasks?",
-    "emptyNotice": "No reseed tasks yet. Select torrents from search results and click reseed check button.",
-    "clearAll": "Clear All",
-    "deleteConfirm": "Confirm deleting this reseed task?",
-    "deleteSelectedConfirm": "Confirm deleting {count} selected reseed tasks?",
-    "deleteSuccess": "Deleted successfully",
-    "deleteError": "Delete failed",
-    "clearSuccess": "Cleared successfully",
-    "clearError": "Clear failed",
-    "sendSuccess": "Sent successfully",
-    "sendError": "Send failed",
-    "sendSingleSuccess": "Sent",
-    "sendSingleError": "Failed to send",
-    "sendConfirm": "Confirm sending {count} torrents to downloader?",
-    "sendBaseTorrent": "Send base torrent",
-    "sendOtherTorrents": "Send other torrents",
-    "sendAllTorrents": "Send all torrents",
-    "setAsBaseTorrent": "Set as base torrent",
-    "setBaseSuccess": "Set as base torrent successfully",
-    "setBaseError": "Failed to set as base torrent",
-    "seeders": "Seeders: ",
-    "leechers": "Leechers: ",
-    "copyLinks": "Copy download links",
-    "copySuccess": "Copied {count} download links",
-    "copyError": "Copy failed",
-    "editSavePath": "Edit save path",
-    "updateSuccess": "Updated successfully",
-    "updateError": "Update failed",
-    "table": {
-      "site": "Site",
-      "title": "Title",
-      "size": "Size",
-      "count": "Count",
-      "time": "Created At"
-    },
-    "warning": {
-      "title": "Warning:",
-      "item1": "Please confirm that the download client has disabled 'auto start download' option before reseeding.",
-      "item2": "The assistant only performs simple verification on torrent files, reseeding success is not guaranteed!",
-      "item3": "Users are responsible for any issues caused by failed reseeding!"
-    }
-  },
-  "torrent": {
-    "status": {
-      "unknown": "Unknown",
-      "downloading": "Downloading",
-      "seeding": "Seeding",
-      "inactive": "Inactive",
-      "completed": "Completed"
-    }
-  },
-  "MediaServerEntity": {
-    "searchPlaceholder": "Search term",
-    "detail": "Details",
-    "loadMore": "Load More",
-    "noItems": "No Items, use Search Input or Load More Button to Load",
-    "ItemInformationDialog": {
-      "title": "Media Details",
-      "type": "Type: ",
-      "duration": "Duration: ",
-      "size": "Size: ",
-      "mediaInfo": "Media Info: "
-    }
-  },
-  "MyData": {
-    "index": {
-      "flushSelectSite": "Refresh selected",
-      "flushCancel": "Refresh canceled",
-      "joinTimeFormat": "Display join time",
-      "joinTimeFormatOptions": {
-        "alive": "Relative Time",
-        "aliveWeek": "Relative Weeks",
-        "added": "Absolute Date"
-      },
-      "showSiteName": "Show Site Name",
-      "showUnreadMessage": "Show Unread Messages",
-      "showUserName": "Show Username",
-      "normalizeLevelName": "Use Site-defined Level Name",
-      "showLevelRequirement": "Show Level Requirement",
-      "onlyShowUserLevelRequirement": "Only show the upgrade queue in level requirements",
-      "showNextLevelInTable": "Show next level requirements in Table",
-      "showNextLevelInDialog": "Show next level requirements in Level Requirement Dialog",
-      "showHnR": "Show H&R",
-      "showSeedingBonus": "Show Seeding Bonus",
-      "updateAtFormatAsAlive": "Display update At as Relative Time",
-      "showIntervalAsDate": "Display level requirement time as date format",
-      "simplifyBonusNumbers": "Simplify Bonus Numbers",
-      "showBonusNeededInterval": "Show estimated bonus time in level requirements",
-      "multiOpen": "Open in batch",
-      "viewTimeline": "Timeline",
-      "viewStatistic": "Data Chart",
-      "setting": "Settings",
-      "siteStatus": "Site Status",
-      "siteCategory": "Site Category",
-      "filter": {
-        "todayNotUpdated": "Not updated today",
-        "lastUpdateError": "Last update error",
-        "unreadMessage": "Unread messages"
-      },
-      "noSiteSelectedRefreshAll": "No site selected, refreshing all sites by default",
-      "noSiteSelectedCancelRefresh": "No site selected, refresh cancelled"
-    },
-    "table": {
-      "levelName": "Level",
-      "userData": "Data",
-      "trueUserData": "True Data",
-      "invites": "Invites",
-      "joinTime": "Join Time",
-      "lastAccessAt": "Last Access At",
-      "lastAccessDurationNote": "Not Access for {0} days",
-      "updateAt": "Updated At",
-      "action": {
-        "viewHistoryData": "View History Data",
-        "flushData": "Refresh Data"
-      }
-    },
-    "HistoryDataView": {
-      "title": "User History Data @ ",
-      "deleteConfirm": "Confirm to delete this history data?",
-      "action": {
-        "viewRaw": "View Raw Data"
-      }
-    },
-    "UserLevelRequirementsTd": {
-      "levelList": "User Level List"
-    }
-  },
   "UserDataStatistic": {
     "chart": {
-      "totalSiteBase": "Basic Data",
-      "totalSiteSeeding": "Seeding Data",
-      "perSiteKuploaded": "Uploaded Data by Site",
-      "perSiteKuploadedIncr": "Upload Increment by Site",
+      "chartSettings": "Chart Settings",
+      "chartStyleSettings": "Chart Style Settings",
+      "dataLabel": "Data",
+      "dateRange": "Date Range",
+      "displayChart": "Display Chart",
+      "displaySiteSettings": "Display Site Settings",
+      "downloadLabel": "Download",
+      "exportFilename": "{name}'s Data Chart ({date})",
+      "hiddenSites": "(And {count} more sites hidden)",
+      "hideLowPercentHint": "Set to 0 to not hide",
+      "hideLowPercentLabel": "Hide details for sites with legend percentage below this value",
+      "noData": "No Data",
+      "perSiteKbonus": "Bonus Points by Site",
+      "perSiteKbonusIncr": "Bonus Increment by Site",
       "perSiteKdownloaded": "Downloaded Data by Site",
       "perSiteKdownloadedIncr": "Download Increment by Site",
       "perSiteKseeding": "Seeding Count by Site",
+      "perSiteKseedingBonus": "Seeding Bonus Points by Site",
+      "perSiteKseedingBonusIncr": "Seeding Bonus Increment by Site",
       "perSiteKseedingIncr": "Seeding Increment by Site",
       "perSiteKseedingSize": "Seeding Size by Site",
       "perSiteKseedingSizeIncr": "Seeding Size Increment by Site",
-      "perSiteKbonus": "Bonus Points by Site",
-      "perSiteKbonusIncr": "Bonus Increment by Site",
-      "perSiteKseedingBonus": "Seeding Bonus Points by Site",
-      "perSiteKseedingBonusIncr": "Seeding Bonus Increment by Site",
-      "uploadLabel": "Upload",
-      "downloadLabel": "Download",
-      "dataLabel": "Data",
-      "seedingSizeLabel": "Seeding Size",
+      "perSiteKuploaded": "Uploaded Data by Site",
+      "perSiteKuploadedIncr": "Upload Increment by Site",
       "seedingLabel": "Seeding",
+      "seedingSizeLabel": "Seeding Size",
       "totalLabel": "Total",
-      "hiddenSites": "(And {count} more sites hidden)",
-      "noData": "No Data",
-      "chartStyleSettings": "Chart Style Settings",
-      "displaySiteSettings": "Display Site Settings",
-      "displayChart": "Display Chart",
-      "dateRange": "Date Range",
-      "chartSettings": "Chart Settings",
-      "hideLowPercentHint": "Set to 0 to not hide",
-      "hideLowPercentLabel": "Hide details for sites with legend percentage below this value",
-      "exportFilename": "{name}'s Data Chart ({date})"
+      "totalSiteBase": "Basic Data",
+      "totalSiteSeeding": "Seeding Data",
+      "uploadLabel": "Upload"
     },
     "dateRange": {
-      "custom": "Custom",
       "all": "All",
+      "custom": "Custom",
       "day": "Last {0} days"
     }
   },
   "UserDataTimeline": {
-    "total": "TOT ",
-    "field": {
-      "site": "Site",
-      "uploads": "Uploads",
-      "uploaded": "UP Size",
-      "downloaded": "DL Size",
-      "seeding": "Seeding",
-      "seedingSize": "SD Size",
-      "bonus": "Bonus",
-      "bonusPerHour": "Bonus/H",
-      "ratio": "Ratio",
-      "siteName": "Site Name",
-      "name": "@:common.username",
-      "level": "User Level",
-      "uid": "User ID"
-    },
     "controls": {
-      "usernameAndTitle": "Username & Title",
-      "timelineTitle": "Timeline Title",
       "components": "Components",
-      "showTopSites": "Show champion and runner-up sites for each data type",
-      "showTimeline": "Show individual site information (master switch)",
       "customBgColor": "Custom Background Color",
-      "siteDisplay": "Site Display Component",
-      "faviconBlur": "Site Favicon Blur",
       "displayContent": "Display Content",
+      "displaySiteSettings": "Display Site Settings",
+      "faviconBlur": "Site Favicon Blur",
+      "showTimeline": "Show individual site information (master switch)",
+      "showTopSites": "Show champion and runner-up sites for each data type",
+      "siteDisplay": "Site Display Component",
       "statsSection": "Statistics Section",
-      "timelineSection": "Timeline Section",
-      "timeDisplay": "Time Display Method",
+      "styleSettings": "Timeline Style Settings",
       "timeAdded": "Event Time",
       "timeAlive": "Time Elapsed",
-      "styleSettings": "Timeline Style Settings",
-      "displaySiteSettings": "Display Site Settings"
+      "timeDisplay": "Time Display Method",
+      "timelineSection": "Timeline Section",
+      "timelineTitle": "Timeline Title",
+      "usernameAndTitle": "Username & Title"
+    },
+    "exportFilename": "{name}'s Timeline ({date})",
+    "field": {
+      "bonus": "Bonus",
+      "bonusPerHour": "Bonus/H",
+      "downloaded": "DL Size",
+      "level": "User Level",
+      "name": "@:common.username",
+      "ratio": "Ratio",
+      "seeding": "Seeding",
+      "seedingSize": "SD Size",
+      "site": "Site",
+      "siteName": "Site Name",
+      "uid": "User ID",
+      "uploaded": "UP Size",
+      "uploads": "Uploads"
     },
     "ptAge": "PT Age: ≈ {years} years",
-    "exportFilename": "{name}'s Timeline ({date})"
+    "total": "TOT "
   },
-  "SearchEntity": {
-    "index": {
-      "table": {
-        "title": "Title",
-        "category": "Category",
-        "size": "Size",
-        "seeders": "Seeders",
-        "leechers": "Leechers",
-        "completed": "Completed",
-        "comments": "Comments",
-        "time": "Published(≈)"
-      },
-      "alert": {
-        "enterKeyword": "Please enter keywords to start searching",
-        "searchStatus": "Search Status",
-        "paused": "Search paused...",
-        "searching": "Searching...",
-        "searchProgress": "Received {0} results, search is still in progress...",
-        "snapshot": "Search Snapshot",
-        "plan": "Search Plan",
-        "keyword": "Keyword",
-        "results": "Total {0} results, ",
-        "duration": "Duration: {0} seconds."
-      },
-      "action": {
-        "start": "Start search queue",
-        "pause": "Pause search queue",
-        "cancel": "Cancel current waiting search",
-        "retry": "Retry Search",
-        "retryFailed": "Retry the failed search plans (such as @:resultParseStatus.unknownError, @:resultParseStatus.parseError, @:resultParseStatus.CFBlocked, @:resultParseStatus.needLogin)",
-        "saveSnapshot": "Save Search Snapshot",
-        "displayPreferences": "Search Results Display Preferences"
-      },
-      "filterLabel": "Filter search results",
-      "selectedTorrents": "Selected {0} torrents",
-      "showSiteName": "Show Site Name",
-      "showTorrentTag": "Show Torrent Tags",
-      "showTorrentSubtitle": "Show Torrent Subtitle",
-      "showSocialInformation": "Show Media Rating Information",
-      "socialInformationSearchOnNewTab": "Open Media Rating Search in a New Tab",
-      "uploadAtFormatAsAlive": "Display Upload Time as Relative Time",
-      "limitTorrentTitleTdWidth": "Limit torrent title column width"
-    },
-    "siteFilter": {
-      "all": "All Site"
-    },
+  "common": {
     "AdvanceFilterGenerateDialog": {
-      "tags": "Tags",
-      "status": "Torrent Status",
-      "size": "Torrent Size",
-      "seeders": "Seeders",
-      "leechers": "Leechers",
-      "completed": "Completed"
-    },
-    "SearchStatusDialog": {
-      "title": "Search Status of [{0}]",
-      "successMsg": "Find {0} results in {0}s",
-      "statusMsg": {
-        "userCancel": "You Cancel this search",
-        "siteNotEnabled": "The site not enabled",
-        "searchEntityNotEnabled": "The search entry not enabled",
-        "noEmptyKeywords": "Empty keywords not supported",
-        "noNonLatin": "Non-Latin characters not supported",
-        "noAdvanceParams": "Advance parameter not supported"
+      "date": "Date",
+      "dateUnit": {
+        "custom": "Custom",
+        "day": "Today",
+        "month": "This Month",
+        "quarter": "This Quarter",
+        "week": "This Week",
+        "year": "This Year"
       },
-      "moveUp": "Move Up in the Queue",
-      "searchAgain": "Search Again"
+      "exclude": "Exclude",
+      "generate": "Generate",
+      "keywords": "Keywords",
+      "required": "Required",
+      "reset": "Reset Filter",
+      "site": "@:common.site",
+      "title": "Generate Advanced Filter"
     },
-    "ActionTd": {
-      "sendToDefault": "Send to Default Downloader",
-      "sendToDownloader": "Send to Downloader",
-      "copyLink": "Copy Download Link",
-      "localDownload": "Download Torrent File Locally",
-      "copyLinkSuccess": "Download link copied to clipboard",
-      "copyLinkFailed": "Failed to copy download link"
+    "action": "Action",
+    "advancedSettings": "Advanced Settings",
+    "back": "Back",
+    "basicInfo": "Basic Information",
+    "btn": {
+      "add": "Add"
     },
-    "SaveSnapshotDialog": {
-      "snapshotName": "Snapshot Name"
+    "checkbox": {
+      "all": "ALL",
+      "invert": "Invert Selection",
+      "none": "Select None"
     },
-    "KeepUploadDialog": {
-      "title": "Reseed Verification",
-      "keepUpload": "Reseed Check",
-      "baseTorrent": "Base Torrent",
-      "otherTorrent": "Other Torrents",
-      "size": "Size: ",
-      "fileCount": "Files: ",
-      "addToKeepUpload": "Add to reseed list",
-      "addToKeepUploadConfirm": "Confirm adding this torrent to reseed list?",
-      "redownload": "Re-download torrent info",
-      "removeFromKeepUpload": "Remove from list",
-      "setSavePath": "Set save path",
-      "create": "Create Task",
-      "createSuccess": "Reseed task created successfully",
-      "createError": "Failed to create reseed task",
-      "noVerifiedItem": "No verified torrents",
-      "status": {
-        "label": "Status: ",
-        "downloading": "Downloading torrent info...",
-        "waiting": "Waiting for verification...",
-        "downloaded": "Torrent info downloaded",
-        "success": "Verification passed",
-        "failed": "Verification failed",
-        "downloadFailed": "Failed to download torrent",
-        "missingFiles": "Missing files"
-      }
-    }
-  },
-  "SearchResultSnapshot": {
-    "table": {
-      "header": {
-        "name": "Snapshot Name",
-        "recordCount": "Torrent Count",
-        "createdAt": "Created At"
-      },
-      "filterLabel": "Filter by snapshot name",
-      "action": {
-        "view": "View",
-        "editTitle": "Edit Title"
+    "count": "Count",
+    "date": "Date",
+    "default": "default",
+    "dialog": {
+      "cancel": "Cancel",
+      "close": "Close",
+      "confirm": "Confirm",
+      "deleteText": "Are you sure to delete these {0} item?",
+      "next": "Next",
+      "ok": "Complete",
+      "prev": "Prev",
+      "reset": "Reset",
+      "title": {
+        "confirmAction": "Confirm Action"
       }
     },
-    "EditNameDialog": {
-      "title": "Rename Search Snapshot",
-      "snapshotName": "Snapshot Name"
-    }
+    "edit": "Edit",
+    "enable": "Enable",
+    "export": "Export",
+    "exportImage": "Export Image",
+    "howToUse": "How To Use",
+    "import": "Import",
+    "language": "Language",
+    "name": "Name",
+    "project": "PT Depiler",
+    "remove": "Delete",
+    "save": "Save",
+    "saveSettings": "Save Settings",
+    "saveSuccess": "Saved successfully",
+    "search": "Search",
+    "site": "Site",
+    "sortIndex": "Priority",
+    "test": "Test",
+    "time": {
+      "ago": " Ago",
+      "day": "Day",
+      "hour": "Hour",
+      "lessThanAWeek": "Less than a week",
+      "minute": "Minute",
+      "month": "Month",
+      "second": "Second",
+      "week": "Week",
+      "year": "Year"
+    },
+    "type": "Type",
+    "username": "Username",
+    "version": "Version",
+    "visit": "Visit"
   },
-  "SetBase": {
-    "tab": {
-      "ui": "Option UI",
-      "search-entity": "@:common.search",
-      "download": "Download",
-      "user-info": "UserInfo",
-      "backup": "Backup & Restore",
-      "social-information": "Social Rating",
-      "native-bridge": "Native Bridge"
-    },
-    "ui": {
-      "changeLanguage": "Switch Language",
-      "displayMode": {
-        "auto": "Auto (Follow Browser or System)",
-        "dark": "Dark Mode",
-        "index": "UI display mode",
-        "light": "Light Mode"
-      },
-      "socialSiteSearchBy": {
-        "id": "Search by ID",
-        "title": "Search by Main Title",
-        "imdb": "Search by IMDb Number",
-        "chosen": "Let me choose"
-      },
-      "tableMultiSortNote": "Multi-column sorting: Click any table header field to start sorting, which will display the number \\\"1\\\" on the field. Click other fields sequentially to display \\\"2\\\", \\\"3\\\", indicating sorting priority. Click the same field again to toggle between ascending, descending, or cancel sorting. The sorting order is determined by these numbers, with smaller numbers having higher priority.",
-      "showReleaseNote": "Show changelog window when plugin updates",
-      "saveTableBehavior": "Remember table header columns, sorting, pagination, etc.",
-      "enableTableMultiSort": "Enable multi-column sorting for some tables",
-      "contentScript": "Content Script (Site Sidebar, etc.)",
-      "contentScriptWarning": "After enabling or disabling related features, save settings and refresh the site page for changes to take effect.",
-      "basicSettings": "Basic Settings",
-      "allowExceptionSites": "Allow setting exception sites without sidebar (enable in site settings)",
-      "enableOnSocialSite": "Enable sidebar on social sites (e.g. Douban, IMDb)",
-      "sidebarStyle": "Sidebar Style",
-      "expandByDefault": "Expand sidebar button by default",
-      "useLargeIcon": "Use large icon buttons",
-      "enableFadeEffect": "Enable fade-in effect (semi-transparent by default, shows on hover)",
-      "sidebarFunctions": "Sidebar Functions",
-      "confirmTwoStep": "Require two-step confirmation for batch copy, local download, etc. on torrent list pages",
-      "allowDragLink": "Allow dragging links to the sidebar button",
-      "dragNote": "Dragged download links may not always be correctly recognized!",
-      "socialSiteSearchLabel": "Social site search method",
-      "contextMenu": "Context Menu",
-      "contextMenuTextSearch": "Enable selected text search",
-      "contextMenuSocialSearch": "Enable social link (douban, imdb) search",
-      "contextMenuLinkPush": "Enable (download) link push",
-      "respondDisplayMode": "Respond to plugin setting "
-    },
-    "searchEntity": {
-      "siteSearchConfig": "Site Search Configuration",
-      "siteQueueConcurrency": "Request Queue Concurrency",
-      "saveLastSearchFilter": "Save last used search filter",
-      "forceImdbIdMatchFilter": "When searching by IMDb, filter out results whose IMDb ID returned by the site does not match",
-      "autoDetectOfficialGroupFromTitle": "Auto Detect Official Tag From Torrent Title",
-      "quickSiteFilter": "Quick Site Filter In Search Page",
-      "showHotRecommendations": "Show hot recommendations button in the search box",
-      "mediaServerSearchConfig": "Media Server Search Configuration",
-      "mediaQueueConcurrency": "Request Queue Concurrency",
-      "mediaSearchLimit": "Number of search results per request",
-      "mediaSearchLimitMessage": "Please do not load too many search results at once. It's not optimized with virtual-scroll, which may cause the browser to freeze and affect the performance of the media server.",
-      "autoLoadInitialMediaWall": "Automatically load the initial media wall",
-      "autoLoadMoreMediaOnScroll": "Automatically load more media when scrolling to the bottom of the page",
-      "allowSingleSiteSearch": "Allow single-site search",
-      "treatTTQueryAsImdbSearch": "Treat tt\\d\\{7,8\\} search terms directly as IMDb search",
-      "imdbTip": "When disabled, you need to use the `imdb|tt12345678` format for IMDb searches.",
-      "filterLabel": "Result Filter",
-      "searchPlanLabel": "Search Plan"
-    },
-    "download": {
-      "localDownloadMethod": "Local Download Method",
-      "localDownloadMethodOptions": {
-        "web": "Web Page",
-        "webTip": "Open the page corresponding to the download link (only applicable to the simplest method; if conditions are not met, it will fall back to @:SetBase.download.localDownloadMethodOptions.extension )",
-        "browser": "Browser Method",
-        "browserTip": "(RECOMMEND) Use the browser's download method provided by the extension to download directly",
-        "extension": "Extension Proxy",
-        "extensionTip": "The extension downloads the torrent in the background and proxies it to @:SetBase.download.localDownloadMethodOptions.browser for downloading"
-      },
-      "saveDownloadHistory": "Save download history (Please do not disable this function unless necessary)",
-      "MyClientTitle": "My Downloader",
-      "initDownloaderTorrentOnEnter": "Automatically load torrents from the downloader when entering the My Downloader page",
-      "localDownloadTitle": "Local Download",
-      "localDownloadIgnoreInterval": "Ignore site download interval limit for local downloads",
-      "pushDownloadServerTitle": "Push to Download Server",
-      "saveLastDownloader": "Save the last used download server settings",
-      "allowDirectSendToClient": "Allow sending links directly (instead of torrent files) to the download server (Do not enable unless necessary)",
-      "useQuickSendToClient": "Use quick push by default",
-      "quickSendToClientNote": "When quick push is enabled, the plugin will perform the following default actions when pushing download tasks:<br />1. Flatten the downloader and download directory options for direct click-to-push.<br />2. When hovering over an option, the label list will temporarily open; clicking will additionally add label information.<br />3. All use local relay mode to push torrents, and basic settings like 'auto-start download' and downloader-specific configs are determined by downloader and site settings."
-    },
-    "userInfo": {
-      "userDataRefresh": "User Data Refresh",
-      "afterTime": "Earliest daily refresh time",
-      "userInfoDisplay": "User Info Display"
-    }
+  "connectCheck": {
+    "default": "Check Connect",
+    "error": "Connect Failed! Check Form Input or Remote Server",
+    "success": "Connect Successful! You can enter next step."
   },
-  "SetNativeBridge": {
-    "permission": {
-      "title": "Permission",
-      "granted": "Permission Granted",
-      "notGranted": "Permission Not Granted",
-      "grant": "Grant Permission",
-      "revoke": "Revoke Permission",
-      "grantFailed": "Permission request was denied"
+  "contentScript": {
+    "AdvanceListModuleDialog": {
+      "selectNotSeeding": "Select not downloaded",
+      "selectSeeders": "Select seeding rows",
+      "selectedInfo": "Selected: {0} torrents, Total size: {1}",
+      "title": "Customize batch actions for {0} torrents"
     },
-    "bridge": {
-      "title": "Bridge Control",
-      "enabled": "Enable Native Bridge",
-      "testConnection": "Test Connection",
-      "status": {
-        "no-permission": "No Permission",
-        "disabled": "Disabled",
-        "connecting": "Connecting...",
-        "connected": "Connected",
-        "retrying": "Retrying...",
-        "error": "Error"
-      }
+    "SocialSiteParseResultsDialog": {
+      "searchExternalId": "Search External ID",
+      "searchId": "Search ID",
+      "searchTitle": "Search Title",
+      "title": "Quick Search"
     },
-    "info": {
-      "title": "About Native Bridge",
-      "description": "The native bridge allows the PT-Depiler CLI tool to communicate with this extension. It requires the CLI tool to be installed separately on your computer.",
-      "cliRequired": "The external CLI tool must be installed for this feature to work. Native bridge is not available on mobile platforms. See {0} for installation instructions.",
-      "cliLink": "ptd-cli",
-      "setupCommand": "Run the following command to register this extension with the CLI tool:",
-      "setupHint": "After running the command, restart the browser or click Test Connection.",
-      "privacy": "When enabled, the native bridge allows the locally installed CLI tool to access extension data including site configuration, search results, download history, user info, and downloader status. All communication is local (between browser and local process) — no data is sent to remote servers. You can disable this feature or revoke the permission at any time."
-    }
+    "advanceList": "Advanced List",
+    "cannotParseDetailLink": "Cannot parse torrent link on this page",
+    "copyLink": "Copy Link",
+    "copyLinkFailed": "Failed to copy download link",
+    "copyLinkSuccess": "Download link copied to clipboard",
+    "noTorrentParsed": "No torrents found on this page",
+    "openPTD": "Open PTD",
+    "parsePageFailed": "Page parsing failed",
+    "parseResultEmpty": "Failed to parse results",
+    "pushTo": "Push to...",
+    "pushToDefault": "Push to Default Downloader",
+    "quickSearch": "Quick Search"
   },
-  "SetDownloader": {
-    "add": {
-      "NoneSelectNotice": "Please select a server type",
-      "selectPlaceholder": "@:SetDownloader.add.NoneSelectNotice ( Support Search )",
-      "newType": "Come here to add the server type you want!",
-      "step": {
-        "selectType": "Select server type",
-        "setOptions": "Configuration"
-      },
-      "title": "Add Download Client"
-    },
-    "common": {
-      "address": "Server Address",
-      "name": "Server Name",
-      "uid": "Server Id",
-      "status": "Status"
-    },
-    "delete": {
-      "text": "Are you sure to delete these {0} Download Servers?"
-    },
-    "edit": {
-      "title": "Edit Download Server"
-    },
-    "editor": {
-      "addressTip": "Full Server Address (may include port or path), Like: http://192.168.1.1:5000/",
-      "autoStart": "Automatically start downloading when sending a torrent",
-      "nameTip": "Pick a nice and recognizable name for this Download Server",
-      "password": "Password",
-      "timeout": "Timeout (seconds)",
-      "uidPlaceholder": " (Generate automatically)"
-    },
-    "index": {
-      "editDefaultDownloaderBtn": "Edit Default Downloader",
-      "changeDefaultDownloader": "Default downloader updated successfully. If necessary, please further configure the download path and tags.",
-      "emptyNotice": "Before using the download service, you need to add at least one download server.",
-      "remove": {
-        "multi": "Are you sure to delete these {count} download servers?",
-        "single": "Are you sure to delete this download server?"
-      },
-      "table": {
-        "enabled": "Enabled ?",
-        "autodl": "Auto DL ?",
-        "action": {
-          "status": "Status",
-          "setPathAndTag": "Set Suggest Download Path and Tags",
-          "deleteDownloader": "Delete this downloader server",
-          "setDefault": "Set this downloader server as Default Downloader."
+  "downloaderLabel": {
+    "localDownload": "Local Download"
+  },
+  "layout": {
+    "header": {
+      "emptySearchNotice": "Get the first page of each tracker",
+      "expand": "Expand More",
+      "home": "Home",
+      "hotRecommendations": {
+        "category": {
+          "anime": "Anime",
+          "movie": "Movies",
+          "tv": "TV",
+          "variety": "Variety"
         },
-        "downloaderCategory": "Downloader Category"
-      }
+        "empty": "No hot recommendations",
+        "loadFailed": "Failed to load hot recommendations. Please try again later.",
+        "loading": "Loading hot recommendations...",
+        "noRating": "No rating",
+        "noSummary": "No summary",
+        "refresh": "Refresh hot recommendations",
+        "title": "Hot Recommendations"
+      },
+      "navBarTip": "Click to show/hide the navigation bar",
+      "searchPlan": {
+        "all": "@:manifest.searchPlanAll",
+        "default": "@:manifest.searchPlanDefault",
+        "singleSite": "@:manifest.searchPlanSingleSite"
+      },
+      "searchTip": "Input keyword, IMDb numbers to search",
+      "wiki": "Wiki",
+      "wrongPixelRatioNotice": "Your page display may be affected by zooming. It is recommended to zoom at 100% to ensure your browsing experience~"
     },
-    "PathAndTag": {
-      "title": "@:SetDownloader.index.table.action.setPathAndTag for downloader [{0}]",
-      "supportDragNote": "(Support drag to sort)",
-      "downloadPath": {
-        "title": "Download Paths",
-        "addTitle": "Added @:SetDownloader.PathAndTag.downloadPath.title @:SetDownloader.PathAndTag.supportDragNote",
-        "addInputLabel": "Added @:SetDownloader.PathAndTag.downloadPath.title",
-        "autoImport": "One-click to import of existing @:SetDownloader.PathAndTag.downloadPath.title from the downloader",
-        "autoImportFail": "@:SetDownloader.PathAndTag.downloadPath.autoImport failed, please add manually.",
-        "clear": "Clear @:SetDownloader.PathAndTag.downloadPath.title"
-      },
-      "tags": {
-        "title": "Tags",
-        "addTitle": "Added @:SetDownloader.PathAndTag.tags.title @:SetDownloader.PathAndTag.supportDragNote",
-        "addInputLabel": "Added @:SetDownloader.PathAndTag.tags.title",
-        "autoImport": "One-click to import of existing @:SetDownloader.PathAndTag.tags.title from the downloader",
-        "autoImportFail": "@:SetDownloader.PathAndTag.tags.autoImport failed, please add manually.",
-        "clear": "Clear @:SetDownloader.PathAndTag.tags.title"
-      },
-      "note": {
-        "title": "Note",
-        "index": "The @:SetDownloader.PathAndTag.downloadPath.title or @:SetDownloader.PathAndTag.tags.title can include the following keywords:",
-        "table": {
-          "keywords": "Keywords",
-          "note": "Note",
-          "example": "Example"
-        },
-        "replaceNote": {
-          "torrentTitle": "The title of torrent",
-          "torrentSubTitle": "The subtitle of torrent",
-          "torrentSite": "The Site ID of torrent",
-          "torrentSiteName": "The Site name of torrent",
-          "searchKeyword": "Search Keywords",
-          "searchPlan": "Search Plan Name",
-          "dateYear": "current year",
-          "dateMonth": "current month",
-          "dateDay": "current day",
-          "custom": "Custom text"
-        }
-      }
+    "init": "Please wait patiently for the page to load.....",
+    "releaseNote": {
+      "changelog": "Changelog",
+      "currentVersion": " (current version)",
+      "faq": "FAQ",
+      "startUsing": "Get Started",
+      "title": "Welcome to {extName}",
+      "wiki": "Wiki Help"
     }
   },
-  "SetSearchSolution": {
-    "solution": "Search Solution",
-    "copy": "Duplicate",
-    "table": {
-      "enable": "Enabled ?",
-      "default": "Default ?",
-      "autoGenerate": "Auto Generate"
-    },
-    "edit": {
-      "title": "Customize @:SetSearchSolution.solution",
-      "addCount": "Added {0} @:SetSearchSolution.solution",
-      "cantAddByDuplicateNote": "A duplicate @:SetSearchSolution.solution already exists and cannot be added again.",
-      "filterPlaceholder": "Filter by site name or url"
-    },
-    "delete": {
-      "text": "Are you sure to delete these {0} @:SetSearchSolution.solution ?"
-    },
-    "spDialog": {
-      "noDefNotice": "This site does not define any search categories, please go to help!",
-      "notice": "It is not recommended to set it here, and it is recommended to configure your user CP in site or use search solution",
-      "selectAllNotice": "(Notice: In most cases, you don't need to select all search terms! )",
-      "title": "Set default search params for Site {name}",
-      "action": {
-        "reset": "Reset this @:SetSearchSolution.solution",
-        "create": "Create a custom @:SetSearchSolution.solution based on this",
-        "add": "Add this @:SetSearchSolution.solution"
-      }
-    },
-    "CustomSolutionDialog": {
-      "title": "Custom Search Plan",
-      "solutionName": "Plan Name",
-      "requestConfig": "Request Config",
-      "requestConfigHint": "Please configure request parameters in JSON format",
-      "requestConfigJsonError": "Must be valid JSON format"
-    },
-    "newSolutionNamePrompt": "Please enter the new search plan name"
+  "levelRequirement": {
+    "adoptions": "Adopted Torrents",
+    "averageSeedingTime": "Average Seeding Time",
+    "bonus": "Bonus",
+    "bonusPerHour": "Bonus Gained Per Hour",
+    "downloaded": "Downloaded",
+    "hnrPreWarning": "PreWarning H&R Count",
+    "hnrUnsatisfied": "Unsatisfied H&R Count",
+    "interval": "Required Waiting Days",
+    "leeching": "Leeching Torrents",
+    "posts": "Posted Threads",
+    "ratio": "Ratio",
+    "seeding": "Seeding Count",
+    "seedingBonus": "Seed Points",
+    "seedingSize": "Seeding Size",
+    "seedingTime": "Seeding Time",
+    "snatches": "Completed Torrents",
+    "totalTraffic": "Total Traffic",
+    "trueDownloaded": "True Downloaded",
+    "trueRatio": "True Ratio",
+    "trueUploaded": "True Uploaded",
+    "uploaded": "Uploaded",
+    "uploads": "Uploaded Torrents"
   },
-  "SetSite": {
-    "add": {
-      "selectSitePlaceholder": "Please Select a site to add (support search in url and site name)",
-      "title": "Add Site"
-    },
-    "common": {
-      "aka": "AKA",
-      "allowQueryUserInfo": "Allow access USP",
-      "allowSearch": "Allow Search",
-      "isOffline": "Offline",
-      "name": "Site Name",
-      "showMessageCount": "Show Notice",
-      "tags": "Tags",
-      "url": "URL",
-      "groups": "Site Groups",
-      "allowContentScript": "Load Content Script",
-      "open": "Open"
-    },
-    "delete": {
-      "text": "Are you sure to delete these {0} Site?"
-    },
-    "edit": {
-      "title": "Edit Site Config"
-    },
-    "editor": {
-      "addUrlTip": "Add a site url which you current used, for example: https://example.com/",
-      "customUrlPlaceholder": "Custom site url",
-      "description": "Site description",
-      "sortIndexTip": "Can be used for search sorting",
-      "tagTip": "Press Enter to add a tag after typing. (Only the first 4 will be displayed on the list page)",
-      "timezone": "Timezone",
-      "uploadSpeedLimit": "Upload Speed",
-      "uploadSpeedLimitHint": "Set upload speed limit (MiB/s) when pushing torrents to downloader, 0 or empty means unlimited"
-    },
-    "index": {
-      "flushFaviconFinish": "The selected site favicon has been refreshed successfully!",
-      "table": {
-        "searchEntries": "Search Entries",
-        "flushFavicon": "Refresh Site Favicon"
-      },
-      "settingNote": [
-        "Only the configured site will display the plugin icon and the corresponding function;",
-        "the offline site will no longer participate in the search and information acquisition;"
-      ],
-      "oneClickImport": "One-Click Import Sites",
-      "reBuildMap": "Rebuild Site Cache"
-    },
-    "oneClickImportDialog": {
-      "title": "One-Click Import Sites",
-      "alert1": "This operation will attempt to import the sites you select with default configurations. Please ensure you have logged into these sites in your browser. The import process cannot be interrupted, please wait patiently.",
-      "alert2": "List of unadded sites",
-      "stats": "Selected {count} sites, added {success} sites, failed to add {failed} sites.",
-      "trying": "Trying to import site [{name}] ...",
-      "status": {
-        "manual": "This site needs to be added manually",
-        "trying": "Trying",
-        "success": "Added successfully",
-        "failed": "Failed to add",
-        "selected": "Selected"
-      },
-      "importComplete": "One-click import complete, successfully added {count} sites"
-    },
-    "ReBuildMapDialog": {
-      "title": "Rebuild Site Mapping Cache",
-      "rebuildSiteHostMap": "Rebuild site host mapping cache",
-      "rebuildSiteNameMap": "Rebuild site name mapping cache",
-      "doRebuildBtn": "Rebuild"
-    },
-    "SiteCategoryPanel": {
-      "siteDefault": "Site Default"
-    },
-    "AddDialog": {
-      "showDeadSite": "Show dead sites"
-    },
-    "Editor": {
-      "siteSettings": "Site Settings",
-      "otherSettings": "Other Settings",
-      "downloadLinkSuffix": "Download Link Suffix",
-      "downloadLinkSuffixHint": "This field will be automatically appended to the site's download links",
-      "downloadLinkSuffixExample": "E.g. if the plugin gets https://example.com/download.php?id=1 and you set &passkey=xxxx, the final download link will be https://example.com/download.php?id=1&passkey=xxxx. Leave this empty by default, and only fill in the passkey if the correct download link cannot be obtained.",
-      "requestTimeout": "Request Timeout",
-      "requestTimeoutHint": "Affects the timeout for site requests (torrent search, user info retrieval)",
-      "downloadInterval": "Download Interval",
-      "downloadIntervalHint": "Affects the download interval for this site (for safety, the plugin will not strictly follow this setting; the actual interval is always slightly greater than or equal to the set interval)"
-    }
-  },
-  "SetBackup": {
-    "table": {
-      "backupFields": "Backup Content",
-      "lastBackupAt": "Last Backup Time",
-      "notBackup": "Not Backed Up",
-      "action": {
-        "backupNow": "Backup Now",
-        "viewHistoryBackup": "View History Backups"
-      }
-    },
-    "localExport": "Local Export",
-    "localImport": "Local Import",
-    "snackbar": {
-      "success": "Backup successful",
-      "failure": "Backup failed"
-    },
-    "AddDialog": {
-      "title": "Add Backup Server"
-    },
-    "Editor": {
-      "serverConfig": "Server Configuration",
-      "backupConfig": "Backup Configuration"
-    },
-    "HistoryDialog": {
-      "title": "Backup History for {name}",
-      "restore": "Restore Backup",
-      "deleteSuccess": "Deleted backup history [{name}] successfully",
-      "deleteFailure": "Failed to delete backup history [{name}]",
-      "table": {
-        "filename": "Backup Filename",
-        "size": "Backup Size",
-        "time": "Backup Time"
-      }
-    },
-    "LocalExportConfirmDialog": {
-      "title": "Select content to export locally"
-    },
-    "RestoreDialog": {
-      "title": "Restore from Backup File",
-      "ptppPrompt": "Need to import PT-Plugin-Plus backup?",
-      "ptppImport": "PT-Plugin-Plus Backup Import",
-      "selectFile": "Select Backup File",
-      "decryptKey": "Decryption Key",
-      "retry": "Retry",
-      "restoreOptions": "Restore Options",
-      "expandCookieMinutes": "Try to extend Cookies expiry (minutes)",
-      "keepExistUserInfo": "Keep locally fetched user information",
-      "missingVersion": "Backup data is missing version info, cannot restore",
-      "versionWarning": "Backup data version is higher than the current extension version. Restoring may cause data incompatibility or loss. Continue?",
-      "success": "Restored successfully",
-      "failure": "Restore failed: {error}",
-      "loadFailure": "Load failed: {error}"
-    }
-  },
-  "userInfo": {
-    "queueConcurrency": "Request Queue Concurrency",
-    "enableAutoRefresh": "Enable background auto-refresh?",
-    "autoRefresh": {
-      "every": "Every",
-      "hoursLabel": "hours auto-refresh today's",
-      "unrefreshedSite": "unrefreshed",
-      "ofSites": "sites.",
-      "retryOnFail": "If refresh fails, retry",
-      "times": "times, with an interval of",
-      "minutes": "minutes.",
-      "lastFlushTime": "Last refresh time:",
-      "nextFlushTime": "Next refresh check time:",
-      "getNextFlushTime": "Get Next Refresh Check Time"
-    },
-    "alwaysPickLastUserInfo": "",
-    "showDeadSite": "Show sites marked as dead (isDead) in the overview",
-    "showPassedSite": "Show sites marked as offline (isOffline) or not allowing user info query in the overview",
-    "autoExtendCookies": {
-      "enabled": "Enable auto-extend cookies period?",
-      "triggerThreshold": "Trigger threshold for extension",
-      "extensionDuration": "Extension duration",
-      "weeks": "weeks,",
-      "months": "months."
-    }
+  "manifest": {
+    "contextMenuSearch": "Using PT Depiler to Search for \"%s\" related torrents",
+    "contextMenuSearchInDefault": "Search in the default plan",
+    "contextMenuSearchInSite": "Search in the specified site",
+    "contextMenuSearchInSolution": "Search in the specified plan",
+    "contextMenuSearchInThisSite": "Search in this site",
+    "contextMenuSearchWithDouban": "Using PT Depiler to Search This Douban ID",
+    "contextMenuSearchWithIMDb": "Using PT Depiler to Search This IMDb ID",
+    "contextMenuSendToDownloader": "Using PT Depiler to Download link",
+    "contextMenuSendToDownloaderAdvanced": "Advanced push",
+    "contextMenuSendToDownloaderDefaultFolder": "Default path",
+    "contextMenuSendToDownloaderIn": "Push to $1 -> $2",
+    "extDesc": "PT Depiler",
+    "extName": "PT Depiler",
+    "notificationSendLinkToDownloaderFailure": "Failed to send the link to the downloader [$1]",
+    "notificationSendLinkToDownloaderSuccess": "Successfully sent the link to the downloader [$1]",
+    "omniboxSearch": "Search $2 in [ $1 ]",
+    "searchPlanAll": "All Sites",
+    "searchPlanDefault": "Default",
+    "searchPlanSingleSite": "Single Site"
   },
   "ptppSettings": {
+    "RestorePtppUserDataDialog": {
+      "importCancelled": "Import operation cancelled.",
+      "importFailure": "Import failed.",
+      "importSuccess": "Import successful. The window will close automatically in 5s. Please refresh the page.",
+      "noSiteWarning": "You don't seem to have added any sites, which may cause import issues. Continue?",
+      "notSupported": "This site is not supported",
+      "overwriteExisting": "Overwrite existing data",
+      "pendingImportData": "Data to Import",
+      "recordCount": "{0} records",
+      "selected": "Selected",
+      "title": "Restore PT-Plugin-Plus User History Data"
+    },
     "basicConfig": "Basic Configuration",
-    "saveKeyNotice": "Note: The key is only saved in the current browser and will not be backed up, please keep it safe; data cannot be recovered if the key is lost after encryption. Leave blank for no encryption.",
     "encryptionKeyLabel": "Backup file encryption/decryption key",
-    "undoKeyTitle": "Restore previous key",
-    "randomGenTitle": "Generate Randomly",
-    "invalidFileFormat": "Invalid file format, please check if the backup was exported correctly (with the backup encryption feature turned off).",
-    "importConfigTitle": "PT-Plugin-Plus Configuration Import",
     "importConfigInfoLine1": "{repoName} can only import user history data from the original PT-Plugin-Plus. Other configuration files are not supported.",
     "importConfigInfoPrep": "Before importing, please make the following preparations:",
+    "importConfigTitle": "PT-Plugin-Plus Configuration Import",
     "importStep1": "First, please back up the current configuration file of {repoName}.",
     "importStep2": "In the site settings of {repoName}, add the sites that need to be restored. (If a site is not added, its corresponding user history data will be ignored).",
     "importStep3": "In PT-Plugin-Plus, disable the backup encryption feature and export the local backup file. It should be a zip file named <code>PT-Plugin-Plus-Backup-yyyy-MM-DD_hh-mm-ss.zip</code>.",
     "importStep4": "Upload the zip package or the extracted <code>userdatas.json</code> file to the input box below.",
+    "invalidFileFormat": "Invalid file format, please check if the backup was exported correctly (with the backup encryption feature turned off).",
+    "randomGenTitle": "Generate Randomly",
+    "saveKeyNotice": "Note: The key is only saved in the current browser and will not be backed up, please keep it safe; data cannot be recovered if the key is lost after encryption. Leave blank for no encryption.",
     "selectBackupFile": "Select PTPP Backup File",
-    "RestorePtppUserDataDialog": {
-      "title": "Restore PT-Plugin-Plus User History Data",
-      "pendingImportData": "Data to Import",
-      "notSupported": "This site is not supported",
-      "selected": "Selected",
-      "noSiteWarning": "You don't seem to have added any sites, which may cause import issues. Continue?",
-      "importCancelled": "Import operation cancelled.",
-      "importSuccess": "Import successful. The window will close automatically in 5s. Please refresh the page.",
-      "importFailure": "Import failed.",
-      "overwriteExisting": "Overwrite existing data",
-      "recordCount": "{0} records"
+    "undoKeyTitle": "Restore previous key"
+  },
+  "resultParseStatus": {
+    "CFBlocked": "Cloudflare Error!",
+    "CFBlockedNotes": "It may be because the site has enabled CloudFlare's security protection, which makes it impossible to retrieve data. You can first try to manually access the site once to pass the verification. If that doesn't work, just wait for the site to recover on its own.",
+    "needLogin": "Login Required!",
+    "noResults": "No Results!",
+    "parseError": "Parse Error!",
+    "passParse": "Passed!",
+    "success": "Fetch Successful!",
+    "unknown": "Unknown Status!",
+    "unknownError": "Unknown Error!",
+    "waiting": "Waiting in Queue...",
+    "working": "Fetching..."
+  },
+  "route": {
+    "About": {
+      "Logger": "Runtime Log",
+      "SpecialThank": "Special Thanks",
+      "TechnologyStack": "Project Reference",
+      "default": "About"
+    },
+    "Devtools": {
+      "Debugger": "Debugger",
+      "SystemLog": "System Log",
+      "default": "Devtools"
+    },
+    "Overview": {
+      "DownloadHistory": "Download History",
+      "KeepUploadTask": "Reseed Task",
+      "MediaServerEntity": "Media Library",
+      "MyClient": "My BtClient",
+      "MyCollection": "Collection",
+      "MyData": "My Data",
+      "SearchEntity": "Search Results",
+      "SearchResultSnapshot": "Search Snapshot",
+      "default": "Overview"
+    },
+    "Settings": {
+      "SetBackup": "Backup & Restore",
+      "SetBase": "General",
+      "SetDownloader": "Download Server",
+      "SetMediaServer": "Media Server",
+      "SetSearchSolution": "Search Solution",
+      "SetSite": "Sites",
+      "default": "Settings"
     }
   },
   "socialConfig": {
-    "basicConfig": "Basic Configuration",
-    "cacheValidityDays": "Cache Validity (days)",
-    "cacheShortWarning": "A cache time that is too short will lead to frequent requests, while one that is too long will result in outdated data.",
-    "requestTimeoutMs": "Request Timeout (milliseconds)",
-    "ptgenConfig": "PtGen Configuration",
-    "preferPtgenLabel": "Prefer data provided by PtGen",
-    "ptgenApiAddress": "PtGen API Address",
-    "ptgenApiMessages": "Select a built-in address or enter an address like https://example.com/ptgen?site=<site>&sid=<sid>",
-    "mediaRatingConfig": "Media Rating Site Configuration",
     "anidbClientId": "AniDB Client ID",
     "anidbClientMessages": "Please apply for a Client ID at https://anidb.net/perl-bin/animedb.pl?show=client and fill it in the format `Name/Version`.",
     "bangumiApiKey": "Bangumi API Key",
-    "bangumiApiMessages": "You can generate an Access Token at https://next.bgm.tv/demo/access-token"
+    "bangumiApiMessages": "You can generate an Access Token at https://next.bgm.tv/demo/access-token",
+    "basicConfig": "Basic Configuration",
+    "cacheShortWarning": "A cache time that is too short will lead to frequent requests, while one that is too long will result in outdated data.",
+    "cacheValidityDays": "Cache Validity (days)",
+    "mediaRatingConfig": "Media Rating Site Configuration",
+    "preferPtgenLabel": "Prefer data provided by PtGen",
+    "ptgenApiAddress": "PtGen API Address",
+    "ptgenApiMessages": "Select a built-in address or enter an address like https://example.com/ptgen?site=<site>&sid=<sid>",
+    "ptgenConfig": "PtGen Configuration",
+    "requestTimeoutMs": "Request Timeout (milliseconds)"
   },
-  "contentScript": {
-    "openPTD": "Open PTD",
-    "noTorrentParsed": "No torrents found on this page",
-    "cannotParseDetailLink": "Cannot parse torrent link on this page",
-    "parseResultEmpty": "Failed to parse results",
-    "parsePageFailed": "Page parsing failed",
-    "copyLinkSuccess": "Download link copied to clipboard",
-    "copyLinkFailed": "Failed to copy download link",
-    "copyLink": "Copy Link",
-    "pushTo": "Push to...",
-    "pushToDefault": "Push to Default Downloader",
-    "quickSearch": "Quick Search",
-    "advanceList": "Advanced List",
-    "AdvanceListModuleDialog": {
-      "title": "Customize batch actions for {0} torrents",
-      "selectSeeders": "Select seeding rows",
-      "selectNotSeeding": "Select not downloaded",
-      "selectedInfo": "Selected: {0} torrents, Total size: {1}"
-    },
-    "SocialSiteParseResultsDialog": {
-      "title": "Quick Search",
-      "searchId": "Search ID",
-      "searchExternalId": "Search External ID",
-      "searchTitle": "Search Title"
-    }
-  },
-  "SentToDownloaderDialog": {
-    "title": "Select downloader for {0} torrents",
-    "isSending": "Sending torrents to downloader {name} [{address}], please wait...",
-    "selectDownloaderFirst": "Please select a downloader first",
-    "noDownloader": "No downloaders available. Please add a downloader in settings.",
-    "selectDownloader": "Select Downloader",
-    "savePath": "Save Path",
-    "savePathHint": "Leave empty to use the downloader's default path",
-    "label": "Torrent Label",
-    "labelHint": "(If supported by the downloader)",
-    "localRelay": "Local Relay",
-    "pauseOnAdd": "Pause on add by default",
-    "moreOptions": "More Options"
-  },
-  "ContextMenuLinkPush": {
-    "invalidLink": "Invalid download link",
-    "keywordWarning": "When pushing links via right-click, some keyword features for download paths or labels may not work correctly!"
-  },
-  "SetMediaServer": {
-    "add": {
-      "title": "Add Media Server"
-    },
-    "Editor": {
-      "authInfo": "Authentication Info"
-    }
-  },
-  "Debugger": {
-    "title": "Debug Page!!!!",
-    "consoleOutput": "All output is in the console panel!!!",
-    "enableLibrary": "Enable Dev Library",
-    "libraryList": "Enable sendMessage, axios, Sizzle, es-toolkit (as _), datefns in console",
-    "debugBuiltinSite": "Debug Built-in Site",
-    "mergeUserConfig": "Merge User Config",
-    "outputSiteDefinition": "Output Site Definition",
-    "outputUserConfig": "Output User Config",
-    "outputSiteInstance": "Output Site Instance",
-    "outputFavicon": "Output Favicon",
-    "debug": "Debug {serverType}",
-    "addServerFirst": "Please add a server on the Set{serverType} page first",
-    "outputConfig": "Output User Config",
-    "outputInstance": "Output {serverType} Instance",
-    "debugPinia": "Debug Pinia",
-    "outputPinia": "Output Pinia Info",
-    "pluginReset": "Plugin Reset",
-    "dangerWarning": "EXTREMELY DANGEROUS!!!!",
-    "confirmReset": "Are you sure you want to reset?",
-    "resetSuccess": "Reset successful",
-    "selectSite": "Select Site",
-    "siteAll": "All",
-    "resetItems": {
-      "resetSystemSettings": "Reset System Settings",
-      "resetSystemSettingsDesc": "Reset all system settings (including language, theme, table display, image style, etc.) to defaults",
-      "clearUserConfig": "Clear User Config",
-      "clearUserConfigDesc": "Clear all user configs (including sites, downloaders, search plans, snapshot metadata, latest user info)",
-      "clearSiteData": "Clear Site Data",
-      "clearSiteDataDesc": "Clear user-fetched site data (including user info history and latest user info)",
-      "clearDownloadHistory": "Clear Download History",
-      "clearFaviconCache": "Clear Site Favicon Cache",
-      "clearMediaCache": "Clear media summary cache from Douban, IMDb, etc.",
-      "clearSearchSnapshot": "Clear Search Snapshots",
-      "clearSearchSnapshotDesc": "Clear all search snapshot data"
-    }
-  },
-  "MyClient": {
-    "refresh": "Refresh",
-    "deleteSelected": "Delete",
-    "searchPlaceholder": "Search by name, hash, label, or path",
-    "table": {
-      "client": "Client",
-      "name": "Torrent Name",
-      "size": "Size",
-      "progress": "Progress",
-      "status": "Status",
-      "ratio": "Ratio",
-      "upSpeed": "Upload Speed",
-      "dlSpeed": "Download Speed",
-      "savePath": "Save Path",
-      "addedAt": "Added At",
-      "totalUploaded": "Total Upload",
-      "totalDownloaded": "Total Download"
-    },
-    "state": {
+  "torrent": {
+    "status": {
+      "completed": "Completed",
       "downloading": "Downloading",
+      "inactive": "Inactive",
       "seeding": "Seeding",
-      "paused": "Paused",
-      "queued": "Queued",
-      "checking": "Checking",
-      "error": "Error",
       "unknown": "Unknown"
-    },
-    "action": {
-      "pause": "Pause",
-      "resume": "Resume",
-      "delete": "Delete",
-      "pauseSuccess": "Paused successfully",
-      "pauseError": "Failed to pause",
-      "resumeSuccess": "Resumed successfully",
-      "resumeError": "Failed to resume",
-      "pauseSelectedSuccess": "Paused {count} torrent(s)",
-      "resumeSelectedSuccess": "Resumed {count} torrent(s)",
-      "viewRaw": "View Raw"
+    }
+  },
+  "userInfo": {
+    "alwaysPickLastUserInfo": "",
+    "autoExtendCookies": {
+      "enabled": "Enable auto-extend cookies period?",
+      "extensionDuration": "Extension duration",
+      "months": "months.",
+      "triggerThreshold": "Trigger threshold for extension",
+      "weeks": "weeks,"
     },
     "autoRefresh": {
-      "btnTitle": "Auto-Refresh",
-      "intervalLabel": "Refresh interval",
-      "intervalUnit": "seconds (0 = off)",
-      "start": "Start auto-refresh",
-      "stop": "Stop auto-refresh",
-      "clientSuspended": "{name} failed 3 times in a row. Auto-refresh suspended. Click the chip to resume.",
-      "suspendedTip": "This client has been suspended due to 3 consecutive failures. Click the alert icon to resume.",
-      "resumeDownloader": "Resume auto-refresh for this downloader",
-      "stopDownloader": "Stop auto-refresh for this downloader",
-      "downloaderFilter": "Downloader Filter"
+      "every": "Every",
+      "getNextFlushTime": "Get Next Refresh Check Time",
+      "hoursLabel": "hours auto-refresh today's",
+      "lastFlushTime": "Last refresh time:",
+      "minutes": "minutes.",
+      "nextFlushTime": "Next refresh check time:",
+      "ofSites": "sites.",
+      "retryOnFail": "If refresh fails, retry",
+      "times": "times, with an interval of",
+      "unrefreshedSite": "unrefreshed"
     },
-    "pauseSelected": "Pause",
-    "resumeSelected": "Resume",
-    "dialog": {
-      "removeData": "Also remove data"
-    },
-    "pushToDownloader": {
-      "navBtn": "Push to Downloader",
-      "title": "Push to Downloader",
-      "modeUrl": "Link / Magnet",
-      "modeFile": "Torrent File",
-      "urlInputLabel": "URLs / Magnet Links",
-      "urlInputHint": "One URL or magnet link per line",
-      "fileInputLabel": "Torrent Files",
-      "fileInputHint": "Select one or more .torrent files to push"
-    },
-    "columnSelector": "Columns",
-    "clientStatusDialog": {
-      "title": "Downloader Status",
-      "openBtn": "All Downloaders Status",
-      "torrentCount": "{count} torrent(s)",
-      "openClient": "Open Downloader"
-    }
+    "enableAutoRefresh": "Enable background auto-refresh?",
+    "queueConcurrency": "Request Queue Concurrency",
+    "showDeadSite": "Show sites marked as dead (isDead) in the overview",
+    "showPassedSite": "Show sites marked as offline (isOffline) or not allowing user info query in the overview"
   }
 }

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -1,226 +1,815 @@
 {
-  "common": {
-    "action": "操作",
-    "btn": {
-      "add": "增加"
+  "ContextMenuLinkPush": {
+    "invalidLink": "无效的下载链接",
+    "keywordWarning": "右键推送链接时，部分 下载路径或标签的 关键字功能可能无法正常工作！"
+  },
+  "Debugger": {
+    "addServerFirst": "请先在 Set{serverType} 页面添加服务器",
+    "confirmReset": "确定要重置吗？",
+    "consoleOutput": "所有输出均在console面板！！！",
+    "dangerWarning": "极其危险！！！！",
+    "debug": "调试{serverType}",
+    "debugBuiltinSite": "调试内置站点",
+    "debugPinia": "调试Pinia",
+    "enableLibrary": "启用开发库",
+    "libraryList": "在console中启用 sendMessage, axios, Sizzle, es-toolkit ( as _ ）, datefns 等方法",
+    "mergeUserConfig": "合并用户配置",
+    "outputConfig": "输出用户配置信息",
+    "outputFavicon": "输出Favicon",
+    "outputInstance": "输出 {serverType} 实例",
+    "outputPinia": "输出Pinia信息",
+    "outputSiteDefinition": "输出站点定义",
+    "outputSiteInstance": "输出站点实例",
+    "outputUserConfig": "输出用户配置信息",
+    "pluginReset": "插件重置",
+    "resetItems": {
+      "clearDownloadHistory": "清空历史下载记录",
+      "clearFaviconCache": "清空站点 Favicon 缓存",
+      "clearMediaCache": "清空来自豆瓣、IMDb等信息站点的媒体简介缓存",
+      "clearSearchSnapshot": "清空搜索快照",
+      "clearSearchSnapshotDesc": "清空所有搜索快照数据",
+      "clearSiteData": "清空站点数据",
+      "clearSiteDataDesc": "清空用户获取的站点数据（包括用户信息历史记录和最近一次用户信息）",
+      "clearUserConfig": "清空用户配置",
+      "clearUserConfigDesc": "清空所有用户配置（包括但不限于站点、下载器、搜索方案及默认值、搜索快照元数据、最近一次用户信息）",
+      "resetSystemSettings": "重置系统设置",
+      "resetSystemSettingsDesc": "重置所有系统设置（包括但不限于语言、主题、表格展示、图片样式等常规设置）为默认值"
     },
-    "checkbox": {
-      "all": "全选",
-      "none": "全不选",
-      "invert": "反选"
-    },
-    "default": "默认",
-    "date": "日期",
-    "time": {
-      "year": "年",
-      "month": "月",
-      "week": "周",
-      "day": "日",
-      "hour": "时",
-      "minute": "分",
-      "second": "秒",
-      "lessThanAWeek": "不足一周",
-      "ago": "前"
-    },
-    "dialog": {
-      "cancel": "取消",
-      "next": "下一步",
-      "ok": "完成",
-      "confirm": "确认",
-      "prev": "上一步",
-      "reset": "重置",
-      "title": {
-        "confirmAction": "确认操作"
-      },
-      "deleteText": "确认删除这 {0} 条记录吗？",
-      "close": "关闭"
-    },
-    "edit": "编辑",
-    "language": "语言",
-    "name": "名称",
-    "project": "PT 助手 Plus",
-    "remove": "删除",
-    "save": "保存",
-    "search": "搜索",
-    "sortIndex": "优先级",
-    "test": "测试",
-    "visit": "访问",
-    "version": "版本",
-    "howToUse": "如何使用？",
-    "import": "导入",
-    "export": "导出",
-    "saveSuccess": "保存成功",
-    "advancedSettings": "高级设置",
-    "back": "返回",
-    "exportImage": "导出图片",
-    "saveSettings": "保存设置",
-    "enable": "启用",
-    "basicInfo": "基本信息",
-    "count": "数量",
-    "site": "站点",
-    "type": "类型",
-    "username": "用户名",
+    "resetSuccess": "重置成功",
+    "selectSite": "选择站点",
+    "siteAll": "全部",
+    "title": "调试页面！！！！"
+  },
+  "DownloadHistory": {
     "AdvanceFilterGenerateDialog": {
-      "title": "生成高级过滤词",
-      "keywords": "关键词",
-      "required": "必要项",
-      "exclude": "排除项",
-      "site": "@:common.site",
-      "date": "日期",
-      "dateUnit": {
-        "day": "今日",
-        "week": "本周",
-        "month": "本月",
-        "quarter": "本季度",
-        "year": "今年",
-        "custom": "自定义"
-      },
-      "reset": "重置搜索词",
-      "generate": "生成"
+      "downloader": "下载器"
+    },
+    "ReDownloadSelectDialog": {
+      "oldMethod": "按原下载方式重试",
+      "selectDownloader": "选择下载服务器",
+      "title": "重新下载 {0} 条记录"
+    },
+    "filterPlaceholder": "过滤下载记录",
+    "reDownload": "重新下载",
+    "refresh": "刷新下载记录列表",
+    "searchTorrent": "全站搜索此种子",
+    "table": {
+      "downloadAt": "下载时间",
+      "downloader": "下载服务器",
+      "status": "下载状态",
+      "title": "种子"
     }
   },
-  "layout": {
-    "header": {
-      "emptySearchNotice": "获取各站第一页种子",
-      "home": "主页",
-      "navBarTip": "点击显示/隐藏导航栏",
-      "searchPlan": {
-        "all": "@:manifest.searchPlanAll",
-        "singleSite": "@:manifest.searchPlanSingleSite",
-        "default": "@:manifest.searchPlanDefault"
-      },
-      "searchTip": "输入种子关键字、IMDb编号进行搜索",
-      "wiki": "帮助",
-      "wrongPixelRatioNotice": "检测到您的页面展示可能受到缩放影响，建议您将当前页面缩放调整为100%，以保障您的浏览体验～",
-      "expand": "展开更多",
-      "hotRecommendations": {
-        "title": "热门推荐",
-        "refresh": "刷新热门推荐",
-        "loading": "正在加载热门推荐...",
-        "empty": "暂无热门推荐",
-        "loadFailed": "热门推荐加载失败，请稍后重试",
-        "noRating": "暂无评分",
-        "noSummary": "暂无简介",
-        "category": {
-          "movie": "电影",
-          "tv": "电视剧",
-          "variety": "综艺",
-          "anime": "动画"
-        }
-      }
+  "KeepUploadTask": {
+    "clearAll": "清空全部",
+    "clearConfirm": "确认清空所有辅种任务吗？",
+    "clearError": "清空失败",
+    "clearSuccess": "清空成功",
+    "copyError": "复制失败",
+    "copyLinks": "复制下载链接",
+    "copySuccess": "已复制 {count} 个下载链接",
+    "defaultPath": "默认路径",
+    "deleteConfirm": "确认删除该辅种任务吗？",
+    "deleteError": "删除失败",
+    "deleteSelectedConfirm": "确认删除选中的 {count} 个辅种任务吗？",
+    "deleteSuccess": "删除成功",
+    "editSavePath": "修改保存路径",
+    "emptyNotice": "暂无辅种任务，请在搜索结果页面选择种子后点击辅种检测按钮",
+    "leechers": "下载：",
+    "savePath": "保存路径：",
+    "seeders": "上传：",
+    "sendAllTorrents": "发送所有种子",
+    "sendBaseTorrent": "发送基准种子",
+    "sendConfirm": "确认发送 {count} 个种子到下载器？",
+    "sendError": "发送失败",
+    "sendOtherTorrents": "发送其他种子",
+    "sendSingleError": "发送失败",
+    "sendSingleSuccess": "发送成功",
+    "sendSuccess": "发送成功",
+    "setAsBaseTorrent": "设为基准种子",
+    "setBaseError": "设置失败",
+    "setBaseSuccess": "已设为基准种子",
+    "table": {
+      "count": "种子数",
+      "site": "站点",
+      "size": "大小",
+      "time": "创建时间",
+      "title": "标题"
     },
-    "init": "请耐心等待页面加载.....",
-    "releaseNote": {
-      "title": "欢迎使用 {extName}",
-      "currentVersion": "（当前版本）",
-      "changelog": "更新日志",
-      "wiki": "Wiki 帮助",
-      "faq": "常见问题",
-      "startUsing": "开始使用"
+    "title": "辅种任务",
+    "torrentCount": "种子数：",
+    "updateError": "更新失败",
+    "updateSuccess": "更新成功",
+    "warning": {
+      "item1": "辅种前请确认下载服务器已关闭类似于「自动开始下载」的选项（如果有）。",
+      "item2": "助手仅对种子文件做简单验证，不保证辅种成功，请自行斟酌是否要使用辅种功能！",
+      "item3": "如出现因辅种失败造成的爆仓，由用户自行负责！",
+      "title": "警告："
     }
-  },
-  "manifest": {
-    "extDesc": "PT Depiler",
-    "extName": "PT Depiler",
-    "searchPlanAll": "全部站点",
-    "searchPlanSingleSite": "单个站点",
-    "searchPlanDefault": "默认",
-    "omniboxSearch": "在 [ $1 ] 中搜索 $2",
-    "contextMenuSearch": "使用 PT Depiler 搜索 \"%s\" 相关的种子",
-    "contextMenuSearchWithDouban": "使用 PT Depiler 搜索当前豆瓣链接相关种子",
-    "contextMenuSearchWithIMDb": "使用 PT Depiler 搜索IMDb链接相关种子",
-    "contextMenuSearchInDefault": "在默认方案中搜索",
-    "contextMenuSearchInSolution": "在指定方案中搜索",
-    "contextMenuSearchInSite": "在指定站点中搜索",
-    "contextMenuSearchInThisSite": "在本站点中搜索",
-    "contextMenuSendToDownloader": "使用 PT Depiler 下载链接",
-    "contextMenuSendToDownloaderAdvanced": "高级推送",
-    "contextMenuSendToDownloaderIn": "推送到 $1 -> $2",
-    "contextMenuSendToDownloaderDefaultFolder": "默认路径",
-    "notificationSendLinkToDownloaderSuccess": "已成功将链接发送到下载器 [$1]",
-    "notificationSendLinkToDownloaderFailure": "将链接发送到下载器 [$1] 失败"
-  },
-  "route": {
-    "About": {
-      "Logger": "插件运行日志",
-      "SpecialThank": "特别感谢",
-      "TechnologyStack": "项目参考与引用",
-      "default": "插件相关"
-    },
-    "Devtools": {
-      "Debugger": "调试信息",
-      "SystemLog": "系统日志",
-      "default": "开发工具"
-    },
-    "Overview": {
-      "DownloadHistory": "下载历史",
-      "MediaServerEntity": "媒体库",
-      "KeepUploadTask": "辅种任务",
-      "MyClient": "我的下载器",
-      "MyCollection": "收藏列表",
-      "MyData": "我的数据",
-      "SearchEntity": "搜索结果",
-      "SearchResultSnapshot": "搜索结果快照",
-      "default": "概览"
-    },
-    "Settings": {
-      "default": "参数设置",
-      "SetBackup": "参数备份与恢复",
-      "SetBase": "常规设置",
-      "SetDownloader": "下载器设置",
-      "SetMediaServer": "媒体服务器设置",
-      "SetSearchSolution": "搜索方案定义",
-      "SetSite": "站点设置"
-    }
-  },
-  "connectCheck": {
-    "default": "检查连接性",
-    "error": "连接失败！请检查填写的信息或者你的远程服务器。",
-    "success": "连接成功，你可以顺利进行下一步。"
-  },
-  "downloaderLabel": {
-    "localDownload": "本地下载"
-  },
-  "levelRequirement": {
-    "interval": "需要等待的日期",
-    "totalTraffic": "总流量",
-    "downloaded": "下载量",
-    "trueDownloaded": "真实下载量",
-    "uploaded": "上传量",
-    "trueUploaded": "真实上传量",
-    "ratio": "分享率",
-    "trueRatio": "真实分享率",
-    "seeding": "做种数",
-    "seedingSize": "做种量",
-    "seedingTime": "做种时间",
-    "averageSeedingTime": "平均做种时间",
-    "bonus": "积分",
-    "seedingBonus": "做种积分",
-    "bonusPerHour": "时魔值",
-    "uploads": "发布数",
-    "leeching": "下载数量",
-    "snatches": "完成种子数",
-    "posts": "发布帖子数",
-    "hnrPreWarning": "H&R 预警的数量",
-    "hnrUnsatisfied": "H&R 未满足的数量",
-    "adoptions": "认领数"
-  },
-  "resultParseStatus": {
-    "unknownError": "未知错误！",
-    "waiting": "队列等待中...",
-    "working": "正在获取中...",
-    "success": "获取成功！",
-    "parseError": "解析错误！",
-    "passParse": "跳过！",
-    "CFBlocked": "CloudFlare 错误！",
-    "CFBlockedNotes": "CloudFlare 返回的错误，可能是因为站点启用了 CloudFlare 的安全防护，导致无法获取数据。可以先尝试手动访问一次站点，以通过 CF 验证。如果不起作用，请等待站点自行恢复。",
-    "needLogin": "需要登录！",
-    "noResults": "无结果！",
-    "unknown": "未知状态！"
   },
   "Logger": {
     "action": {
       "details": "详细信息"
+    }
+  },
+  "MediaServerEntity": {
+    "ItemInformationDialog": {
+      "duration": "时长：",
+      "mediaInfo": "媒体信息：",
+      "size": "大小：",
+      "title": "媒体详情",
+      "type": "类型："
+    },
+    "detail": "详情",
+    "loadMore": "加载更多",
+    "noItems": "暂无内容，请使用搜索框或点击加载更多按钮",
+    "searchPlaceholder": "搜索词"
+  },
+  "MyClient": {
+    "action": {
+      "delete": "删除",
+      "pause": "暂停",
+      "pauseError": "暂停失败",
+      "pauseSelectedSuccess": "已暂停 {count} 个种子",
+      "pauseSuccess": "暂停成功",
+      "resume": "开始",
+      "resumeError": "开始失败",
+      "resumeSelectedSuccess": "已开始 {count} 个种子",
+      "resumeSuccess": "开始成功",
+      "viewRaw": "查看原始数据"
+    },
+    "autoRefresh": {
+      "btnTitle": "自动刷新",
+      "clientSuspended": "{name} 刷新失败 3 次，已暂停自动刷新。点击下载器标签可恢复。",
+      "downloaderFilter": "下载器筛选",
+      "intervalLabel": "刷新间隔",
+      "intervalUnit": "秒（0 表示关闭）",
+      "resumeDownloader": "恢复该下载器的自动刷新",
+      "start": "开始自动刷新",
+      "stop": "停止自动刷新",
+      "stopDownloader": "停止该下载器的自动刷新",
+      "suspendedTip": "该下载器已因连续失败 3 次而被暂停。点击感叹号图标可恢复。"
+    },
+    "clientStatusDialog": {
+      "openBtn": "全部下载器状态",
+      "openClient": "打开下载器",
+      "title": "下载器状态",
+      "torrentCount": "{count} 个种子"
+    },
+    "columnSelector": "自定义列",
+    "deleteSelected": "删除",
+    "dialog": {
+      "removeData": "同时删除数据"
+    },
+    "pauseSelected": "暂停",
+    "pushToDownloader": {
+      "fileInputHint": "选择一个或多个 .torrent 文件进行推送",
+      "fileInputLabel": "种子文件",
+      "modeFile": "种子文件",
+      "modeUrl": "链接 / 磁力",
+      "navBtn": "推送到下载器",
+      "title": "推送到下载器",
+      "urlInputHint": "每行一个链接或磁力链接",
+      "urlInputLabel": "下载链接 / 磁力链接"
+    },
+    "refresh": "刷新",
+    "resumeSelected": "开始",
+    "searchPlaceholder": "搜索种子名称、Hash、标签、路径",
+    "state": {
+      "checking": "检查中",
+      "downloading": "下载中",
+      "error": "错误",
+      "paused": "已暂停",
+      "queued": "排队中",
+      "seeding": "做种中",
+      "unknown": "未知"
+    },
+    "table": {
+      "addedAt": "添加时间",
+      "client": "下载器",
+      "dlSpeed": "下载速度",
+      "name": "种子名称",
+      "progress": "进度",
+      "ratio": "分享率",
+      "savePath": "保存路径",
+      "size": "大小",
+      "status": "状态",
+      "totalDownloaded": "总下载量",
+      "totalUploaded": "总上传量",
+      "upSpeed": "上传速度"
+    }
+  },
+  "MyData": {
+    "HistoryDataView": {
+      "action": {
+        "viewRaw": "查看原始数据"
+      },
+      "deleteConfirm": "确认删除这条历史数据吗？",
+      "title": "用户历史数据"
+    },
+    "UserLevelRequirementsTd": {
+      "levelList": "用户等级列表"
+    },
+    "index": {
+      "filter": {
+        "lastUpdateError": "最后更新状态异常",
+        "todayNotUpdated": "今日未更新",
+        "unreadMessage": "未读信息"
+      },
+      "flushCancel": "取消刷新",
+      "flushSelectSite": "刷新数据",
+      "joinTimeFormat": "入站时间显示",
+      "joinTimeFormatOptions": {
+        "added": "绝对日期",
+        "alive": "相对时间",
+        "aliveWeek": "相对周数"
+      },
+      "multiOpen": "批量打开",
+      "noSiteSelectedCancelRefresh": "未选择任何站点，取消刷新",
+      "noSiteSelectedRefreshAll": "未选择任何站点，默认刷新全部站点",
+      "normalizeLevelName": "使用站点定义的等级名称",
+      "onlyShowUserLevelRequirement": "只显示等级要求中的升级队列",
+      "setting": "设置",
+      "showBonusNeededInterval": "等级要求中展示积分预估时间",
+      "showHnR": "显示 H&R",
+      "showIntervalAsDate": "等级要求时间显示为日期格式",
+      "showLevelRequirement": "显示等级要求",
+      "showNextLevelInDialog": "在站点等级列表中显示下一级别要求",
+      "showNextLevelInTable": "在表格中显示下一级别要求",
+      "showSeedingBonus": "显示做种积分",
+      "showSiteName": "显示站点名称",
+      "showUnreadMessage": "显示未读消息",
+      "showUserName": "显示用户名",
+      "simplifyBonusNumbers": "简化积分数字显示",
+      "siteCategory": "站点分类",
+      "siteStatus": "站点状态",
+      "updateAtFormatAsAlive": "更新时间显示为相对时间",
+      "viewStatistic": "数据图表",
+      "viewTimeline": "时间轴"
+    },
+    "table": {
+      "action": {
+        "flushData": "刷新数据",
+        "viewHistoryData": "查看历史数据"
+      },
+      "invites": "邀请数",
+      "joinTime": "入站时间",
+      "lastAccessAt": "最近访问时间",
+      "lastAccessDurationNote": "已经 {0} 天未访问了",
+      "levelName": "等级",
+      "trueUserData": "真实数据量",
+      "updateAt": "更新时间",
+      "userData": "数据量"
+    }
+  },
+  "SearchEntity": {
+    "ActionTd": {
+      "copyLink": "复制下载链接",
+      "copyLinkFailed": "复制下载链接失败",
+      "copyLinkSuccess": "下载链接已复制到剪贴板",
+      "localDownload": "下载种子文件到本地",
+      "sendToDefault": "发送到默认下载器",
+      "sendToDownloader": "发送到下载器"
+    },
+    "AdvanceFilterGenerateDialog": {
+      "completed": "完成人数",
+      "leechers": "下载人数",
+      "seeders": "上传人数",
+      "size": "种子大小",
+      "status": "种子状态",
+      "tags": "标签"
+    },
+    "KeepUploadDialog": {
+      "addToKeepUpload": "添加到辅种列表",
+      "addToKeepUploadConfirm": "确认将该种子添加到辅种列表？",
+      "baseTorrent": "基准种子",
+      "create": "创建任务",
+      "createError": "辅种任务创建失败",
+      "createSuccess": "辅种任务创建成功",
+      "fileCount": "文件数：",
+      "keepUpload": "辅种检测",
+      "noVerifiedItem": "没有验证通过的种子",
+      "otherTorrent": "其他种子",
+      "redownload": "重新下载种子信息",
+      "removeFromKeepUpload": "从列表中移除",
+      "setSavePath": "设置保存路径",
+      "size": "大小：",
+      "status": {
+        "downloadFailed": "下载种子失败",
+        "downloaded": "种子信息已下载",
+        "downloading": "正在下载种子信息...",
+        "failed": "验证失败",
+        "label": "状态：",
+        "missingFiles": "缺少文件",
+        "success": "验证通过",
+        "waiting": "等待验证..."
+      },
+      "title": "辅种检测"
+    },
+    "SaveSnapshotDialog": {
+      "snapshotName": "快照名称"
+    },
+    "SearchStatusDialog": {
+      "moveUp": "在队列中上移",
+      "searchAgain": "重新搜索",
+      "statusMsg": {
+        "noAdvanceParams": "不支持高级搜索参数",
+        "noEmptyKeywords": "不支持空关键词",
+        "noNonLatin": "不支持非拉丁字符",
+        "searchEntityNotEnabled": "该搜索入口未启用",
+        "siteNotEnabled": "该站点未启用",
+        "userCancel": "用户取消该搜索请求"
+      },
+      "successMsg": "共找到 {0} 条结果，用时 {0}s",
+      "title": "方案 [{0}] 搜索状态"
+    },
+    "index": {
+      "action": {
+        "cancel": "取消当前等待的搜索",
+        "displayPreferences": "搜索结果展示偏好",
+        "pause": "暂停搜索队列",
+        "retry": "重新搜索",
+        "retryFailed": "重新搜索失败的方案（如 @:resultParseStatus.unknownError , @:resultParseStatus.parseError , @:resultParseStatus.CFBlocked , @:resultParseStatus.needLogin ）",
+        "saveSnapshot": "保存搜索快照",
+        "start": "开始搜索队列"
+      },
+      "alert": {
+        "duration": "耗时： {0} 秒。",
+        "enterKeyword": "请输入搜索关键词开始搜索",
+        "keyword": "关键词",
+        "paused": "搜索暂停中…",
+        "plan": "搜索方案",
+        "results": "共 {0} 条结果，",
+        "searchProgress": "已接收 {0} 条结果，搜索仍在进行……",
+        "searchStatus": "搜索情况",
+        "searching": "搜索中…",
+        "snapshot": "搜索快照"
+      },
+      "filterLabel": "过滤搜索结果",
+      "limitTorrentTitleTdWidth": "限制种子标题宽度",
+      "selectedTorrents": "已选择 {0} 个种子",
+      "showSiteName": "显示站点名称",
+      "showSocialInformation": "显示媒体评价信息",
+      "showTorrentSubtitle": "显示种子副标题",
+      "showTorrentTag": "显示种子标签",
+      "socialInformationSearchOnNewTab": "媒体评价信息搜索在新标签页中打开",
+      "table": {
+        "category": "分类",
+        "comments": "评论",
+        "completed": "完成",
+        "leechers": "下载",
+        "seeders": "上传",
+        "size": "大小",
+        "time": "发布于(≈)",
+        "title": "标题"
+      },
+      "uploadAtFormatAsAlive": "上传时间显示为相对时间"
+    },
+    "siteFilter": {
+      "all": "全部站点"
+    }
+  },
+  "SearchResultSnapshot": {
+    "EditNameDialog": {
+      "snapshotName": "快照名称",
+      "title": "搜索快照重命名"
+    },
+    "table": {
+      "action": {
+        "editTitle": "编辑标题",
+        "view": "查看"
+      },
+      "filterLabel": "快照名称过滤",
+      "header": {
+        "createdAt": "创建时间",
+        "name": "快照名称",
+        "recordCount": "种子数"
+      }
+    }
+  },
+  "SentToDownloaderDialog": {
+    "isSending": "正在向下载器 {name} [{address}] 发送种子，请稍候...",
+    "label": "种子标签",
+    "labelHint": "（如果该下载服务器支持）",
+    "localRelay": "本地中转",
+    "moreOptions": "更多选项",
+    "noDownloader": "没有可用的下载器，请先在设置中添加下载器。",
+    "noDownloaderForSite": "当前站点没有可用的下载器，请检查下载器设置中的站点过滤配置。",
+    "pauseOnAdd": "添加时默认暂停",
+    "savePath": "保存路径",
+    "savePathHint": "不设置则为该下载服务器的默认路径",
+    "selectDownloader": "选择下载器",
+    "selectDownloaderFirst": "请先选择下载器",
+    "title": "为 {0} 个种子选择下载器"
+  },
+  "SetBackup": {
+    "AddDialog": {
+      "title": "添加备份服务器"
+    },
+    "Editor": {
+      "backupConfig": "备份配置",
+      "serverConfig": "服务器配置"
+    },
+    "HistoryDialog": {
+      "deleteFailure": "删除备份历史 [{name}] 失败",
+      "deleteSuccess": "删除备份历史 [{name}] 成功",
+      "restore": "恢复备份",
+      "table": {
+        "filename": "备份文件名",
+        "size": "备份大小",
+        "time": "备份时间"
+      },
+      "title": "{name} 的历史备份"
+    },
+    "LocalExportConfirmDialog": {
+      "title": "请选择本地需要导出的内容"
+    },
+    "RestoreDialog": {
+      "decryptKey": "解密密钥",
+      "expandCookieMinutes": "尝试延长Cookies期限（单位：分钟）",
+      "failure": "恢复失败: {error}",
+      "keepExistUserInfo": "保留本地已获取过的用户信息",
+      "loadFailure": "加载失败: {error}",
+      "missingVersion": "备份数据缺少版本信息，无法恢复",
+      "ptppImport": "PT-Plugin-Plus 备份导入",
+      "ptppPrompt": "需要导入 PT-Plugin-Plus 备份？",
+      "restoreOptions": "恢复选项",
+      "retry": "重试",
+      "selectFile": "选择备份文件",
+      "success": "恢复成功",
+      "title": "从备份文件中恢复",
+      "versionWarning": "备份数据版本高于当前扩展版本，恢复可能会导致数据不兼容或丢失，是否继续？"
+    },
+    "localExport": "本地导出",
+    "localImport": "本地导入",
+    "snackbar": {
+      "failure": "备份失败",
+      "success": "备份成功"
+    },
+    "table": {
+      "action": {
+        "backupNow": "立即备份",
+        "viewHistoryBackup": "查看历史备份"
+      },
+      "backupFields": "备份内容",
+      "lastBackupAt": "最近一次备份时间",
+      "notBackup": "未备份"
+    }
+  },
+  "SetBase": {
+    "download": {
+      "allowDirectSendToClient": "是否允许直接将链接（而不是种子文件）发送到下载服务器（如非必要请勿启用）",
+      "enableSiteFilter": "启用站点过滤器（启用后可在下载器设置中配置每个下载器可使用的站点）",
+      "initDownloaderTorrentOnEnter": "进入 我的下载器 页面时，自动加载下载器中的种子信息",
+      "localDownloadIgnoreInterval": "本地下载时忽略站点下载间隔限制",
+      "localDownloadMethod": "本地下载方式",
+      "localDownloadMethodOptions": {
+        "browser": "浏览器方法",
+        "browserTip": "（推荐）调用浏览器为插件提供的下载方法直接下载",
+        "extension": "插件中转",
+        "extensionTip": "插件后台下载种子，并中转到 @:SetBase.download.localDownloadMethodOptions.browser 进行下载",
+        "web": "网页打开",
+        "webTip": "打开下载链接对应的页面（只适用于最简单的方式，如果不符合条件，则会回落到 @:SetBase.download.localDownloadMethodOptions.extension ）"
+      },
+      "localDownloadTitle": "本地下载",
+      "myClientTitle": "我的下载器页面设置",
+      "pushDownloadServerTitle": "下载服务器推送",
+      "quickSendToClientNote": "启用快速推送后，插件会在推送下载任务时，做以下默认操作：<br />1. 展平 下载器和下载目录 选项供直接点击推送。<br />2. 鼠标移到选项时，则会暂开标签列表，点击时会额外添加标签信息。<br />3. 均采用本地中转模式推送种子，且 `是否自动开始下载` 等基本设置项和下载器专有配置项值由下载器设置和站点设置决定。",
+      "saveDownloadHistory": "是否保存下载历史（如非必要请勿关闭此功能）",
+      "saveLastDownloader": "保存上一次使用的下载服务器设置",
+      "useQuickSendToClient": "默认使用快速推送"
+    },
+    "searchEntity": {
+      "allowSingleSiteSearch": "是否允许单一站点搜索",
+      "autoDetectOfficialGroupFromTitle": "自动识别种子标题中的官方组信息，并形成标签",
+      "autoLoadInitialMediaWall": "自动加载首屏媒体墙",
+      "autoLoadMoreMediaOnScroll": "当滚动到页面底部时，自动加载新的媒体墙",
+      "filterLabel": "结果筛选",
+      "forceImdbIdMatchFilter": "使用 IMDb 搜索时，在搜索结果中滤去站点返回的IMDb号不匹配的结果",
+      "imdbTip": "关闭后，你需要使用 `imdb|tt12345678` 的格式来进行 IMDb 搜索。",
+      "mediaQueueConcurrency": "请求队列长度",
+      "mediaSearchLimit": "单次搜索结果数量",
+      "mediaSearchLimitMessage": "请不要一次性加载过多的搜索结果，未作 virtual‑scroll 优化，可能会导致浏览器卡死，同时也会影响媒体服务器的性能",
+      "mediaServerSearchConfig": "媒体服务器搜索配置",
+      "quickSiteFilter": "直接显示站点筛选栏",
+      "saveLastSearchFilter": "保存上一次使用的搜索筛选词",
+      "searchPlanLabel": "搜索方案",
+      "showHotRecommendations": "在搜索框中显示热门推荐按钮",
+      "siteQueueConcurrency": "请求队列长度",
+      "siteSearchConfig": "站点搜索配置",
+      "treatTTQueryAsImdbSearch": "是否将 tt\\d\\{7,8\\} 的搜索词直接视为 IMDb 搜索"
+    },
+    "tab": {
+      "backup": "备份恢复",
+      "download": "下载",
+      "native-bridge": "原生通信桥",
+      "search-entity": "@:common.search",
+      "social-information": "媒体评分",
+      "ui": "界面UI",
+      "user-info": "用户信息"
+    },
+    "ui": {
+      "allowDragLink": "允许拖拽链接到侧边栏按钮",
+      "allowExceptionSites": "允许设置不启用侧边栏的例外站点（启用后需在站点设置中对应关闭）",
+      "basicSettings": "基本设置",
+      "changeLanguage": "切换语言",
+      "confirmTwoStep": "对种子列表页批量复制、本地下载等操作需要二步确认",
+      "contentScript": "内容脚本（站点侧边栏等）",
+      "contentScriptWarning": "启用或禁用相关功能后需要保存设置，并刷新站点页面才能生效。",
+      "contextMenu": "右键菜单",
+      "contextMenuLinkPush": "启用（下载）链接推送",
+      "contextMenuSocialSearch": "启用社交链接（ douban, imdb ）搜索",
+      "contextMenuTextSearch": "启用选中文字搜索",
+      "displayMode": {
+        "auto": "跟随系统",
+        "dark": "暗黑模式",
+        "index": "页面显示模式",
+        "light": "明亮模式"
+      },
+      "dragNote": "拖拽时的下载链接不一定能被正确识别！",
+      "enableFadeEffect": "启用淡入效果（即默认半透明，当鼠标移入时显示）",
+      "enableOnSocialSite": "在社交站点（如豆瓣、IMDb）启用侧边栏",
+      "enableTableMultiSort": "启用部分表格的多列排序功能",
+      "expandByDefault": "默认展开侧边栏按钮",
+      "respondDisplayMode": "响应插件设置中的 ",
+      "saveTableBehavior": "记忆部分表格的 表头列展示、排序、分页 等信息",
+      "showReleaseNote": "插件更新时显示更新日志窗口",
+      "sidebarFunctions": "侧边栏功能",
+      "sidebarStyle": "侧边栏样式",
+      "socialSiteSearchBy": {
+        "chosen": "让我选择",
+        "id": "按 ID 搜索",
+        "imdb": "按 IMDb 编号 搜索",
+        "title": "按 主标题 搜索"
+      },
+      "socialSiteSearchLabel": "社交站点搜索方式",
+      "tableMultiSortNote": "多列排序使用方法：点击任意表头字段开始排序，字段上会显示数字“1”。再点击其他字段，依次显示“2”“3”，表示排序优先级。再次点击相同字段可切换升序、降序或取消排序。排序顺序由这些数字决定，数字越小优先级越高。",
+      "useLargeIcon": "使用大图标按键"
+    },
+    "userInfo": {
+      "afterTime": "每日最早刷新时间",
+      "userDataRefresh": "用户数据刷新",
+      "userInfoDisplay": "用户信息展示"
+    }
+  },
+  "SetDownloader": {
+    "PathAndTag": {
+      "downloadPath": {
+        "addInputLabel": "添加@:SetDownloader.PathAndTag.downloadPath.title",
+        "addTitle": "已添加的@:SetDownloader.PathAndTag.downloadPath.title@:SetDownloader.PathAndTag.supportDragNote",
+        "autoImport": "一键导入下载器中已有的@:SetDownloader.PathAndTag.downloadPath.title",
+        "autoImportFail": "@:SetDownloader.PathAndTag.downloadPath.autoImport 失败，请手动添加。",
+        "clear": "清空@:SetDownloader.PathAndTag.downloadPath.title",
+        "title": "下载路径"
+      },
+      "note": {
+        "index": "@:SetDownloader.PathAndTag.downloadPath.title 或 @:SetDownloader.PathAndTag.tags.title 中可包含以下关键字：",
+        "replaceNote": {
+          "custom": "自定义的内容替换",
+          "dateDay": "当前日份",
+          "dateMonth": "当前月份",
+          "dateYear": "当前年份",
+          "searchKeyword": "当前搜索关键字",
+          "searchPlan": "当前搜索方案名称",
+          "torrentSite": "该种子的站点id",
+          "torrentSiteName": "该种子的站点名称",
+          "torrentSubTitle": "该种子的副标题",
+          "torrentTitle": "该种子的标题"
+        },
+        "table": {
+          "example": "示例",
+          "keywords": "关键词",
+          "note": "说明"
+        },
+        "title": "说明"
+      },
+      "supportDragNote": "（支持拖拽排序）",
+      "tags": {
+        "addInputLabel": "添加@:SetDownloader.PathAndTag.tags.title",
+        "addTitle": "已添加的@:SetDownloader.PathAndTag.tags.title@:SetDownloader.PathAndTag.supportDragNote",
+        "autoImport": "一键导入下载器中已有的@:SetDownloader.PathAndTag.tags.title",
+        "autoImportFail": "@:SetDownloader.PathAndTag.tags.autoImport 失败，请手动添加。",
+        "clear": "清空@:SetDownloader.PathAndTag.tags.title",
+        "title": "标签"
+      },
+      "title": "为下载器 [{0}] @:SetDownloader.index.table.action.setPathAndTag"
+    },
+    "add": {
+      "NoneSelectNotice": "请选择一个服务器类型",
+      "newType": "找不到想要的服务器类型？来这里添加吧！",
+      "selectPlaceholder": "@:SetDownloader.add.NoneSelectNotice （支持搜索）",
+      "step": {
+        "selectType": "选择服务器类型",
+        "setOptions": "详细配置"
+      },
+      "title": "新增下载服务器"
+    },
+    "common": {
+      "address": "服务器地址",
+      "name": "服务器名称",
+      "status": "服务器状态",
+      "uid": "服务器ID"
+    },
+    "delete": {
+      "text": "确认删除这 {0} 个下载服务器吗？"
+    },
+    "edit": {
+      "title": "编辑下载服务器"
+    },
+    "editor": {
+      "addressTip": "完整的服务器地址（含端口），如：http://192.168.1.1:5000/",
+      "autoStart": "发送种子时自动开始下载",
+      "nameTip": "取一个好听又好分辨的名称",
+      "password": "密码",
+      "timeout": "超时时长（秒）",
+      "uidPlaceholder": "（自动生成）"
+    },
+    "index": {
+      "changeDefaultDownloader": "更新默认下载服务器成功！如有必要请进一步设置下载地址和标签。",
+      "editDefaultDownloaderBtn": "默认下载服务器设置",
+      "emptyNotice": "在使用推送服务之前，您至少需要添加一个下载服务器。",
+      "remove": {
+        "multi": "你确定删除这{count}个下载服务器吗？",
+        "single": "确认要删除这个下载服务器吗？"
+      },
+      "table": {
+        "action": {
+          "deleteDownloader": "删除该下载服务器",
+          "setDefault": "设置为默认下载服务器",
+          "setPathAndTag": "设置预设的下载路径和标签",
+          "setSiteFilter": "设置站点过滤",
+          "status": "状态"
+        },
+        "autodl": "自动下载？",
+        "downloaderCategory": "下载器分类",
+        "enabled": "启用？"
+      }
+    },
+    "siteFilter": {
+      "excludedSites": "排除的站点",
+      "excludedSitesHint": "如果站点被排除，则在站点页面不会显示该下载器（在助手聚合搜索页面不生效）",
+      "noSites": "暂无已添加的站点",
+      "title": "设置下载器 [{0}] 的站点过滤（排除方式）"
+    }
+  },
+  "SetMediaServer": {
+    "Editor": {
+      "authInfo": "认证信息"
+    },
+    "add": {
+      "title": "添加媒体服务器"
+    }
+  },
+  "SetNativeBridge": {
+    "bridge": {
+      "enabled": "启用原生通信桥",
+      "status": {
+        "connected": "已连接",
+        "connecting": "连接中...",
+        "disabled": "已禁用",
+        "error": "错误",
+        "no-permission": "未授权",
+        "retrying": "重试中..."
+      },
+      "testConnection": "测试连接",
+      "title": "通信桥控制"
+    },
+    "info": {
+      "cliLink": "ptd-cli",
+      "cliRequired": "此功能需要安装外部 CLI 工具。移动平台上不可用。安装说明请参考 {0}。",
+      "description": "原生通信桥允许 PT-Depiler CLI 工具与本扩展进行通信。需要在电脑上单独安装 CLI 工具。",
+      "privacy": "启用后，原生通信桥允许本地安装的 CLI 工具访问扩展数据，包括站点配置、搜索结果、下载历史、用户信息和下载器状态。所有通信均在本地进行（浏览器与本机进程之间），不会将数据发送至任何远程服务器。您可以随时禁用此功能或撤销权限。",
+      "setupCommand": "运行以下命令将此扩展注册到 CLI 工具：",
+      "setupHint": "运行命令后，重启浏览器或点击测试连接。",
+      "title": "关于原生通信桥"
+    },
+    "permission": {
+      "grant": "授予权限",
+      "grantFailed": "权限请求被拒绝",
+      "granted": "已授权",
+      "notGranted": "未授权",
+      "revoke": "撤销权限",
+      "title": "权限"
+    }
+  },
+  "SetSearchSolution": {
+    "CustomSolutionDialog": {
+      "requestConfig": "请求配置",
+      "requestConfigHint": "请按JSON格式配置请求参数",
+      "requestConfigJsonError": "必须是合法的JSON格式",
+      "solutionName": "方案名称",
+      "title": "自定义搜索方案"
+    },
+    "copy": "创建副本",
+    "delete": {
+      "text": "确认删除这 {0} 个 @:SetSearchSolution.solution 吗？"
+    },
+    "edit": {
+      "addCount": "已添加 @:SetSearchSolution.solution {0} 个",
+      "cantAddByDuplicateNote": "已存在相同的 @:SetSearchSolution.solution ，无法重复添加。",
+      "filterPlaceholder": "通过站点名称或 url 进行搜索",
+      "title": "自定义 @:SetSearchSolution.solution"
+    },
+    "newSolutionNamePrompt": "请输入新搜索方案名称",
+    "solution": "搜索方案",
+    "spDialog": {
+      "action": {
+        "add": "添加此@:SetSearchSolution.solution",
+        "create": "基于此创建自定义@:SetSearchSolution.solution",
+        "reset": "重置此@:SetSearchSolution.solution"
+      },
+      "noDefNotice": "该站点未定义搜索模块，请到项目仓库提供帮助！",
+      "notice": "不推荐在此处进行设置，更建议在对应站点的个人设置中配置或使用插件提供的搜索方案功能！",
+      "selectAllNotice": "（注意：在大多数情况下，你并不需要全选所有搜索项！）",
+      "title": "配置站点默认搜索模式 - {name}"
+    },
+    "table": {
+      "autoGenerate": "自动生成",
+      "default": "默认？",
+      "enable": "启用？"
+    }
+  },
+  "SetSite": {
+    "AddDialog": {
+      "showDeadSite": "展示已死亡站点"
+    },
+    "Editor": {
+      "downloadInterval": "下载间隔",
+      "downloadIntervalHint": "影响该站点的下载间隔时间（为了安全考虑，插件不会严格遵守该设置，实际间隔总是会略大于等于设置的间隔）",
+      "downloadLinkSuffix": "下载链接后缀",
+      "downloadLinkSuffixExample": "如插件获得的链接为 https://example.com/download.php?id=1，此处设置为 &passkey=xxxx， 则最终下载链接为 https://example.com/download.php?id=1&passkey=xxxx. 通常无须填写，仅在无法获得 passkey 时可手动添加",
+      "downloadLinkSuffixHint": "该字段会被自动添加到该站点的下载链接后",
+      "otherSettings": "其他设置",
+      "requestTimeout": "请求超时",
+      "requestTimeoutHint": "影响该站点请求（种子搜索、用户信息获取）的超时等待时间",
+      "siteSettings": "站点设置"
+    },
+    "ReBuildMapDialog": {
+      "doRebuildBtn": "重建",
+      "rebuildSiteHostMap": "重建站点域名关系缓存",
+      "rebuildSiteNameMap": "重建站点名称关系缓存",
+      "title": "重建站点映射关系缓存"
+    },
+    "SiteCategoryPanel": {
+      "siteDefault": "站点默认"
+    },
+    "add": {
+      "selectSitePlaceholder": "请选择一个站点（支持搜索）",
+      "title": "添加站点"
+    },
+    "common": {
+      "aka": "站点别名",
+      "allowContentScript": "加载侧边栏",
+      "allowQueryUserInfo": "获取个人信息",
+      "allowSearch": "允许搜索",
+      "groups": "站点分类",
+      "isOffline": "已离线",
+      "name": "站点名称",
+      "open": "打开",
+      "showMessageCount": "信息提醒",
+      "tags": "标签",
+      "url": "网站链接"
+    },
+    "delete": {
+      "text": "确认删除这 {0} 个站点吗？"
+    },
+    "edit": {
+      "title": "编辑站点配置"
+    },
+    "editor": {
+      "addUrlTip": "增加一个你正在使用的站点域名，输入的应该以 https:// 或 http:// 开头，以 / 结尾，例如 https://example.com/",
+      "customUrlPlaceholder": "自定义站点域名",
+      "description": "网站描述",
+      "sortIndexTip": "可用于搜索排序",
+      "tagTip": "标签输入完成后按回车添加。（只有前4个会在列表页显示）",
+      "timezone": "时区",
+      "uploadSpeedLimit": "上传速度",
+      "uploadSpeedLimitHint": "设置向下载器推送种子时的上传速度限制 (MiB/s)，0或不填时不限速"
+    },
+    "index": {
+      "flushFaviconFinish": "所选站点的图标已成功刷新！",
+      "oneClickImport": "一键导入站点",
+      "reBuildMap": "重建站点映射",
+      "settingNote": ["只有配置过的站点才会显示插件图标及相应的功能；", "已离线的站点不再参与搜索和信息获取；"],
+      "table": {
+        "flushFavicon": "刷新站点图标",
+        "searchEntries": "搜索入口"
+      }
+    },
+    "oneClickImportDialog": {
+      "alert1": "此操作会尝试以默认配置导入你选择的站点，请确保该站点已在浏览器上登录过。导入过程不能中断，请耐心等待。",
+      "alert2": "未添加的站点列表",
+      "importComplete": "一键导入完成，成功添加 {count} 个站点",
+      "stats": "已选择 {count} 个站点，已添加 {success} 个站点，添加失败 {failed} 个站点。",
+      "status": {
+        "failed": "添加失败",
+        "manual": "该站点需要手动添加",
+        "selected": "已选择",
+        "success": "已添加成功",
+        "trying": "正在尝试中"
+      },
+      "title": "一键导入站点",
+      "trying": "正在尝试导入站点 [{name}] ..."
     }
   },
   "SpecialThank": {
@@ -243,984 +832,404 @@
     },
     "thankNote": "PT 助手的诞生是建立在这些项目基础之上，在此感谢所有项目的参与人员，感谢他们的付出！"
   },
-  "DownloadHistory": {
-    "refresh": "刷新下载记录列表",
-    "reDownload": "重新下载",
-    "searchTorrent": "全站搜索此种子",
-    "filterPlaceholder": "过滤下载记录",
-    "table": {
-      "title": "种子",
-      "downloader": "下载服务器",
-      "downloadAt": "下载时间",
-      "status": "下载状态"
-    },
-    "AdvanceFilterGenerateDialog": {
-      "downloader": "下载器"
-    },
-    "ReDownloadSelectDialog": {
-      "title": "重新下载 {0} 条记录",
-      "oldMethod": "按原下载方式重试",
-      "selectDownloader": "选择下载服务器"
-    }
-  },
-  "KeepUploadTask": {
-    "title": "辅种任务",
-    "savePath": "保存路径：",
-    "defaultPath": "默认路径",
-    "torrentCount": "种子数：",
-    "clearConfirm": "确认清空所有辅种任务吗？",
-    "emptyNotice": "暂无辅种任务，请在搜索结果页面选择种子后点击辅种检测按钮",
-    "clearAll": "清空全部",
-    "deleteConfirm": "确认删除该辅种任务吗？",
-    "deleteSelectedConfirm": "确认删除选中的 {count} 个辅种任务吗？",
-    "deleteSuccess": "删除成功",
-    "deleteError": "删除失败",
-    "clearSuccess": "清空成功",
-    "clearError": "清空失败",
-    "sendSuccess": "发送成功",
-    "sendError": "发送失败",
-    "sendSingleSuccess": "发送成功",
-    "sendSingleError": "发送失败",
-    "sendConfirm": "确认发送 {count} 个种子到下载器？",
-    "sendBaseTorrent": "发送基准种子",
-    "sendOtherTorrents": "发送其他种子",
-    "sendAllTorrents": "发送所有种子",
-    "setAsBaseTorrent": "设为基准种子",
-    "setBaseSuccess": "已设为基准种子",
-    "setBaseError": "设置失败",
-    "seeders": "上传：",
-    "leechers": "下载：",
-    "copyLinks": "复制下载链接",
-    "copySuccess": "已复制 {count} 个下载链接",
-    "copyError": "复制失败",
-    "editSavePath": "修改保存路径",
-    "updateSuccess": "更新成功",
-    "updateError": "更新失败",
-    "table": {
-      "site": "站点",
-      "title": "标题",
-      "size": "大小",
-      "count": "种子数",
-      "time": "创建时间"
-    },
-    "warning": {
-      "title": "警告：",
-      "item1": "辅种前请确认下载服务器已关闭类似于「自动开始下载」的选项（如果有）。",
-      "item2": "助手仅对种子文件做简单验证，不保证辅种成功，请自行斟酌是否要使用辅种功能！",
-      "item3": "如出现因辅种失败造成的爆仓，由用户自行负责！"
-    }
-  },
-  "torrent": {
-    "status": {
-      "unknown": "未知",
-      "downloading": "下载中",
-      "seeding": "做种中",
-      "inactive": "未活动",
-      "completed": "已完成"
-    }
-  },
-  "MediaServerEntity": {
-    "searchPlaceholder": "搜索词",
-    "detail": "详情",
-    "loadMore": "加载更多",
-    "noItems": "暂无内容，请使用搜索框或点击加载更多按钮",
-    "ItemInformationDialog": {
-      "title": "媒体详情",
-      "type": "类型：",
-      "duration": "时长：",
-      "size": "大小：",
-      "mediaInfo": "媒体信息："
-    }
-  },
-  "MyData": {
-    "index": {
-      "flushSelectSite": "刷新数据",
-      "flushCancel": "取消刷新",
-      "joinTimeFormat": "入站时间显示",
-      "joinTimeFormatOptions": {
-        "alive": "相对时间",
-        "aliveWeek": "相对周数",
-        "added": "绝对日期"
-      },
-      "showSiteName": "显示站点名称",
-      "showUnreadMessage": "显示未读消息",
-      "showUserName": "显示用户名",
-      "normalizeLevelName": "使用站点定义的等级名称",
-      "showLevelRequirement": "显示等级要求",
-      "onlyShowUserLevelRequirement": "只显示等级要求中的升级队列",
-      "showNextLevelInTable": "在表格中显示下一级别要求",
-      "showNextLevelInDialog": "在站点等级列表中显示下一级别要求",
-      "showHnR": "显示 H&R",
-      "showSeedingBonus": "显示做种积分",
-      "updateAtFormatAsAlive": "更新时间显示为相对时间",
-      "showIntervalAsDate": "等级要求时间显示为日期格式",
-      "simplifyBonusNumbers": "简化积分数字显示",
-      "showBonusNeededInterval": "等级要求中展示积分预估时间",
-      "multiOpen": "批量打开",
-      "viewTimeline": "时间轴",
-      "viewStatistic": "数据图表",
-      "setting": "设置",
-      "siteStatus": "站点状态",
-      "siteCategory": "站点分类",
-      "filter": {
-        "todayNotUpdated": "今日未更新",
-        "lastUpdateError": "最后更新状态异常",
-        "unreadMessage": "未读信息"
-      },
-      "noSiteSelectedRefreshAll": "未选择任何站点，默认刷新全部站点",
-      "noSiteSelectedCancelRefresh": "未选择任何站点，取消刷新"
-    },
-    "table": {
-      "levelName": "等级",
-      "userData": "数据量",
-      "trueUserData": "真实数据量",
-      "invites": "邀请数",
-      "joinTime": "入站时间",
-      "lastAccessAt": "最近访问时间",
-      "lastAccessDurationNote": "已经 {0} 天未访问了",
-      "updateAt": "更新时间",
-      "action": {
-        "viewHistoryData": "查看历史数据",
-        "flushData": "刷新数据"
-      }
-    },
-    "HistoryDataView": {
-      "title": "用户历史数据",
-      "deleteConfirm": "确认删除这条历史数据吗？",
-      "action": {
-        "viewRaw": "查看原始数据"
-      }
-    },
-    "UserLevelRequirementsTd": {
-      "levelList": "用户等级列表"
-    }
-  },
   "UserDataStatistic": {
     "chart": {
-      "totalSiteBase": "基本数据",
-      "totalSiteSeeding": "做种数据",
-      "perSiteKuploaded": "分站点上传数据",
-      "perSiteKuploadedIncr": "分站点上传增量",
+      "chartSettings": "图表设置",
+      "chartStyleSettings": "数据图表样式设置",
+      "dataLabel": "数据",
+      "dateRange": "时间段",
+      "displayChart": "展示图表",
+      "displaySiteSettings": "展示站点设置",
+      "downloadLabel": "下载",
+      "exportFilename": "{name}的数据图表（{date}）",
+      "hiddenSites": "（另有 {count} 个站点数据被隐藏 )",
+      "hideLowPercentHint": "设置为0则不隐藏",
+      "hideLowPercentLabel": "隐藏分站点图中图例百分比低于该值的详情",
+      "noData": "无数据",
+      "perSiteKbonus": "分站点魔力",
+      "perSiteKbonusIncr": "分站点魔力增量",
       "perSiteKdownloaded": "分站点下载数据",
       "perSiteKdownloadedIncr": "分站点下载增量",
       "perSiteKseeding": "分站点做种数",
+      "perSiteKseedingBonus": "分站点做种积分",
+      "perSiteKseedingBonusIncr": "分站点做种积分增量",
       "perSiteKseedingIncr": "分站点做种数增量",
       "perSiteKseedingSize": "分站点做种量",
       "perSiteKseedingSizeIncr": "分站点做种量增量",
-      "perSiteKbonus": "分站点魔力",
-      "perSiteKbonusIncr": "分站点魔力增量",
-      "perSiteKseedingBonus": "分站点做种积分",
-      "perSiteKseedingBonusIncr": "分站点做种积分增量",
-      "uploadLabel": "上传",
-      "downloadLabel": "下载",
-      "dataLabel": "数据",
-      "seedingSizeLabel": "做种量",
+      "perSiteKuploaded": "分站点上传数据",
+      "perSiteKuploadedIncr": "分站点上传增量",
       "seedingLabel": "做种数",
+      "seedingSizeLabel": "做种量",
       "totalLabel": "总和",
-      "hiddenSites": "（另有 {count} 个站点数据被隐藏 )",
-      "noData": "无数据",
-      "chartStyleSettings": "数据图表样式设置",
-      "displaySiteSettings": "展示站点设置",
-      "displayChart": "展示图表",
-      "dateRange": "时间段",
-      "chartSettings": "图表设置",
-      "hideLowPercentHint": "设置为0则不隐藏",
-      "hideLowPercentLabel": "隐藏分站点图中图例百分比低于该值的详情",
-      "exportFilename": "{name}的数据图表（{date}）"
+      "totalSiteBase": "基本数据",
+      "totalSiteSeeding": "做种数据",
+      "uploadLabel": "上传"
     },
     "dateRange": {
-      "custom": "自定义",
       "all": "全部",
+      "custom": "自定义",
       "day": "近 {0} 天"
     }
   },
   "UserDataTimeline": {
-    "total": "总",
-    "field": {
-      "site": "站点数",
-      "uploads": "发布数",
-      "uploaded": "上传量",
-      "downloaded": "下载量",
-      "seeding": "做种数",
-      "seedingSize": "做种量",
-      "bonus": "积分值",
-      "bonusPerHour": "时魔值",
-      "ratio": "分享率",
-      "siteName": "站点名称",
-      "name": "@:common.username",
-      "level": "用户等级",
-      "uid": "用户ID"
-    },
     "controls": {
-      "usernameAndTitle": "用户名及标题",
-      "timelineTitle": "时间轴标题",
       "components": "组件",
-      "showTopSites": "展示各类数据的冠军及亚军站点",
-      "showTimeline": "展示各个站点信息（总开关）",
       "customBgColor": "自定义背景色",
-      "siteDisplay": "站点展示组件",
-      "faviconBlur": "站点Favicon模糊度",
       "displayContent": "展示内容",
+      "displaySiteSettings": "展示站点设置",
+      "faviconBlur": "站点Favicon模糊度",
+      "showTimeline": "展示各个站点信息（总开关）",
+      "showTopSites": "展示各类数据的冠军及亚军站点",
+      "siteDisplay": "站点展示组件",
       "statsSection": "统计部分",
-      "timelineSection": "时间轴部分",
-      "timeDisplay": "时间显示方式",
+      "styleSettings": "时间轴样式设置",
       "timeAdded": "发生时间",
       "timeAlive": "过去时间",
-      "styleSettings": "时间轴样式设置",
-      "displaySiteSettings": "展示站点设置"
+      "timeDisplay": "时间显示方式",
+      "timelineSection": "时间轴部分",
+      "timelineTitle": "时间轴标题",
+      "usernameAndTitle": "用户名及标题"
+    },
+    "exportFilename": "{name}的时间轴（{date}）",
+    "field": {
+      "bonus": "积分值",
+      "bonusPerHour": "时魔值",
+      "downloaded": "下载量",
+      "level": "用户等级",
+      "name": "@:common.username",
+      "ratio": "分享率",
+      "seeding": "做种数",
+      "seedingSize": "做种量",
+      "site": "站点数",
+      "siteName": "站点名称",
+      "uid": "用户ID",
+      "uploaded": "上传量",
+      "uploads": "发布数"
     },
     "ptAge": "P龄: ≈ {years} 年",
-    "exportFilename": "{name}的时间轴（{date}）"
+    "total": "总"
   },
-  "SearchEntity": {
-    "index": {
-      "table": {
-        "title": "标题",
-        "category": "分类",
-        "size": "大小",
-        "seeders": "上传",
-        "leechers": "下载",
-        "completed": "完成",
-        "comments": "评论",
-        "time": "发布于(≈)"
-      },
-      "alert": {
-        "enterKeyword": "请输入搜索关键词开始搜索",
-        "searchStatus": "搜索情况",
-        "paused": "搜索暂停中…",
-        "searching": "搜索中…",
-        "searchProgress": "已接收 {0} 条结果，搜索仍在进行……",
-        "snapshot": "搜索快照",
-        "plan": "搜索方案",
-        "keyword": "关键词",
-        "results": "共 {0} 条结果，",
-        "duration": "耗时： {0} 秒。"
-      },
-      "action": {
-        "start": "开始搜索队列",
-        "pause": "暂停搜索队列",
-        "cancel": "取消当前等待的搜索",
-        "retry": "重新搜索",
-        "retryFailed": "重新搜索失败的方案（如 @:resultParseStatus.unknownError , @:resultParseStatus.parseError , @:resultParseStatus.CFBlocked , @:resultParseStatus.needLogin ）",
-        "saveSnapshot": "保存搜索快照",
-        "displayPreferences": "搜索结果展示偏好"
-      },
-      "filterLabel": "过滤搜索结果",
-      "selectedTorrents": "已选择 {0} 个种子",
-      "showSiteName": "显示站点名称",
-      "showTorrentTag": "显示种子标签",
-      "showTorrentSubtitle": "显示种子副标题",
-      "showSocialInformation": "显示媒体评价信息",
-      "socialInformationSearchOnNewTab": "媒体评价信息搜索在新标签页中打开",
-      "uploadAtFormatAsAlive": "上传时间显示为相对时间",
-      "limitTorrentTitleTdWidth": "限制种子标题宽度"
-    },
-    "siteFilter": {
-      "all": "全部站点"
-    },
+  "common": {
     "AdvanceFilterGenerateDialog": {
-      "tags": "标签",
-      "status": "种子状态",
-      "size": "种子大小",
-      "seeders": "上传人数",
-      "leechers": "下载人数",
-      "completed": "完成人数"
-    },
-    "SearchStatusDialog": {
-      "title": "方案 [{0}] 搜索状态",
-      "successMsg": "共找到 {0} 条结果，用时 {0}s",
-      "statusMsg": {
-        "userCancel": "用户取消该搜索请求",
-        "siteNotEnabled": "该站点未启用",
-        "searchEntityNotEnabled": "该搜索入口未启用",
-        "noEmptyKeywords": "不支持空关键词",
-        "noNonLatin": "不支持非拉丁字符",
-        "noAdvanceParams": "不支持高级搜索参数"
+      "date": "日期",
+      "dateUnit": {
+        "custom": "自定义",
+        "day": "今日",
+        "month": "本月",
+        "quarter": "本季度",
+        "week": "本周",
+        "year": "今年"
       },
-      "moveUp": "在队列中上移",
-      "searchAgain": "重新搜索"
+      "exclude": "排除项",
+      "generate": "生成",
+      "keywords": "关键词",
+      "required": "必要项",
+      "reset": "重置搜索词",
+      "site": "@:common.site",
+      "title": "生成高级过滤词"
     },
-    "ActionTd": {
-      "sendToDefault": "发送到默认下载器",
-      "sendToDownloader": "发送到下载器",
-      "copyLink": "复制下载链接",
-      "localDownload": "下载种子文件到本地",
-      "copyLinkSuccess": "下载链接已复制到剪贴板",
-      "copyLinkFailed": "复制下载链接失败"
+    "action": "操作",
+    "advancedSettings": "高级设置",
+    "back": "返回",
+    "basicInfo": "基本信息",
+    "btn": {
+      "add": "增加"
     },
-    "SaveSnapshotDialog": {
-      "snapshotName": "快照名称"
+    "checkbox": {
+      "all": "全选",
+      "invert": "反选",
+      "none": "全不选"
     },
-    "KeepUploadDialog": {
-      "title": "辅种检测",
-      "keepUpload": "辅种检测",
-      "baseTorrent": "基准种子",
-      "otherTorrent": "其他种子",
-      "size": "大小：",
-      "fileCount": "文件数：",
-      "addToKeepUpload": "添加到辅种列表",
-      "addToKeepUploadConfirm": "确认将该种子添加到辅种列表？",
-      "redownload": "重新下载种子信息",
-      "removeFromKeepUpload": "从列表中移除",
-      "setSavePath": "设置保存路径",
-      "create": "创建任务",
-      "createSuccess": "辅种任务创建成功",
-      "createError": "辅种任务创建失败",
-      "noVerifiedItem": "没有验证通过的种子",
-      "status": {
-        "label": "状态：",
-        "downloading": "正在下载种子信息...",
-        "waiting": "等待验证...",
-        "downloaded": "种子信息已下载",
-        "success": "验证通过",
-        "failed": "验证失败",
-        "downloadFailed": "下载种子失败",
-        "missingFiles": "缺少文件"
-      }
-    }
-  },
-  "SearchResultSnapshot": {
-    "table": {
-      "header": {
-        "name": "快照名称",
-        "recordCount": "种子数",
-        "createdAt": "创建时间"
-      },
-      "filterLabel": "快照名称过滤",
-      "action": {
-        "view": "查看",
-        "editTitle": "编辑标题"
+    "count": "数量",
+    "date": "日期",
+    "default": "默认",
+    "dialog": {
+      "cancel": "取消",
+      "close": "关闭",
+      "confirm": "确认",
+      "deleteText": "确认删除这 {0} 条记录吗？",
+      "next": "下一步",
+      "ok": "完成",
+      "prev": "上一步",
+      "reset": "重置",
+      "title": {
+        "confirmAction": "确认操作"
       }
     },
-    "EditNameDialog": {
-      "title": "搜索快照重命名",
-      "snapshotName": "快照名称"
-    }
+    "edit": "编辑",
+    "enable": "启用",
+    "export": "导出",
+    "exportImage": "导出图片",
+    "howToUse": "如何使用？",
+    "import": "导入",
+    "language": "语言",
+    "name": "名称",
+    "project": "PT 助手 Plus",
+    "remove": "删除",
+    "save": "保存",
+    "saveSettings": "保存设置",
+    "saveSuccess": "保存成功",
+    "search": "搜索",
+    "site": "站点",
+    "sortIndex": "优先级",
+    "test": "测试",
+    "time": {
+      "ago": "前",
+      "day": "日",
+      "hour": "时",
+      "lessThanAWeek": "不足一周",
+      "minute": "分",
+      "month": "月",
+      "second": "秒",
+      "week": "周",
+      "year": "年"
+    },
+    "type": "类型",
+    "username": "用户名",
+    "version": "版本",
+    "visit": "访问"
   },
-  "SetBase": {
-    "tab": {
-      "ui": "界面UI",
-      "search-entity": "@:common.search",
-      "download": "下载",
-      "user-info": "用户信息",
-      "backup": "备份恢复",
-      "social-information": "媒体评分",
-      "native-bridge": "原生通信桥"
-    },
-    "ui": {
-      "changeLanguage": "切换语言",
-      "displayMode": {
-        "auto": "跟随系统",
-        "dark": "暗黑模式",
-        "index": "页面显示模式",
-        "light": "明亮模式"
-      },
-      "socialSiteSearchBy": {
-        "id": "按 ID 搜索",
-        "title": "按 主标题 搜索",
-        "imdb": "按 IMDb 编号 搜索",
-        "chosen": "让我选择"
-      },
-      "tableMultiSortNote": "多列排序使用方法：点击任意表头字段开始排序，字段上会显示数字“1”。再点击其他字段，依次显示“2”“3”，表示排序优先级。再次点击相同字段可切换升序、降序或取消排序。排序顺序由这些数字决定，数字越小优先级越高。",
-      "showReleaseNote": "插件更新时显示更新日志窗口",
-      "saveTableBehavior": "记忆部分表格的 表头列展示、排序、分页 等信息",
-      "enableTableMultiSort": "启用部分表格的多列排序功能",
-      "contentScript": "内容脚本（站点侧边栏等）",
-      "contentScriptWarning": "启用或禁用相关功能后需要保存设置，并刷新站点页面才能生效。",
-      "basicSettings": "基本设置",
-      "allowExceptionSites": "允许设置不启用侧边栏的例外站点（启用后需在站点设置中对应关闭）",
-      "enableOnSocialSite": "在社交站点（如豆瓣、IMDb）启用侧边栏",
-      "sidebarStyle": "侧边栏样式",
-      "expandByDefault": "默认展开侧边栏按钮",
-      "useLargeIcon": "使用大图标按键",
-      "enableFadeEffect": "启用淡入效果（即默认半透明，当鼠标移入时显示）",
-      "sidebarFunctions": "侧边栏功能",
-      "confirmTwoStep": "对种子列表页批量复制、本地下载等操作需要二步确认",
-      "allowDragLink": "允许拖拽链接到侧边栏按钮",
-      "dragNote": "拖拽时的下载链接不一定能被正确识别！",
-      "socialSiteSearchLabel": "社交站点搜索方式",
-      "contextMenu": "右键菜单",
-      "contextMenuTextSearch": "启用选中文字搜索",
-      "contextMenuSocialSearch": "启用社交链接（ douban, imdb ）搜索",
-      "contextMenuLinkPush": "启用（下载）链接推送",
-      "respondDisplayMode": "响应插件设置中的 "
-    },
-    "searchEntity": {
-      "siteSearchConfig": "站点搜索配置",
-      "siteQueueConcurrency": "请求队列长度",
-      "saveLastSearchFilter": "保存上一次使用的搜索筛选词",
-      "forceImdbIdMatchFilter": "使用 IMDb 搜索时，在搜索结果中滤去站点返回的IMDb号不匹配的结果",
-      "autoDetectOfficialGroupFromTitle": "自动识别种子标题中的官方组信息，并形成标签",
-      "quickSiteFilter": "直接显示站点筛选栏",
-      "showHotRecommendations": "在搜索框中显示热门推荐按钮",
-      "mediaServerSearchConfig": "媒体服务器搜索配置",
-      "mediaQueueConcurrency": "请求队列长度",
-      "mediaSearchLimit": "单次搜索结果数量",
-      "mediaSearchLimitMessage": "请不要一次性加载过多的搜索结果，未作 virtual‑scroll 优化，可能会导致浏览器卡死，同时也会影响媒体服务器的性能",
-      "autoLoadInitialMediaWall": "自动加载首屏媒体墙",
-      "autoLoadMoreMediaOnScroll": "当滚动到页面底部时，自动加载新的媒体墙",
-      "allowSingleSiteSearch": "是否允许单一站点搜索",
-      "treatTTQueryAsImdbSearch": "是否将 tt\\d\\{7,8\\} 的搜索词直接视为 IMDb 搜索",
-      "imdbTip": "关闭后，你需要使用 `imdb|tt12345678` 的格式来进行 IMDb 搜索。",
-      "filterLabel": "结果筛选",
-      "searchPlanLabel": "搜索方案"
-    },
-    "download": {
-      "localDownloadMethod": "本地下载方式",
-      "localDownloadMethodOptions": {
-        "web": "网页打开",
-        "webTip": "打开下载链接对应的页面（只适用于最简单的方式，如果不符合条件，则会回落到 @:SetBase.download.localDownloadMethodOptions.extension ）",
-        "browser": "浏览器方法",
-        "browserTip": "（推荐）调用浏览器为插件提供的下载方法直接下载",
-        "extension": "插件中转",
-        "extensionTip": "插件后台下载种子，并中转到 @:SetBase.download.localDownloadMethodOptions.browser 进行下载"
-      },
-      "saveDownloadHistory": "是否保存下载历史（如非必要请勿关闭此功能）",
-      "myClientTitle": "我的下载器页面设置",
-      "initDownloaderTorrentOnEnter": "进入 我的下载器 页面时，自动加载下载器中的种子信息",
-      "localDownloadTitle": "本地下载",
-      "localDownloadIgnoreInterval": "本地下载时忽略站点下载间隔限制",
-      "pushDownloadServerTitle": "下载服务器推送",
-      "saveLastDownloader": "保存上一次使用的下载服务器设置",
-      "allowDirectSendToClient": "是否允许直接将链接（而不是种子文件）发送到下载服务器（如非必要请勿启用）",
-      "useQuickSendToClient": "默认使用快速推送",
-      "quickSendToClientNote": "启用快速推送后，插件会在推送下载任务时，做以下默认操作：<br />1. 展平 下载器和下载目录 选项供直接点击推送。<br />2. 鼠标移到选项时，则会暂开标签列表，点击时会额外添加标签信息。<br />3. 均采用本地中转模式推送种子，且 `是否自动开始下载` 等基本设置项和下载器专有配置项值由下载器设置和站点设置决定。"
-    },
-    "userInfo": {
-      "userDataRefresh": "用户数据刷新",
-      "afterTime": "每日最早刷新时间",
-      "userInfoDisplay": "用户信息展示"
-    }
+  "connectCheck": {
+    "default": "检查连接性",
+    "error": "连接失败！请检查填写的信息或者你的远程服务器。",
+    "success": "连接成功，你可以顺利进行下一步。"
   },
-  "SetNativeBridge": {
-    "permission": {
-      "title": "权限",
-      "granted": "已授权",
-      "notGranted": "未授权",
-      "grant": "授予权限",
-      "revoke": "撤销权限",
-      "grantFailed": "权限请求被拒绝"
+  "contentScript": {
+    "AdvanceListModuleDialog": {
+      "selectNotSeeding": "勾选未下载过",
+      "selectSeeders": "勾选上传行",
+      "selectedInfo": "已选中：{0} 个种子，总大小：{1}",
+      "title": "为 {0} 个种子自定义批量操作行为"
     },
-    "bridge": {
-      "title": "通信桥控制",
-      "enabled": "启用原生通信桥",
-      "testConnection": "测试连接",
-      "status": {
-        "no-permission": "未授权",
-        "disabled": "已禁用",
-        "connecting": "连接中...",
-        "connected": "已连接",
-        "retrying": "重试中...",
-        "error": "错误"
-      }
+    "SocialSiteParseResultsDialog": {
+      "searchExternalId": "搜索外部ID",
+      "searchId": "搜索ID",
+      "searchTitle": "搜索标题",
+      "title": "快速搜索"
     },
-    "info": {
-      "title": "关于原生通信桥",
-      "description": "原生通信桥允许 PT-Depiler CLI 工具与本扩展进行通信。需要在电脑上单独安装 CLI 工具。",
-      "cliRequired": "此功能需要安装外部 CLI 工具。移动平台上不可用。安装说明请参考 {0}。",
-      "cliLink": "ptd-cli",
-      "setupCommand": "运行以下命令将此扩展注册到 CLI 工具：",
-      "setupHint": "运行命令后，重启浏览器或点击测试连接。",
-      "privacy": "启用后，原生通信桥允许本地安装的 CLI 工具访问扩展数据，包括站点配置、搜索结果、下载历史、用户信息和下载器状态。所有通信均在本地进行（浏览器与本机进程之间），不会将数据发送至任何远程服务器。您可以随时禁用此功能或撤销权限。"
-    }
+    "advanceList": "高级列表",
+    "cannotParseDetailLink": "无法解析当前页面种子链接",
+    "copyLink": "复制链接",
+    "copyLinkFailed": "复制下载链接失败",
+    "copyLinkSuccess": "下载链接已复制到剪贴板",
+    "noTorrentParsed": "未解析到当前页面种子",
+    "openPTD": "打开PTD",
+    "parsePageFailed": "页面解析失败",
+    "parseResultEmpty": "未能解析出结果",
+    "pushTo": "推送到...",
+    "pushToDefault": "推送到默认下载器",
+    "quickSearch": "快捷搜索"
   },
-  "SetDownloader": {
-    "add": {
-      "NoneSelectNotice": "请选择一个服务器类型",
-      "selectPlaceholder": "@:SetDownloader.add.NoneSelectNotice （支持搜索）",
-      "newType": "找不到想要的服务器类型？来这里添加吧！",
-      "step": {
-        "selectType": "选择服务器类型",
-        "setOptions": "详细配置"
-      },
-      "title": "新增下载服务器"
-    },
-    "common": {
-      "address": "服务器地址",
-      "name": "服务器名称",
-      "uid": "服务器ID",
-      "status": "服务器状态"
-    },
-    "delete": {
-      "text": "确认删除这 {0} 个下载服务器吗？"
-    },
-    "edit": {
-      "title": "编辑下载服务器"
-    },
-    "editor": {
-      "addressTip": "完整的服务器地址（含端口），如：http://192.168.1.1:5000/",
-      "autoStart": "发送种子时自动开始下载",
-      "nameTip": "取一个好听又好分辨的名称",
-      "password": "密码",
-      "timeout": "超时时长（秒）",
-      "uidPlaceholder": "（自动生成）"
-    },
-    "index": {
-      "editDefaultDownloaderBtn": "默认下载服务器设置",
-      "changeDefaultDownloader": "更新默认下载服务器成功！如有必要请进一步设置下载地址和标签。",
-      "emptyNotice": "在使用推送服务之前，您至少需要添加一个下载服务器。",
-      "remove": {
-        "multi": "你确定删除这{count}个下载服务器吗？",
-        "single": "确认要删除这个下载服务器吗？"
-      },
-      "table": {
-        "enabled": "启用？",
-        "autodl": "自动下载？",
-        "action": {
-          "status": "状态",
-          "setPathAndTag": "设置预设的下载路径和标签",
-          "deleteDownloader": "删除该下载服务器",
-          "setDefault": "设置为默认下载服务器"
+  "downloaderLabel": {
+    "localDownload": "本地下载"
+  },
+  "layout": {
+    "header": {
+      "emptySearchNotice": "获取各站第一页种子",
+      "expand": "展开更多",
+      "home": "主页",
+      "hotRecommendations": {
+        "category": {
+          "anime": "动画",
+          "movie": "电影",
+          "tv": "电视剧",
+          "variety": "综艺"
         },
-        "downloaderCategory": "下载器分类"
-      }
+        "empty": "暂无热门推荐",
+        "loadFailed": "热门推荐加载失败，请稍后重试",
+        "loading": "正在加载热门推荐...",
+        "noRating": "暂无评分",
+        "noSummary": "暂无简介",
+        "refresh": "刷新热门推荐",
+        "title": "热门推荐"
+      },
+      "navBarTip": "点击显示/隐藏导航栏",
+      "searchPlan": {
+        "all": "@:manifest.searchPlanAll",
+        "default": "@:manifest.searchPlanDefault",
+        "singleSite": "@:manifest.searchPlanSingleSite"
+      },
+      "searchTip": "输入种子关键字、IMDb编号进行搜索",
+      "wiki": "帮助",
+      "wrongPixelRatioNotice": "检测到您的页面展示可能受到缩放影响，建议您将当前页面缩放调整为100%，以保障您的浏览体验～"
     },
-    "PathAndTag": {
-      "title": "为下载器 [{0}] @:SetDownloader.index.table.action.setPathAndTag",
-      "supportDragNote": "（支持拖拽排序）",
-      "downloadPath": {
-        "title": "下载路径",
-        "addTitle": "已添加的@:SetDownloader.PathAndTag.downloadPath.title@:SetDownloader.PathAndTag.supportDragNote",
-        "addInputLabel": "添加@:SetDownloader.PathAndTag.downloadPath.title",
-        "autoImport": "一键导入下载器中已有的@:SetDownloader.PathAndTag.downloadPath.title",
-        "autoImportFail": "@:SetDownloader.PathAndTag.downloadPath.autoImport 失败，请手动添加。",
-        "clear": "清空@:SetDownloader.PathAndTag.downloadPath.title"
-      },
-      "tags": {
-        "title": "标签",
-        "addTitle": "已添加的@:SetDownloader.PathAndTag.tags.title@:SetDownloader.PathAndTag.supportDragNote",
-        "addInputLabel": "添加@:SetDownloader.PathAndTag.tags.title",
-        "autoImport": "一键导入下载器中已有的@:SetDownloader.PathAndTag.tags.title",
-        "autoImportFail": "@:SetDownloader.PathAndTag.tags.autoImport 失败，请手动添加。",
-        "clear": "清空@:SetDownloader.PathAndTag.tags.title"
-      },
-      "note": {
-        "title": "说明",
-        "index": "@:SetDownloader.PathAndTag.downloadPath.title 或 @:SetDownloader.PathAndTag.tags.title 中可包含以下关键字：",
-        "table": {
-          "keywords": "关键词",
-          "note": "说明",
-          "example": "示例"
-        },
-        "replaceNote": {
-          "torrentTitle": "该种子的标题",
-          "torrentSubTitle": "该种子的副标题",
-          "torrentSite": "该种子的站点id",
-          "torrentSiteName": "该种子的站点名称",
-          "searchKeyword": "当前搜索关键字",
-          "searchPlan": "当前搜索方案名称",
-          "dateYear": "当前年份",
-          "dateMonth": "当前月份",
-          "dateDay": "当前日份",
-          "custom": "自定义的内容替换"
-        }
-      }
+    "init": "请耐心等待页面加载.....",
+    "releaseNote": {
+      "changelog": "更新日志",
+      "currentVersion": "（当前版本）",
+      "faq": "常见问题",
+      "startUsing": "开始使用",
+      "title": "欢迎使用 {extName}",
+      "wiki": "Wiki 帮助"
     }
   },
-  "SetSearchSolution": {
-    "solution": "搜索方案",
-    "copy": "创建副本",
-    "table": {
-      "enable": "启用？",
-      "default": "默认？",
-      "autoGenerate": "自动生成"
-    },
-    "edit": {
-      "title": "自定义 @:SetSearchSolution.solution",
-      "addCount": "已添加 @:SetSearchSolution.solution {0} 个",
-      "cantAddByDuplicateNote": "已存在相同的 @:SetSearchSolution.solution ，无法重复添加。",
-      "filterPlaceholder": "通过站点名称或 url 进行搜索"
-    },
-    "delete": {
-      "text": "确认删除这 {0} 个 @:SetSearchSolution.solution 吗？"
-    },
-    "spDialog": {
-      "noDefNotice": "该站点未定义搜索模块，请到项目仓库提供帮助！",
-      "notice": "不推荐在此处进行设置，更建议在对应站点的个人设置中配置或使用插件提供的搜索方案功能！",
-      "selectAllNotice": "（注意：在大多数情况下，你并不需要全选所有搜索项！）",
-      "title": "配置站点默认搜索模式 - {name}",
-      "action": {
-        "reset": "重置此@:SetSearchSolution.solution",
-        "create": "基于此创建自定义@:SetSearchSolution.solution",
-        "add": "添加此@:SetSearchSolution.solution"
-      }
-    },
-    "CustomSolutionDialog": {
-      "title": "自定义搜索方案",
-      "solutionName": "方案名称",
-      "requestConfig": "请求配置",
-      "requestConfigHint": "请按JSON格式配置请求参数",
-      "requestConfigJsonError": "必须是合法的JSON格式"
-    },
-    "newSolutionNamePrompt": "请输入新搜索方案名称"
+  "levelRequirement": {
+    "adoptions": "认领数",
+    "averageSeedingTime": "平均做种时间",
+    "bonus": "积分",
+    "bonusPerHour": "时魔值",
+    "downloaded": "下载量",
+    "hnrPreWarning": "H&R 预警的数量",
+    "hnrUnsatisfied": "H&R 未满足的数量",
+    "interval": "需要等待的日期",
+    "leeching": "下载数量",
+    "posts": "发布帖子数",
+    "ratio": "分享率",
+    "seeding": "做种数",
+    "seedingBonus": "做种积分",
+    "seedingSize": "做种量",
+    "seedingTime": "做种时间",
+    "snatches": "完成种子数",
+    "totalTraffic": "总流量",
+    "trueDownloaded": "真实下载量",
+    "trueRatio": "真实分享率",
+    "trueUploaded": "真实上传量",
+    "uploaded": "上传量",
+    "uploads": "发布数"
   },
-  "SetSite": {
-    "add": {
-      "selectSitePlaceholder": "请选择一个站点（支持搜索）",
-      "title": "添加站点"
-    },
-    "common": {
-      "aka": "站点别名",
-      "allowQueryUserInfo": "获取个人信息",
-      "allowSearch": "允许搜索",
-      "isOffline": "已离线",
-      "name": "站点名称",
-      "showMessageCount": "信息提醒",
-      "tags": "标签",
-      "url": "网站链接",
-      "groups": "站点分类",
-      "allowContentScript": "加载侧边栏",
-      "open": "打开"
-    },
-    "delete": {
-      "text": "确认删除这 {0} 个站点吗？"
-    },
-    "edit": {
-      "title": "编辑站点配置"
-    },
-    "editor": {
-      "addUrlTip": "增加一个你正在使用的站点域名，输入的应该以 https:// 或 http:// 开头，以 / 结尾，例如 https://example.com/",
-      "customUrlPlaceholder": "自定义站点域名",
-      "description": "网站描述",
-      "sortIndexTip": "可用于搜索排序",
-      "tagTip": "标签输入完成后按回车添加。（只有前4个会在列表页显示）",
-      "timezone": "时区",
-      "uploadSpeedLimit": "上传速度",
-      "uploadSpeedLimitHint": "设置向下载器推送种子时的上传速度限制 (MiB/s)，0或不填时不限速"
-    },
-    "index": {
-      "flushFaviconFinish": "所选站点的图标已成功刷新！",
-      "table": {
-        "searchEntries": "搜索入口",
-        "flushFavicon": "刷新站点图标"
-      },
-      "settingNote": ["只有配置过的站点才会显示插件图标及相应的功能；", "已离线的站点不再参与搜索和信息获取；"],
-      "oneClickImport": "一键导入站点",
-      "reBuildMap": "重建站点映射"
-    },
-    "oneClickImportDialog": {
-      "title": "一键导入站点",
-      "alert1": "此操作会尝试以默认配置导入你选择的站点，请确保该站点已在浏览器上登录过。导入过程不能中断，请耐心等待。",
-      "alert2": "未添加的站点列表",
-      "stats": "已选择 {count} 个站点，已添加 {success} 个站点，添加失败 {failed} 个站点。",
-      "trying": "正在尝试导入站点 [{name}] ...",
-      "status": {
-        "manual": "该站点需要手动添加",
-        "trying": "正在尝试中",
-        "success": "已添加成功",
-        "failed": "添加失败",
-        "selected": "已选择"
-      },
-      "importComplete": "一键导入完成，成功添加 {count} 个站点"
-    },
-    "ReBuildMapDialog": {
-      "title": "重建站点映射关系缓存",
-      "rebuildSiteHostMap": "重建站点域名关系缓存",
-      "rebuildSiteNameMap": "重建站点名称关系缓存",
-      "doRebuildBtn": "重建"
-    },
-    "SiteCategoryPanel": {
-      "siteDefault": "站点默认"
-    },
-    "AddDialog": {
-      "showDeadSite": "展示已死亡站点"
-    },
-    "Editor": {
-      "siteSettings": "站点设置",
-      "otherSettings": "其他设置",
-      "downloadLinkSuffix": "下载链接后缀",
-      "downloadLinkSuffixHint": "该字段会被自动添加到该站点的下载链接后",
-      "downloadLinkSuffixExample": "如插件获得的链接为 https://example.com/download.php?id=1，此处设置为 &passkey=xxxx， 则最终下载链接为 https://example.com/download.php?id=1&passkey=xxxx. 通常无须填写，仅在无法获得 passkey 时可手动添加",
-      "requestTimeout": "请求超时",
-      "requestTimeoutHint": "影响该站点请求（种子搜索、用户信息获取）的超时等待时间",
-      "downloadInterval": "下载间隔",
-      "downloadIntervalHint": "影响该站点的下载间隔时间（为了安全考虑，插件不会严格遵守该设置，实际间隔总是会略大于等于设置的间隔）"
-    }
-  },
-  "SetBackup": {
-    "table": {
-      "backupFields": "备份内容",
-      "lastBackupAt": "最近一次备份时间",
-      "notBackup": "未备份",
-      "action": {
-        "backupNow": "立即备份",
-        "viewHistoryBackup": "查看历史备份"
-      }
-    },
-    "localExport": "本地导出",
-    "localImport": "本地导入",
-    "snackbar": {
-      "success": "备份成功",
-      "failure": "备份失败"
-    },
-    "AddDialog": {
-      "title": "添加备份服务器"
-    },
-    "Editor": {
-      "serverConfig": "服务器配置",
-      "backupConfig": "备份配置"
-    },
-    "HistoryDialog": {
-      "title": "{name} 的历史备份",
-      "restore": "恢复备份",
-      "deleteSuccess": "删除备份历史 [{name}] 成功",
-      "deleteFailure": "删除备份历史 [{name}] 失败",
-      "table": {
-        "filename": "备份文件名",
-        "size": "备份大小",
-        "time": "备份时间"
-      }
-    },
-    "LocalExportConfirmDialog": {
-      "title": "请选择本地需要导出的内容"
-    },
-    "RestoreDialog": {
-      "title": "从备份文件中恢复",
-      "ptppPrompt": "需要导入 PT-Plugin-Plus 备份？",
-      "ptppImport": "PT-Plugin-Plus 备份导入",
-      "selectFile": "选择备份文件",
-      "decryptKey": "解密密钥",
-      "retry": "重试",
-      "restoreOptions": "恢复选项",
-      "expandCookieMinutes": "尝试延长Cookies期限（单位：分钟）",
-      "keepExistUserInfo": "保留本地已获取过的用户信息",
-      "missingVersion": "备份数据缺少版本信息，无法恢复",
-      "versionWarning": "备份数据版本高于当前扩展版本，恢复可能会导致数据不兼容或丢失，是否继续？",
-      "success": "恢复成功",
-      "failure": "恢复失败: {error}",
-      "loadFailure": "加载失败: {error}"
-    }
-  },
-  "userInfo": {
-    "queueConcurrency": "请求队列长度",
-    "enableAutoRefresh": "是否启用后台定时刷新？",
-    "autoRefresh": {
-      "every": "每隔",
-      "hoursLabel": "小时自动刷新一次当天",
-      "unrefreshedSite": "未刷新过",
-      "ofSites": "的站点",
-      "retryOnFail": "如果刷新失败，则重试",
-      "times": "次，每次间隔",
-      "minutes": "分钟。",
-      "lastFlushTime": "最近一次刷新时间:",
-      "nextFlushTime": "下一次检查时间:",
-      "getNextFlushTime": "获取下一次检查时间"
-    },
-    "alwaysPickLastUserInfo": "刷新用户数据时尽可能使用已有的历史信息",
-    "showDeadSite": "在概览中展示已被标记为死亡 （isDead） 的站点",
-    "showPassedSite": "在概览中展示已被标记为离线 （isOffline） 或不允许查询用户信息的站点",
-    "autoExtendCookies": {
-      "enabled": "是否启用自动延长cookies周期？",
-      "triggerThreshold": "当cookies剩余有效期少于",
-      "extensionDuration": "自动延长其有效期",
-      "weeks": "周，",
-      "months": "个月。"
-    }
+  "manifest": {
+    "contextMenuSearch": "使用 PT Depiler 搜索 \"%s\" 相关的种子",
+    "contextMenuSearchInDefault": "在默认方案中搜索",
+    "contextMenuSearchInSite": "在指定站点中搜索",
+    "contextMenuSearchInSolution": "在指定方案中搜索",
+    "contextMenuSearchInThisSite": "在本站点中搜索",
+    "contextMenuSearchWithDouban": "使用 PT Depiler 搜索当前豆瓣链接相关种子",
+    "contextMenuSearchWithIMDb": "使用 PT Depiler 搜索IMDb链接相关种子",
+    "contextMenuSendToDownloader": "使用 PT Depiler 下载链接",
+    "contextMenuSendToDownloaderAdvanced": "高级推送",
+    "contextMenuSendToDownloaderDefaultFolder": "默认路径",
+    "contextMenuSendToDownloaderIn": "推送到 $1 -> $2",
+    "extDesc": "PT Depiler",
+    "extName": "PT Depiler",
+    "notificationSendLinkToDownloaderFailure": "将链接发送到下载器 [$1] 失败",
+    "notificationSendLinkToDownloaderSuccess": "已成功将链接发送到下载器 [$1]",
+    "omniboxSearch": "在 [ $1 ] 中搜索 $2",
+    "searchPlanAll": "全部站点",
+    "searchPlanDefault": "默认",
+    "searchPlanSingleSite": "单个站点"
   },
   "ptppSettings": {
+    "RestorePtppUserDataDialog": {
+      "importCancelled": "导入操作已取消。",
+      "importFailure": "导入失败。",
+      "importSuccess": "导入成功，窗口将在 5s 后自动关闭，请刷新页面。",
+      "noSiteWarning": "你似乎还没有添加任何站点，这可能导致导入异常，是否继续？",
+      "notSupported": "该站点暂不支持",
+      "overwriteExisting": "是否覆盖已有数据",
+      "pendingImportData": "待导入数据",
+      "recordCount": "{0}条",
+      "selected": "已选择",
+      "title": "恢复 PT-Plugin-Plus 的用户历史数据信息"
+    },
     "basicConfig": "基本配置",
-    "saveKeyNotice": "注意：密钥仅保存在当前浏览器，不会备份，请妥善保存；加密后如密钥丢失将无法恢复数据。留空表示不做加密。",
     "encryptionKeyLabel": "备份文件加密、解密密钥",
-    "undoKeyTitle": "恢复上一个密钥",
-    "randomGenTitle": "随机生成",
-    "invalidFileFormat": "文件格式错误，请检查是否按正确步骤（关闭备份加密功能）导出备份。",
-    "importConfigTitle": "PT-Plugin-Plus 配置导入",
     "importConfigInfoLine1": "{repoName} 只能导入原 PT-Plugin-Plus 的用户历史数据信息，其他配置文件不支持导入。",
     "importConfigInfoPrep": "在导入之前，请做好以下准备：",
+    "importConfigTitle": "PT-Plugin-Plus 配置导入",
     "importStep1": "请先备份好当前 {repoName} 的配置文件。",
     "importStep2": "在 {repoName} 的站点设置中添加需要恢复的站点。（如果没有添加站点，对应的用户历史数据会被忽略）",
     "importStep3": "在 PT-Plugin-Plus 中，关闭备份加密功能，并导出本地备份文件。其应该是一个名为 <code>PT-Plugin-Plus-Backup-yyyy-MM-DD_hh-mm-ss.zip</code> 的 zip 压缩文件。",
     "importStep4": "将压缩包或者从压缩包中解压出的 <code>userdatas.json</code> 文件，上传到下面的输入框中。",
+    "invalidFileFormat": "文件格式错误，请检查是否按正确步骤（关闭备份加密功能）导出备份。",
+    "randomGenTitle": "随机生成",
+    "saveKeyNotice": "注意：密钥仅保存在当前浏览器，不会备份，请妥善保存；加密后如密钥丢失将无法恢复数据。留空表示不做加密。",
     "selectBackupFile": "选择 PTPP 备份文件",
-    "RestorePtppUserDataDialog": {
-      "title": "恢复 PT-Plugin-Plus 的用户历史数据信息",
-      "pendingImportData": "待导入数据",
-      "notSupported": "该站点暂不支持",
-      "selected": "已选择",
-      "noSiteWarning": "你似乎还没有添加任何站点，这可能导致导入异常，是否继续？",
-      "importCancelled": "导入操作已取消。",
-      "importSuccess": "导入成功，窗口将在 5s 后自动关闭，请刷新页面。",
-      "importFailure": "导入失败。",
-      "overwriteExisting": "是否覆盖已有数据",
-      "recordCount": "{0}条"
+    "undoKeyTitle": "恢复上一个密钥"
+  },
+  "resultParseStatus": {
+    "CFBlocked": "CloudFlare 错误！",
+    "CFBlockedNotes": "CloudFlare 返回的错误，可能是因为站点启用了 CloudFlare 的安全防护，导致无法获取数据。可以先尝试手动访问一次站点，以通过 CF 验证。如果不起作用，请等待站点自行恢复。",
+    "needLogin": "需要登录！",
+    "noResults": "无结果！",
+    "parseError": "解析错误！",
+    "passParse": "跳过！",
+    "success": "获取成功！",
+    "unknown": "未知状态！",
+    "unknownError": "未知错误！",
+    "waiting": "队列等待中...",
+    "working": "正在获取中..."
+  },
+  "route": {
+    "About": {
+      "Logger": "插件运行日志",
+      "SpecialThank": "特别感谢",
+      "TechnologyStack": "项目参考与引用",
+      "default": "插件相关"
+    },
+    "Devtools": {
+      "Debugger": "调试信息",
+      "SystemLog": "系统日志",
+      "default": "开发工具"
+    },
+    "Overview": {
+      "DownloadHistory": "下载历史",
+      "KeepUploadTask": "辅种任务",
+      "MediaServerEntity": "媒体库",
+      "MyClient": "我的下载器",
+      "MyCollection": "收藏列表",
+      "MyData": "我的数据",
+      "SearchEntity": "搜索结果",
+      "SearchResultSnapshot": "搜索结果快照",
+      "default": "概览"
+    },
+    "Settings": {
+      "SetBackup": "参数备份与恢复",
+      "SetBase": "常规设置",
+      "SetDownloader": "下载器设置",
+      "SetMediaServer": "媒体服务器设置",
+      "SetSearchSolution": "搜索方案定义",
+      "SetSite": "站点设置",
+      "default": "参数设置"
     }
   },
   "socialConfig": {
-    "basicConfig": "基本配置",
-    "cacheValidityDays": "缓存有效期（天）",
-    "cacheShortWarning": "缓存时间过短会导致频繁请求，过长会导致数据不及时",
-    "requestTimeoutMs": "请求超时时间 (毫秒)",
-    "ptgenConfig": "PtGen 配置",
-    "preferPtgenLabel": "优先使用 PtGen 提供的数据",
-    "ptgenApiAddress": "PtGen API 地址",
-    "ptgenApiMessages": "选择内置地址或输入类似 https://example.com/ptgen?site=<site>&sid=<sid> 的地址",
-    "mediaRatingConfig": "各媒体评分站点配置",
     "anidbClientId": "AniDB Client ID",
     "anidbClientMessages": "请在 https://anidb.net/perl-bin/animedb.pl?show=client 中申请 Client ID， 并按照 `Name/Version` 的格式填写",
     "bangumiApiKey": "Bangumi API Key",
-    "bangumiApiMessages": "你可以在 https://next.bgm.tv/demo/access-token 生成一个 Access Token"
+    "bangumiApiMessages": "你可以在 https://next.bgm.tv/demo/access-token 生成一个 Access Token",
+    "basicConfig": "基本配置",
+    "cacheShortWarning": "缓存时间过短会导致频繁请求，过长会导致数据不及时",
+    "cacheValidityDays": "缓存有效期（天）",
+    "mediaRatingConfig": "各媒体评分站点配置",
+    "preferPtgenLabel": "优先使用 PtGen 提供的数据",
+    "ptgenApiAddress": "PtGen API 地址",
+    "ptgenApiMessages": "选择内置地址或输入类似 https://example.com/ptgen?site=<site>&sid=<sid> 的地址",
+    "ptgenConfig": "PtGen 配置",
+    "requestTimeoutMs": "请求超时时间 (毫秒)"
   },
-  "contentScript": {
-    "openPTD": "打开PTD",
-    "noTorrentParsed": "未解析到当前页面种子",
-    "cannotParseDetailLink": "无法解析当前页面种子链接",
-    "parseResultEmpty": "未能解析出结果",
-    "parsePageFailed": "页面解析失败",
-    "copyLinkSuccess": "下载链接已复制到剪贴板",
-    "copyLinkFailed": "复制下载链接失败",
-    "copyLink": "复制链接",
-    "pushTo": "推送到...",
-    "pushToDefault": "推送到默认下载器",
-    "quickSearch": "快捷搜索",
-    "advanceList": "高级列表",
-    "AdvanceListModuleDialog": {
-      "title": "为 {0} 个种子自定义批量操作行为",
-      "selectSeeders": "勾选上传行",
-      "selectNotSeeding": "勾选未下载过",
-      "selectedInfo": "已选中：{0} 个种子，总大小：{1}"
-    },
-    "SocialSiteParseResultsDialog": {
-      "title": "快速搜索",
-      "searchId": "搜索ID",
-      "searchExternalId": "搜索外部ID",
-      "searchTitle": "搜索标题"
-    }
-  },
-  "SentToDownloaderDialog": {
-    "title": "为 {0} 个种子选择下载器",
-    "isSending": "正在向下载器 {name} [{address}] 发送种子，请稍候...",
-    "selectDownloaderFirst": "请先选择下载器",
-    "noDownloader": "没有可用的下载器，请先在设置中添加下载器。",
-    "selectDownloader": "选择下载器",
-    "savePath": "保存路径",
-    "savePathHint": "不设置则为该下载服务器的默认路径",
-    "label": "种子标签",
-    "labelHint": "（如果该下载服务器支持）",
-    "localRelay": "本地中转",
-    "pauseOnAdd": "添加时默认暂停",
-    "moreOptions": "更多选项"
-  },
-  "ContextMenuLinkPush": {
-    "invalidLink": "无效的下载链接",
-    "keywordWarning": "右键推送链接时，部分 下载路径或标签的 关键字功能可能无法正常工作！"
-  },
-  "SetMediaServer": {
-    "add": {
-      "title": "添加媒体服务器"
-    },
-    "Editor": {
-      "authInfo": "认证信息"
-    }
-  },
-  "Debugger": {
-    "title": "调试页面！！！！",
-    "consoleOutput": "所有输出均在console面板！！！",
-    "enableLibrary": "启用开发库",
-    "libraryList": "在console中启用 sendMessage, axios, Sizzle, es-toolkit ( as _ ）, datefns 等方法",
-    "debugBuiltinSite": "调试内置站点",
-    "mergeUserConfig": "合并用户配置",
-    "outputSiteDefinition": "输出站点定义",
-    "outputUserConfig": "输出用户配置信息",
-    "outputSiteInstance": "输出站点实例",
-    "outputFavicon": "输出Favicon",
-    "debug": "调试{serverType}",
-    "addServerFirst": "请先在 Set{serverType} 页面添加服务器",
-    "outputConfig": "输出用户配置信息",
-    "outputInstance": "输出 {serverType} 实例",
-    "debugPinia": "调试Pinia",
-    "outputPinia": "输出Pinia信息",
-    "pluginReset": "插件重置",
-    "dangerWarning": "极其危险！！！！",
-    "confirmReset": "确定要重置吗？",
-    "resetSuccess": "重置成功",
-    "selectSite": "选择站点",
-    "siteAll": "全部",
-    "resetItems": {
-      "resetSystemSettings": "重置系统设置",
-      "resetSystemSettingsDesc": "重置所有系统设置（包括但不限于语言、主题、表格展示、图片样式等常规设置）为默认值",
-      "clearUserConfig": "清空用户配置",
-      "clearUserConfigDesc": "清空所有用户配置（包括但不限于站点、下载器、搜索方案及默认值、搜索快照元数据、最近一次用户信息）",
-      "clearSiteData": "清空站点数据",
-      "clearSiteDataDesc": "清空用户获取的站点数据（包括用户信息历史记录和最近一次用户信息）",
-      "clearDownloadHistory": "清空历史下载记录",
-      "clearFaviconCache": "清空站点 Favicon 缓存",
-      "clearMediaCache": "清空来自豆瓣、IMDb等信息站点的媒体简介缓存",
-      "clearSearchSnapshot": "清空搜索快照",
-      "clearSearchSnapshotDesc": "清空所有搜索快照数据"
-    }
-  },
-  "MyClient": {
-    "refresh": "刷新",
-    "deleteSelected": "删除",
-    "searchPlaceholder": "搜索种子名称、Hash、标签、路径",
-    "table": {
-      "client": "下载器",
-      "name": "种子名称",
-      "size": "大小",
-      "progress": "进度",
-      "status": "状态",
-      "ratio": "分享率",
-      "upSpeed": "上传速度",
-      "dlSpeed": "下载速度",
-      "savePath": "保存路径",
-      "addedAt": "添加时间",
-      "totalUploaded": "总上传量",
-      "totalDownloaded": "总下载量"
-    },
-    "state": {
+  "torrent": {
+    "status": {
+      "completed": "已完成",
       "downloading": "下载中",
+      "inactive": "未活动",
       "seeding": "做种中",
-      "paused": "已暂停",
-      "queued": "排队中",
-      "checking": "检查中",
-      "error": "错误",
       "unknown": "未知"
-    },
-    "action": {
-      "pause": "暂停",
-      "resume": "开始",
-      "delete": "删除",
-      "pauseSuccess": "暂停成功",
-      "pauseError": "暂停失败",
-      "resumeSuccess": "开始成功",
-      "resumeError": "开始失败",
-      "pauseSelectedSuccess": "已暂停 {count} 个种子",
-      "resumeSelectedSuccess": "已开始 {count} 个种子",
-      "viewRaw": "查看原始数据"
+    }
+  },
+  "userInfo": {
+    "alwaysPickLastUserInfo": "刷新用户数据时尽可能使用已有的历史信息",
+    "autoExtendCookies": {
+      "enabled": "是否启用自动延长cookies周期？",
+      "extensionDuration": "自动延长其有效期",
+      "months": "个月。",
+      "triggerThreshold": "当cookies剩余有效期少于",
+      "weeks": "周，"
     },
     "autoRefresh": {
-      "btnTitle": "自动刷新",
-      "intervalLabel": "刷新间隔",
-      "intervalUnit": "秒（0 表示关闭）",
-      "start": "开始自动刷新",
-      "stop": "停止自动刷新",
-      "clientSuspended": "{name} 刷新失败 3 次，已暂停自动刷新。点击下载器标签可恢复。",
-      "suspendedTip": "该下载器已因连续失败 3 次而被暂停。点击感叹号图标可恢复。",
-      "resumeDownloader": "恢复该下载器的自动刷新",
-      "stopDownloader": "停止该下载器的自动刷新",
-      "downloaderFilter": "下载器筛选"
+      "every": "每隔",
+      "getNextFlushTime": "获取下一次检查时间",
+      "hoursLabel": "小时自动刷新一次当天",
+      "lastFlushTime": "最近一次刷新时间:",
+      "minutes": "分钟。",
+      "nextFlushTime": "下一次检查时间:",
+      "ofSites": "的站点",
+      "retryOnFail": "如果刷新失败，则重试",
+      "times": "次，每次间隔",
+      "unrefreshedSite": "未刷新过"
     },
-    "pauseSelected": "暂停",
-    "resumeSelected": "开始",
-    "dialog": {
-      "removeData": "同时删除数据"
-    },
-    "pushToDownloader": {
-      "navBtn": "推送到下载器",
-      "title": "推送到下载器",
-      "modeUrl": "链接 / 磁力",
-      "modeFile": "种子文件",
-      "urlInputLabel": "下载链接 / 磁力链接",
-      "urlInputHint": "每行一个链接或磁力链接",
-      "fileInputLabel": "种子文件",
-      "fileInputHint": "选择一个或多个 .torrent 文件进行推送"
-    },
-    "columnSelector": "自定义列",
-    "clientStatusDialog": {
-      "title": "下载器状态",
-      "openBtn": "全部下载器状态",
-      "torrentCount": "{count} 个种子",
-      "openClient": "打开下载器"
-    }
+    "enableAutoRefresh": "是否启用后台定时刷新？",
+    "queueConcurrency": "请求队列长度",
+    "showDeadSite": "在概览中展示已被标记为死亡 （isDead） 的站点",
+    "showPassedSite": "在概览中展示已被标记为离线 （isOffline） 或不允许查询用户信息的站点"
   }
 }


### PR DESCRIPTION
写在最前面：

这是一个妥协或者说折中的pr，具体原因我大概在 #454 中讲过，即 原PTPP中以一个方案对应捆绑多个站点+多个下载器是一种很奇怪的设计，且过于复杂。PTD 在最初设计的时候，主要是围绕 options 页面的聚合搜索来实现的，这种情况下，会使得对应的推送逻辑很难梳理（跨站点勾选种子时，对应应该展示那些下载器和那些路径、标签）。另一方面，PTD比PTPP多支持一个标签的推送属性，这使得相关设计会更加麻烦。

所以，我一直坚持 site 是 site， downloader 的归 downloader， 额外的捆绑是不需要的。

当然，不可否认，确实有相关的需求，正如 #454 , #860 , #1287 等。在 content-script 层面，只需要考虑单个站点时，这样在操作上会更加便捷。这样也间接的实现了原先PTPP中的对应设计（只需要你使用多添加几个相同配置的下载客户端，并配置不同的站点排除和路径、标签设置即可）。

closed: #860

-----------------

## Summary by Sourcery

Add per-site downloader exclusion support and use site-aware enabled downloader lists across download dialogs and content scripts.

New Features:
- Allow configuring which sites each downloader is excluded from via a new site filter dialog in downloader settings.
- Add a global setting to enable per-site downloader filtering and store excluded site IDs on downloader metadata.
- Filter enabled downloaders by current site in download dialogs and content scripts, including default and quick-send actions.

Enhancements:
- Adjust downloader selection and empty-state messaging in the send-to-downloader dialog to respect per-site filtering and sorting.
- Improve settings UI layout and toggle controls related to download and content script options.