### PR TITLE
feat(torrentTags): 优化tags的显示

### DIFF
--- a/src/entries/options/components/TorrentTitleTd.vue
+++ b/src/entries/options/components/TorrentTitleTd.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { reactive, useTemplateRef } from "vue";
+import { reactive, ref, computed, useTemplateRef } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import { useElementSize } from "@vueuse/core";
@@ -30,6 +30,36 @@ interface ISocialInformationData extends ISocialInformation {
 
 // @ts-ignore
 const socialInformation = reactive<Record<TSupportSocialSite | string, ISocialInformationData>>({});
+
+const tagsExpanded = ref(false);
+
+const visibleTags = computed(() => {
+  const tags = item.tags;
+  if (!tags || !tags.length) return [];
+  const hiddenNames = configStore.searchEntifyControl.hiddenTagNames || [];
+  return tags.filter((tag) => !hiddenNames.includes(tag.name));
+});
+
+const maxTagCount = computed(() => configStore.searchEntifyControl.maxTagCountBeforeGroup || 0);
+
+const displayedTags = computed(() => {
+  if (!maxTagCount.value || maxTagCount.value >= visibleTags.value.length || tagsExpanded.value) {
+    return visibleTags.value;
+  }
+  return visibleTags.value.slice(0, maxTagCount.value);
+});
+
+const hasMoreTags = computed(
+  () => maxTagCount.value > 0 && visibleTags.value.length > maxTagCount.value && !tagsExpanded.value,
+);
+
+const hiddenTagCount = computed(() => visibleTags.value.length - maxTagCount.value);
+
+function tempHideTag(name: string) {
+  if (!configStore.searchEntifyControl.hiddenTagNames.includes(name)) {
+    configStore.searchEntifyControl.hiddenTagNames = [...configStore.searchEntifyControl.hiddenTagNames, name];
+  }
+}
 
 function loadSocialInformation(site: TSupportSocialSite) {
   if (item[`ext_${site}`] && !socialInformation[site]) {
@@ -157,8 +187,30 @@ function doAdvanceSearch(site: TSupportSocialSite, sid: string) {
       <!-- 种子标签信息 -->
       <div ref="tags">
         <template v-if="configStore.searchEntifyControl.showTorrentTag && item.tags && item.tags.length > 0">
-          <v-chip v-for="tag in item.tags" :color="tag.color" class="mr-1" label size="x-small">
-            {{ tag.name }}
+          <v-hover v-for="tag in displayedTags" :key="tag.name" v-slot:default="{ isHovering, props }">
+            <v-chip
+              v-bind="props"
+              :color="tag.color"
+              :closable="isHovering as unknown as boolean"
+              class="mr-1"
+              label
+              size="x-small"
+              @click:close="tempHideTag(tag.name)"
+            >
+              {{ tag.name }}
+            </v-chip>
+          </v-hover>
+          <v-chip
+            v-if="hasMoreTags"
+            class="mr-1"
+            label
+            size="x-small"
+            color="primary"
+            variant="tonal"
+            prepend-icon="mdi-arrow-expand-right"
+            @click="tagsExpanded = true"
+          >
+            {{ hiddenTagCount }}
           </v-chip>
         </template>
       </div>

--- a/src/entries/options/stores/config.ts
+++ b/src/entries/options/stores/config.ts
@@ -241,6 +241,8 @@ export const useConfigStore = defineStore("config", {
       socialInformationSearchOnNewTab: true,
       uploadAtFormatAsAlive: false,
       limitTorrentTitleTdWidth: false,
+      maxTagCountBeforeGroup: 0,
+      hiddenTagNames: [],
     },
 
     userInfo: {

--- a/src/entries/options/views/Overview/SearchEntity/AdvanceFilterGenerateDialog.vue
+++ b/src/entries/options/views/Overview/SearchEntity/AdvanceFilterGenerateDialog.vue
@@ -5,7 +5,7 @@
  * 如果需要忽略，目前只能重置过滤词。
  * refs: https://github.com/vuetifyjs/vuetify/blob/0ca7e93ad011b358591da646fdbd6ebe83625d25/packages/vuetify/src/components/VCheckbox/VCheckboxBtn.tsx#L49-L53
  */
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { addDays, startOfDay } from "date-fns";
 import { ETorrentStatus, preDefinedTorrentTagNameSet, sortTorrentTags } from "@ptd/site";
@@ -43,6 +43,13 @@ const statusOptions = [
 
 const torrentTags = computed(() => sortTorrentTags(advanceItemPropsRef.value.tags));
 
+const showHiddenTags = ref(false);
+
+const filteredTorrentTags = computed(() => {
+  const hiddenNames = configStore.searchEntifyControl.hiddenTagNames || [];
+  return torrentTags.value.filter((tag) => showHiddenTags.value || !hiddenNames.includes(tag.name));
+});
+
 function updateTableFilter() {
   updateTableFilterValueFn();
   showDialog.value = false;
@@ -67,10 +74,18 @@ function enterDialog() {
       <v-divider />
       <v-card-text>
         <v-container>
-          <v-row><v-label>{{ t("common.AdvanceFilterGenerateDialog.keywords") }}</v-label> </v-row>
+          <v-row
+            ><v-label>{{ t("common.AdvanceFilterGenerateDialog.keywords") }}</v-label>
+          </v-row>
           <v-row>
             <v-col cols="12" md="6">
-              <v-combobox v-model="advanceFilterDictRef.text.required" chips hide-details :label="t('common.AdvanceFilterGenerateDialog.required')" multiple />
+              <v-combobox
+                v-model="advanceFilterDictRef.text.required"
+                chips
+                hide-details
+                :label="t('common.AdvanceFilterGenerateDialog.required')"
+                multiple
+              />
             </v-col>
             <v-col cols="12" md="6">
               <v-combobox
@@ -83,7 +98,9 @@ function enterDialog() {
             </v-col>
           </v-row>
 
-          <v-row><v-label>{{ t("common.AdvanceFilterGenerateDialog.site") }}</v-label></v-row>
+          <v-row
+            ><v-label>{{ t("common.AdvanceFilterGenerateDialog.site") }}</v-label></v-row
+          >
           <v-row>
             <v-col
               v-for="site in advanceItemPropsRef.site"
@@ -111,10 +128,26 @@ function enterDialog() {
           </v-row>
 
           <template v-if="configStore.searchEntifyControl.showTorrentTag">
-            <v-row><v-label>{{ t("SearchEntity.AdvanceFilterGenerateDialog.tags") }}</v-label></v-row>
+            <v-row>
+              <v-label>{{ t("SearchEntity.AdvanceFilterGenerateDialog.tags") }}</v-label>
+              <v-spacer />
+              <v-btn
+                v-if="configStore.searchEntifyControl.hiddenTagNames?.length"
+                variant="text"
+                size="x-small"
+                color="info"
+                @click="showHiddenTags = !showHiddenTags"
+              >
+                {{
+                  showHiddenTags
+                    ? t("SearchEntity.AdvanceFilterGenerateDialog.hideHiddenTags")
+                    : t("SearchEntity.AdvanceFilterGenerateDialog.showHiddenTags")
+                }}
+              </v-btn>
+            </v-row>
             <v-row>
               <v-col
-                v-for="tag in torrentTags"
+                v-for="tag in filteredTorrentTags"
                 :key="`${reBuildFilterCountRef}_${tag.name}`"
                 class="pa-0"
                 cols="4"
@@ -145,7 +178,9 @@ function enterDialog() {
               </v-col>
             </v-row>
           </template>
-          <v-row><v-label>{{ t("SearchEntity.AdvanceFilterGenerateDialog.status") }}</v-label></v-row>
+          <v-row
+            ><v-label>{{ t("SearchEntity.AdvanceFilterGenerateDialog.status") }}</v-label></v-row
+          >
           <v-row>
             <v-col
               v-for="status in statusOptions"
@@ -221,7 +256,9 @@ function enterDialog() {
               </v-row>
             </v-col>
             <v-col cols="6">
-              <v-row><v-label>{{ t("SearchEntity.AdvanceFilterGenerateDialog.size") }}</v-label></v-row>
+              <v-row
+                ><v-label>{{ t("SearchEntity.AdvanceFilterGenerateDialog.size") }}</v-label></v-row
+              >
               <v-row>
                 <v-range-slider
                   v-model="advanceFilterDictRef.size"
@@ -245,7 +282,9 @@ function enterDialog() {
           </v-row>
           <v-row>
             <v-col cols="4">
-              <v-row><v-label>{{ t("SearchEntity.AdvanceFilterGenerateDialog.seeders") }}</v-label></v-row>
+              <v-row
+                ><v-label>{{ t("SearchEntity.AdvanceFilterGenerateDialog.seeders") }}</v-label></v-row
+              >
               <v-row>
                 <v-range-slider
                   v-model="advanceFilterDictRef.seeders"
@@ -264,7 +303,9 @@ function enterDialog() {
               </v-row>
             </v-col>
             <v-col cols="4">
-              <v-row><v-label>{{ t("SearchEntity.AdvanceFilterGenerateDialog.leechers") }}</v-label></v-row>
+              <v-row
+                ><v-label>{{ t("SearchEntity.AdvanceFilterGenerateDialog.leechers") }}</v-label></v-row
+              >
               <v-row>
                 <v-range-slider
                   v-model="advanceFilterDictRef.leechers"
@@ -283,7 +324,9 @@ function enterDialog() {
               </v-row>
             </v-col>
             <v-col cols="4">
-              <v-row><v-label>{{ t("SearchEntity.AdvanceFilterGenerateDialog.completed") }}</v-label></v-row>
+              <v-row
+                ><v-label>{{ t("SearchEntity.AdvanceFilterGenerateDialog.completed") }}</v-label></v-row
+              >
               <v-row>
                 <v-range-slider
                   v-model="advanceFilterDictRef.completed"
@@ -306,10 +349,14 @@ function enterDialog() {
       </v-card-text>
       <v-divider />
       <v-card-actions>
-        <v-btn variant="text" @click="() => reBuildAdvanceFilter(true)">{{ t("common.AdvanceFilterGenerateDialog.reset") }}</v-btn>
+        <v-btn variant="text" @click="() => reBuildAdvanceFilter(true)">{{
+          t("common.AdvanceFilterGenerateDialog.reset")
+        }}</v-btn>
         <v-spacer />
         <v-btn color="error" variant="text" @click="showDialog = false">{{ t("common.dialog.cancel") }}</v-btn>
-        <v-btn color="primary" variant="text" @click="updateTableFilter">{{ t("common.AdvanceFilterGenerateDialog.generate") }}</v-btn>
+        <v-btn color="primary" variant="text" @click="updateTableFilter">{{
+          t("common.AdvanceFilterGenerateDialog.generate")
+        }}</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>

--- a/src/entries/options/views/Settings/SetBase/SearchEntityWindow.vue
+++ b/src/entries/options/views/Settings/SetBase/SearchEntityWindow.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import { isEmpty } from "es-toolkit/compat";
 
@@ -14,6 +15,16 @@ async function clearLastFilter(v: boolean) {
     await metadataStore.setLastSearchFilter("");
   }
 }
+
+const hiddenTagNamesText = computed({
+  get: () => configStore.searchEntifyControl.hiddenTagNames.join("\n"),
+  set: (val: string) => {
+    configStore.searchEntifyControl.hiddenTagNames = val
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  },
+});
 </script>
 
 <template>
@@ -90,13 +101,6 @@ async function clearLastFilter(v: boolean) {
           />
 
           <v-switch
-            v-model="configStore.searchEntity.autoDetectOfficialGroupFromTitle"
-            :label="t('SetBase.searchEntity.autoDetectOfficialGroupFromTitle')"
-            color="success"
-            hide-details
-          />
-
-          <v-switch
             v-model="configStore.searchEntity.quickSiteFilter"
             :label="t('SetBase.searchEntity.quickSiteFilter')"
             color="success"
@@ -104,6 +108,39 @@ async function clearLastFilter(v: boolean) {
           />
 
           <v-divider />
+        </v-col>
+      </v-row>
+
+      <v-row dense>
+        <v-col cols="12" md="2" class="d-flex align-center justify-center">
+          <v-label>{{ t("SetBase.searchEntity.tagLabel") }}</v-label>
+        </v-col>
+        <v-col>
+          <v-switch
+            v-model="configStore.searchEntity.autoDetectOfficialGroupFromTitle"
+            :label="t('SetBase.searchEntity.autoDetectOfficialGroupFromTitle')"
+            color="success"
+            hide-details
+          />
+
+          <v-number-input
+            v-model="configStore.searchEntifyControl.maxTagCountBeforeGroup"
+            :label="t('SetBase.searchEntity.maxTagCountBeforeGroup')"
+            :min="0"
+            :max="50"
+            controlVariant="default"
+            hide-details
+          />
+
+          <v-textarea
+            v-model="hiddenTagNamesText"
+            :label="t('SetBase.searchEntity.hiddenTagNames')"
+            :messages="t('SetBase.searchEntity.hiddenTagNamesMessage')"
+            class="mt-2"
+            auto-grow
+            clearable
+            rows="5"
+          />
         </v-col>
       </v-row>
     </v-col>

--- a/src/entries/shared/types/storages/config.ts
+++ b/src/entries/shared/types/storages/config.ts
@@ -157,6 +157,10 @@ export interface IConfigPiniaStorageSchema {
     uploadAtFormatAsAlive: boolean;
     // 是否限制种子标题列的最大宽度，防止过长导致表格布局混乱
     limitTorrentTitleTdWidth: boolean;
+    // 种子标签数量超过多少个时使用分组显示（0表示不限制）
+    maxTagCountBeforeGroup: number;
+    // 默认隐藏的标签名称列表
+    hiddenTagNames: string[];
   };
 
   userInfo: {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -273,8 +273,10 @@
     },
     "AdvanceFilterGenerateDialog": {
       "completed": "Completed",
+      "hideHiddenTags": "hide hidden tags",
       "leechers": "Leechers",
       "seeders": "Seeders",
+      "showHiddenTags": "show hidden tags",
       "size": "Torrent Size",
       "status": "Torrent Status",
       "tags": "Tags"
@@ -486,7 +488,10 @@
       "autoLoadMoreMediaOnScroll": "Automatically load more media when scrolling to the bottom of the page",
       "filterLabel": "Result Filter",
       "forceImdbIdMatchFilter": "When searching by IMDb, filter out results whose IMDb ID returned by the site does not match",
+      "hiddenTagNames": "Hidden tags (one per line)",
+      "hiddenTagNamesMessage": "Closing tags on the search page is temporary. Save here to make it permanent.",
       "imdbTip": "When disabled, you need to use the `imdb|tt12345678` format for IMDb searches.",
+      "maxTagCountBeforeGroup": "Max tags shown before grouping (0 = unlimited)",
       "mediaQueueConcurrency": "Request Queue Concurrency",
       "mediaSearchLimit": "Number of search results per request",
       "mediaSearchLimitMessage": "Please do not load too many search results at once. It's not optimized with virtual-scroll, which may cause the browser to freeze and affect the performance of the media server.",
@@ -497,6 +502,7 @@
       "showHotRecommendations": "Show hot recommendations button in the search box",
       "siteQueueConcurrency": "Request Queue Concurrency",
       "siteSearchConfig": "Site Search Configuration",
+      "tagLabel": "Tags Filter",
       "treatTTQueryAsImdbSearch": "Treat tt\\d\\{7,8\\} search terms directly as IMDb search"
     },
     "tab": {

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -273,8 +273,10 @@
     },
     "AdvanceFilterGenerateDialog": {
       "completed": "完成人数",
+      "hideHiddenTags": "隐藏隐藏标签",
       "leechers": "下载人数",
       "seeders": "上传人数",
+      "showHiddenTags": "展示隐藏标签",
       "size": "种子大小",
       "status": "种子状态",
       "tags": "标签"
@@ -486,7 +488,10 @@
       "autoLoadMoreMediaOnScroll": "当滚动到页面底部时，自动加载新的媒体墙",
       "filterLabel": "结果筛选",
       "forceImdbIdMatchFilter": "使用 IMDb 搜索时，在搜索结果中滤去站点返回的IMDb号不匹配的结果",
+      "hiddenTagNames": "隐藏标签（每行一个）",
+      "hiddenTagNamesMessage": "在搜索页面手动关闭的为临时关闭，需要在本页面保存后才为永久保存。",
       "imdbTip": "关闭后，你需要使用 `imdb|tt12345678` 的格式来进行 IMDb 搜索。",
+      "maxTagCountBeforeGroup": "标签分组显示上限（0表示不限制）",
       "mediaQueueConcurrency": "请求队列长度",
       "mediaSearchLimit": "单次搜索结果数量",
       "mediaSearchLimitMessage": "请不要一次性加载过多的搜索结果，未作 virtual‑scroll 优化，可能会导致浏览器卡死，同时也会影响媒体服务器的性能",
@@ -497,6 +502,7 @@
       "showHotRecommendations": "在搜索框中显示热门推荐按钮",
       "siteQueueConcurrency": "请求队列长度",
       "siteSearchConfig": "站点搜索配置",
+      "tagLabel": "标签筛选",
       "treatTTQueryAsImdbSearch": "是否将 tt\\d\\{7,8\\} 的搜索词直接视为 IMDb 搜索"
     },
     "tab": {


### PR DESCRIPTION
目前各个站点的tags越来越丰富，但实际很多tags并没有意义。
本pr计划引入下面两个功能： ① 隐藏过多的tags； ② 允许不显示某些tags

1. 在搜索设置页面增加两个控制项

<img width="1101" height="311" alt="image" src="https://github.com/user-attachments/assets/8ed37f93-5bfa-4819-9c6e-e1652a0f7f16" />

2. 当一个种子的 tags 数超过限制，超出部分会被隐藏

<img width="356" height="75" alt="image" src="https://github.com/user-attachments/assets/8542a868-2e85-4eb4-b1d7-645aad1705b5" />

3. 当鼠标hover时，允许 **临时** 关闭该tags ，注意这种关闭是不持久化的，如果需要保存，请在搜索页面手动保存。

<img width="254" height="117" alt="image" src="https://github.com/user-attachments/assets/2a3151a6-9fa3-4c74-ab72-e7aae1728cc5" />

4. 在过滤词生成窗口，默认隐藏被关闭的tags

<img width="808" height="134" alt="image" src="https://github.com/user-attachments/assets/22922592-9df6-409b-92d6-05d4bca4e98b" />

## Summary by Sourcery

Add configurable controls to limit and hide torrent tags in search results and the advanced filter dialog.

New Features:
- Allow configuring a maximum number of torrent tags to display per item before grouping the remainder.
- Support maintaining a persistent list of hidden tag names that are excluded from tag displays by default.
- Enable temporarily hiding individual tags directly from the torrent list via hover-close chips.
- Add a toggle in the advanced filter generation dialog to show or hide tags that are in the hidden tag list.

Enhancements:
- Reorganize search entity settings to include a dedicated section for tag display controls.