### PR TITLE
feat: add downloader save path management

### DIFF
--- a/src/entries/options/components/SentToDownloaderDialog/Index.vue
+++ b/src/entries/options/components/SentToDownloaderDialog/Index.vue
@@ -47,6 +47,7 @@ const addTorrentOptions = ref<Required<Omit<CAddTorrentOptions, "localDownloadOp
 
 const suggestFolders = computed(() => selectedDownloader.value?.suggestFolders ?? []);
 const suggestTags = computed(() => selectedDownloader.value?.suggestTags ?? []);
+const quickSuggestFolders = computed(() => suggestFolders.value.slice(0, 5));
 
 const currentSiteIds = computed(() => [...new Set(torrentItems.map((t) => t.site).filter(Boolean))]);
 const enabledDownloadersBySite = computed(() => {
@@ -79,10 +80,28 @@ watch(selectedDownloader, (value) => {
   }
 });
 
+async function saveSelectedDownloaderPath() {
+  const downloader = selectedDownloader.value;
+  const savePath = addTorrentOptions.value.savePath.trim();
+  addTorrentOptions.value.savePath = savePath;
+  if (!downloader?.id || !savePath) return;
+
+  const suggestFolders = downloader.suggestFolders ?? [];
+  if (suggestFolders.includes(savePath)) return;
+
+  const nextSuggestFolders = [...suggestFolders, savePath];
+  selectedDownloader.value = { ...downloader, suggestFolders: nextSuggestFolders };
+  await metadataStore.simplePatch("downloaders", downloader.id, "suggestFolders", nextSuggestFolders);
+}
+
 async function sendToDownloader() {
   if (!selectedDownloader.value?.id) {
     runtimeStore.showSnakebar(t("SentToDownloaderDialog.selectDownloaderFirst"), { color: "error" });
     return;
+  }
+
+  if (!isDefaultSend) {
+    await saveSelectedDownloaderPath();
   }
 
   // 保存此次选择记录（默认推送不保存）
@@ -90,7 +109,10 @@ async function sendToDownloader() {
     // noinspection ES6MissingAwait
     metadataStore.setLastDownloader({
       id: selectedDownloader.value.id,
-      options: addTorrentOptions.value,
+      options: {
+        ...addTorrentOptions.value,
+        advanceAddTorrentOptions: { ...addTorrentOptions.value.advanceAddTorrentOptions },
+      },
     });
   }
 
@@ -110,15 +132,16 @@ function quickSendToDownloader(downloader: IDownloaderMetadata, path: string = "
   addTorrentOptions.value.localDownload = true;
   addTorrentOptions.value.addAtPaused = !(downloader.feature?.DefaultAutoStart ?? true);
   addTorrentOptions.value.advanceAddTorrentOptions = downloader.advanceAddTorrentOptions ?? {};
-
-  if (path) {
-    addTorrentOptions.value.savePath = path;
-  }
+  addTorrentOptions.value.savePath = path;
   if (label) {
     addTorrentOptions.value.label = label;
   }
 
   return sendToDownloader();
+}
+
+function selectSavePath(path: string) {
+  addTorrentOptions.value.savePath = path;
 }
 
 function dialogEnter() {
@@ -137,7 +160,7 @@ function dialogEnter() {
     sendToDownloader();
   } else {
     restoreAddTorrentOptions(); // 先重置所有选项，然后如果需要则从uiStore中获取历史情况
-    quickSendToClient.value = configStore.download.useQuickSendToClient;
+    quickSendToClient.value = false;
 
     // 如果不是快速发送到客户端模式，则尝试设置默认下载器
     if (!quickSendToClient.value) {
@@ -257,6 +280,28 @@ function dialogLeave() {
                 </template>
               </v-autocomplete>
             </v-row>
+            <v-row v-if="quickSuggestFolders.length > 0" dense>
+              <v-col class="py-0">
+                <div class="quick-save-path-row">
+                  <span class="text-caption text-medium-emphasis mr-2">
+                    {{ t("SentToDownloaderDialog.quickSavePaths") }}
+                  </span>
+                  <v-chip
+                    v-for="path in quickSuggestFolders"
+                    :key="path"
+                    :active="addTorrentOptions.savePath === path"
+                    :title="path"
+                    color="info"
+                    prepend-icon="mdi-folder"
+                    size="small"
+                    variant="tonal"
+                    @click="selectSavePath(path)"
+                  >
+                    <span class="quick-save-path-text">{{ path }}</span>
+                  </v-chip>
+                </div>
+              </v-col>
+            </v-row>
             <v-row>
               <v-col class="py-0 pl-0" cols="6">
                 <v-combobox
@@ -356,4 +401,21 @@ function dialogLeave() {
   </v-dialog>
 </template>
 
-<style scoped lang="scss"></style>
+<style scoped lang="scss">
+.quick-save-path-row {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.quick-save-path-text {
+  display: inline-block;
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: bottom;
+  white-space: nowrap;
+}
+</style>

--- a/src/entries/options/components/SentToDownloaderDialog/utils.ts
+++ b/src/entries/options/components/SentToDownloaderDialog/utils.ts
@@ -6,6 +6,14 @@ import { useRuntimeStore } from "@/options/stores/runtime.ts";
 import { useMetadataStore } from "@/options/stores/metadata.ts";
 import { sendMessage } from "@/messages.ts";
 
+function replaceValue(value: string, replaceMap: Record<string, string>) {
+  let replacedValue = value;
+  for (const [replaceKey, replaceWith] of Object.entries(replaceMap)) {
+    replacedValue = replacedValue.replace(`$${replaceKey}$`, replaceWith);
+  }
+  return replacedValue;
+}
+
 export function sendTorrentToDownloader(
   torrentItems: ITorrent[],
   downloaderId: TDownloaderKey,
@@ -16,12 +24,12 @@ export function sendTorrentToDownloader(
 
   // 预处理自定义输入
   for (const key of ["savePath", "label"] as (keyof typeof addTorrentOptions)[]) {
-    if ((addTorrentOptions[key] as string).includes("<...>")) {
+    const fieldValue = addTorrentOptions[key];
+    if (typeof fieldValue === "string" && fieldValue.includes("<...>")) {
       // 此处允许空字符 ""， 但不允许用户取消（即取消动态替换操作则认为取消推送任务）
       const userInput = prompt(`请输入替换 ${key} 中的 <...> 的内容：`);
       if (userInput !== null) {
-        // @ts-ignore
-        addTorrentOptions[key] = (addTorrentOptions[key] as string).replace("<...>", userInput.trim());
+        (addTorrentOptions as Record<string, any>)[key] = fieldValue.replace("<...>", userInput.trim());
       } else {
         return Promise.reject(`因取消输入 ${key} 中的 <...> 的内容而停止推送`); // 用户取消输入，则跳过该任务
       }
@@ -68,10 +76,10 @@ export function sendTorrentToDownloader(
           if (realAddTorrentOptions[key] === "") {
             delete realAddTorrentOptions[key];
           } else {
-            for (const [replaceKey, value] of Object.entries(replaceMap)) {
-              // @ts-ignore
-              realAddTorrentOptions[key] = (realAddTorrentOptions[key]! as string).replace(`$${replaceKey}$`, value);
-            }
+            (realAddTorrentOptions as Record<string, any>)[key] = replaceValue(
+              realAddTorrentOptions[key] as string,
+              replaceMap,
+            );
           }
         }
       }

--- a/src/entries/options/views/Settings/SetBase/UiWindow.vue
+++ b/src/entries/options/views/Settings/SetBase/UiWindow.vue
@@ -32,6 +32,10 @@ function beforeSave() {
   }
 }
 
+function resetContentScriptPosition() {
+  configStore.updateContentScriptPosition(0, 0);
+}
+
 defineExpose({
   beforeSave,
 });
@@ -157,6 +161,15 @@ defineExpose({
               hide-details
               :label="t('SetBase.ui.enableFadeEffect')"
             />
+            <v-btn
+              class="my-2"
+              color="primary"
+              prepend-icon="mdi-crosshairs-gps"
+              variant="tonal"
+              @click="resetContentScriptPosition"
+            >
+              {{ t("SetBase.ui.resetSidebarPosition") }}
+            </v-btn>
             <v-divider />
           </v-col>
         </v-row>

--- a/src/entries/options/views/Settings/SetDownloader/DefaultDownloaderEditDialog.vue
+++ b/src/entries/options/views/Settings/SetDownloader/DefaultDownloaderEditDialog.vue
@@ -97,8 +97,16 @@ function enterDialog() {
           </v-autocomplete>
 
           <!-- 如果用户已经在对应下载器的预设了下载路径和标签，则加载对应的列表 -->
-          <v-combobox v-model="defaultDownloaderConfig.folder" :items="suggests.folder" :label="t('SetDownloader.PathAndTag.downloadPath.title')" />
-          <v-combobox v-model="defaultDownloaderConfig.tags" :items="suggests.tags" :label="t('SetDownloader.PathAndTag.tags.title')" />
+          <v-combobox
+            v-model="defaultDownloaderConfig.folder"
+            :items="suggests.folder"
+            :label="t('SetDownloader.PathAndTag.downloadPath.title')"
+          />
+          <v-combobox
+            v-model="defaultDownloaderConfig.tags"
+            :items="suggests.tags"
+            :label="t('SetDownloader.PathAndTag.tags.title')"
+          />
         </v-form>
       </v-card-text>
       <v-divider />

--- a/src/entries/options/views/Settings/SetDownloader/Index.vue
+++ b/src/entries/options/views/Settings/SetDownloader/Index.vue
@@ -91,6 +91,17 @@ function editDownloaderPathAndTag(downloaderId: TDownloaderKey) {
   showPathAndTagSuggestDialog.value = true;
 }
 
+const selectedPathManageDownloaderId = computed<TDownloaderKey | null>(() => {
+  if (tableSelected.value.length === 1) return tableSelected.value[0];
+  if (metadataStore.getDownloaders.length === 1) return metadataStore.getDownloaders[0].id;
+  return null;
+});
+
+function editSelectedDownloaderPathAndTag() {
+  if (!selectedPathManageDownloaderId.value) return;
+  editDownloaderPathAndTag(selectedPathManageDownloaderId.value);
+}
+
 function editDownloaderSiteFilter(downloaderId: TDownloaderKey) {
   toEditDownloaderId.value = downloaderId;
   showSiteFilterDialog.value = true;
@@ -130,6 +141,14 @@ async function confirmDeleteDownloader(downloaderId: TDownloaderKey) {
           color="indigo"
           icon="mdi-auto-download"
           @click="showDefaultDownloaderEditDialog = true"
+        />
+
+        <NavButton
+          :disabled="!selectedPathManageDownloaderId"
+          :text="t('SetDownloader.index.manageSavePathsBtn')"
+          color="amber"
+          icon="mdi-folder-settings"
+          @click="editSelectedDownloaderPathAndTag"
         />
 
         <v-spacer />

--- a/src/entries/options/views/Settings/SetDownloader/PathAndTagSuggestDialog.vue
+++ b/src/entries/options/views/Settings/SetDownloader/PathAndTagSuggestDialog.vue
@@ -18,7 +18,8 @@ const metadataStore = useMetadataStore();
 
 const clientConfig = ref<IDownloaderMetadata>();
 const clientMetadata = ref<TorrentClientMetaData>();
-const expansionPanelOpen = ref<string>("note");
+const expansionPanelOpen = ref<string>("path");
+const newFolderInput = ref<string>("");
 
 // [key (for i18n), value, example]
 const pathReplaceMap: [string, string, string][] = [
@@ -48,15 +49,61 @@ watch(
   { immediate: true },
 );
 
-const suggestFolderInput = computed({
-  get: () => (clientConfig.value?.suggestFolders ?? []).join("\n"),
-  set: (value) => {
-    clientConfig.value!.suggestFolders = value
-      .split("\n")
-      .map((v) => v.trim())
-      .filter(Boolean);
-  },
-});
+function normalizeList(values: string[]) {
+  return [...new Set(values.map((v) => v.trim()).filter(Boolean))];
+}
+
+function setSuggestFolders(paths: string[]) {
+  clientConfig.value!.suggestFolders = normalizeList(paths);
+}
+
+function addSuggestFolder(path: string = newFolderInput.value) {
+  const nextPath = path.trim();
+  if (!nextPath) return;
+
+  const suggestFolders = clientConfig.value?.suggestFolders ?? [];
+  if (suggestFolders.includes(nextPath)) {
+    runtimeStore.showSnakebar(t("SetDownloader.PathAndTag.downloadPath.duplicate"), { color: "warning" });
+    return;
+  }
+
+  setSuggestFolders([...suggestFolders, nextPath]);
+  newFolderInput.value = "";
+}
+
+function updateSuggestFolder(index: number, value: string) {
+  const suggestFolders = [...(clientConfig.value?.suggestFolders ?? [])];
+  suggestFolders[index] = value;
+  clientConfig.value!.suggestFolders = suggestFolders;
+}
+
+function normalizeSuggestFolders() {
+  setSuggestFolders(clientConfig.value?.suggestFolders ?? []);
+}
+
+function removeSuggestFolder(index: number) {
+  const suggestFolders = [...(clientConfig.value?.suggestFolders ?? [])];
+  suggestFolders.splice(index, 1);
+  setSuggestFolders(suggestFolders);
+}
+
+function moveSuggestFolder(index: number, offset: number) {
+  const suggestFolders = [...(clientConfig.value?.suggestFolders ?? [])];
+  const targetIndex = index + offset;
+  if (targetIndex < 0 || targetIndex >= suggestFolders.length) return;
+
+  const [folder] = suggestFolders.splice(index, 1);
+  suggestFolders.splice(targetIndex, 0, folder);
+  setSuggestFolders(suggestFolders);
+}
+
+function clearSuggestFolders() {
+  clientConfig.value!.suggestFolders = [];
+}
+
+function appendPathKeyword(keyword: string) {
+  newFolderInput.value += keyword;
+}
 
 const isLoadingClientFolders = ref<boolean>(false);
 async function loadClientFolders() {
@@ -66,7 +113,7 @@ async function loadClientFolders() {
     const clientPaths = await client.getClientPaths();
     for (const path of clientPaths) {
       if ((clientConfig.value?.suggestFolders ?? []).includes(path)) continue; // 避免重复添加
-      suggestFolderInput.value += "\n" + path;
+      addSuggestFolder(path);
     }
   } catch (e) {
     runtimeStore.showSnakebar(t("SetDownloader.PathAndTag.downloadPath.autoImportFail"), { color: "error" });
@@ -103,6 +150,8 @@ async function loadClientLabels() {
 }
 
 function saveClientConfig() {
+  normalizeSuggestFolders();
+  clientConfig.value!.suggestTags = normalizeList(clientConfig.value?.suggestTags ?? []);
   metadataStore.addDownloader(clientConfig.value as IDownloaderMetadata);
   showDialog.value = false;
 }
@@ -138,45 +187,127 @@ function saveClientConfig() {
                 {{ clientMetadata?.feature?.CustomPath.description }}
               </v-alert>
 
-              <v-textarea
-                v-model="suggestFolderInput"
-                :label="t('SetDownloader.PathAndTag.downloadPath.addInputLabel')"
-                class="mt-2"
+              <v-alert class="mt-2" density="compact" type="info" variant="tonal">
+                {{ t("SetDownloader.PathAndTag.downloadPath.quickHint") }}
+              </v-alert>
+
+              <v-row class="mt-2" dense>
+                <v-col cols="12" md="9">
+                  <v-text-field
+                    v-model="newFolderInput"
+                    :label="t('SetDownloader.PathAndTag.downloadPath.addInputLabel')"
+                    :placeholder="t('SetDownloader.PathAndTag.downloadPath.addPlaceholder')"
+                    hide-details
+                    @keydown.enter.prevent="addSuggestFolder()"
+                  />
+                </v-col>
+                <v-col cols="12" md="3">
+                  <v-btn block color="success" height="56" prepend-icon="mdi-plus" @click="addSuggestFolder()">
+                    {{ t("SetDownloader.PathAndTag.downloadPath.add") }}
+                  </v-btn>
+                </v-col>
+              </v-row>
+
+              <v-chip-group class="mt-1">
+                <v-chip
+                  v-for="pathReplace in pathReplaceMap"
+                  :key="pathReplace[1]"
+                  :title="pathReplace[2]"
+                  class="mr-1"
+                  size="small"
+                  @click="appendPathKeyword(pathReplace[1])"
+                >
+                  {{ pathReplace[1] }}
+                </v-chip>
+              </v-chip-group>
+
+              <div class="d-flex align-center mt-3 mb-1">
+                <div class="text-subtitle-2">
+                  {{ t("SetDownloader.PathAndTag.downloadPath.addTitle") }}
+                </div>
+                <v-spacer />
+                <v-btn
+                  :loading="isLoadingClientFolders"
+                  :title="t('SetDownloader.PathAndTag.downloadPath.autoImport')"
+                  color="primary"
+                  prepend-icon="mdi-import"
+                  size="small"
+                  variant="text"
+                  @click="loadClientFolders"
+                >
+                  {{ t("SetDownloader.PathAndTag.downloadPath.autoImportShort") }}
+                </v-btn>
+                <v-btn
+                  :disabled="(clientConfig?.suggestFolders ?? []).length === 0"
+                  :title="t('SetDownloader.PathAndTag.downloadPath.clear')"
+                  color="red"
+                  icon="$clear"
+                  size="small"
+                  variant="text"
+                  @click="clearSuggestFolders"
+                />
+              </div>
+
+              <v-alert
+                v-if="(clientConfig?.suggestFolders ?? []).length === 0"
+                density="compact"
+                type="warning"
+                variant="tonal"
               >
-                <template #append>
-                  <div class="d-flex flex-column">
+                {{ t("SetDownloader.PathAndTag.downloadPath.empty") }}
+              </v-alert>
+
+              <div v-else class="save-path-list">
+                <div
+                  v-for="(path, index) in clientConfig?.suggestFolders ?? []"
+                  :key="`${path}-${index}`"
+                  class="save-path-row"
+                >
+                  <div class="save-path-index">
+                    <v-chip v-if="index < 5" class="save-path-chip" color="info" label size="small">
+                      {{ t("SetDownloader.PathAndTag.downloadPath.quickBadge") }} {{ index + 1 }}
+                    </v-chip>
+                    <v-chip v-else class="save-path-chip" label size="small">#{{ index + 1 }}</v-chip>
+                  </div>
+
+                  <v-text-field
+                    :model-value="path"
+                    class="save-path-input"
+                    density="compact"
+                    hide-details
+                    :label="t('SetDownloader.PathAndTag.downloadPath.pathLabel')"
+                    @blur="normalizeSuggestFolders"
+                    @update:model-value="(value) => updateSuggestFolder(index, value)"
+                  />
+
+                  <div class="save-path-actions">
                     <v-btn
-                      :loading="isLoadingClientFolders"
-                      :title="t('SetDownloader.PathAndTag.downloadPath.autoImport')"
-                      color="primary"
-                      icon="mdi-import"
+                      :disabled="index === 0"
+                      :title="t('SetDownloader.PathAndTag.downloadPath.moveUp')"
+                      icon="mdi-arrow-up"
+                      size="small"
                       variant="text"
-                      @click="loadClientFolders"
+                      @click="moveSuggestFolder(index, -1)"
                     />
                     <v-btn
-                      :title="t('SetDownloader.PathAndTag.downloadPath.clear')"
-                      color="red"
-                      icon="$clear"
+                      :disabled="index === (clientConfig?.suggestFolders ?? []).length - 1"
+                      :title="t('SetDownloader.PathAndTag.downloadPath.moveDown')"
+                      icon="mdi-arrow-down"
+                      size="small"
                       variant="text"
-                      @click="suggestFolderInput = ''"
+                      @click="moveSuggestFolder(index, 1)"
+                    />
+                    <v-btn
+                      :title="t('SetDownloader.PathAndTag.downloadPath.remove')"
+                      color="error"
+                      icon="mdi-delete"
+                      size="small"
+                      variant="text"
+                      @click="removeSuggestFolder(index)"
                     />
                   </div>
-                </template>
-                <template #details>
-                  <v-chip-group>
-                    <v-chip
-                      v-for="pathReplace in pathReplaceMap"
-                      :key="pathReplace[1]"
-                      :title="pathReplace[2]"
-                      class="mr-1"
-                      size="small"
-                      @click="() => (suggestFolderInput += '/' + pathReplace[1])"
-                    >
-                      {{ pathReplace[1] }}
-                    </v-chip>
-                  </v-chip-group>
-                </template>
-              </v-textarea>
+                </div>
+              </div>
             </v-expansion-panel-text>
           </v-expansion-panel>
           <v-expansion-panel value="tag">
@@ -263,4 +394,51 @@ function saveClientConfig() {
   </v-dialog>
 </template>
 
-<style scoped lang="scss"></style>
+<style scoped lang="scss">
+.save-path-list {
+  border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+}
+
+.save-path-row {
+  align-items: center;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 92px minmax(0, 1fr) 112px;
+}
+
+.save-path-index {
+  display: flex;
+  justify-content: flex-start;
+  min-width: 0;
+}
+
+.save-path-chip {
+  width: 76px;
+}
+
+.save-path-input {
+  min-width: 0;
+}
+
+.save-path-actions {
+  display: flex;
+  justify-content: flex-end;
+  white-space: nowrap;
+}
+
+@media (max-width: 700px) {
+  .save-path-row {
+    align-items: stretch;
+    grid-template-columns: 1fr;
+  }
+
+  .save-path-actions {
+    justify-content: flex-start;
+  }
+}
+</style>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -398,8 +398,10 @@
     "noDownloader": "No downloaders available. Please add a downloader in settings.",
     "noDownloaderForSite": "No downloaders available for this site. Check the site filter settings in downloader configuration.",
     "pauseOnAdd": "Pause on add by default",
+    "quickSavePaths": "Quick save paths",
+    "quickSavePathsHint": "Shows the first 5 saved paths for this downloader",
     "savePath": "Save Path",
-    "savePathHint": "Leave empty to use the downloader's default path",
+    "savePathHint": "Select or enter a new path. New paths are saved to this downloader after sending. Leave empty to use the downloader's default path",
     "selectDownloader": "Select Downloader",
     "selectDownloaderFirst": "Please select a downloader first",
     "title": "Select downloader for {0} torrents"
@@ -550,6 +552,7 @@
       },
       "socialSiteSearchLabel": "Social site search method",
       "tableMultiSortNote": "Multi-column sorting: Click any table header field to start sorting, which will display the number \\\"1\\\" on the field. Click other fields sequentially to display \\\"2\\\", \\\"3\\\", indicating sorting priority. Click the same field again to toggle between ascending, descending, or cancel sorting. The sorting order is determined by these numbers, with smaller numbers having higher priority.",
+      "resetSidebarPosition": "Reset floating button position",
       "useLargeIcon": "Use large icon buttons"
     },
     "userInfo": {
@@ -561,11 +564,22 @@
   "SetDownloader": {
     "PathAndTag": {
       "downloadPath": {
+        "add": "Add",
         "addInputLabel": "Added @:SetDownloader.PathAndTag.downloadPath.title",
         "addTitle": "Added @:SetDownloader.PathAndTag.downloadPath.title @:SetDownloader.PathAndTag.supportDragNote",
+        "addPlaceholder": "Enter a save path, then press Enter or click Add",
         "autoImport": "One-click to import of existing @:SetDownloader.PathAndTag.downloadPath.title from the downloader",
         "autoImportFail": "@:SetDownloader.PathAndTag.downloadPath.autoImport failed, please add manually.",
+        "autoImportShort": "Import",
         "clear": "Clear @:SetDownloader.PathAndTag.downloadPath.title",
+        "duplicate": "This save path already exists",
+        "empty": "No save paths yet. Add paths here to reuse them in the push dialog; the first 5 are shown as quick buttons.",
+        "moveDown": "Move down",
+        "moveUp": "Move up",
+        "pathLabel": "Save path",
+        "quickBadge": "Quick",
+        "quickHint": "This list is saved to the downloader. The first 5 save paths appear as quick buttons in the push dialog.",
+        "remove": "Remove save path",
         "title": "Download Paths"
       },
       "note": {
@@ -634,6 +648,7 @@
       "changeDefaultDownloader": "Default downloader updated successfully. If necessary, please further configure the download path and tags.",
       "editDefaultDownloaderBtn": "Edit Default Downloader",
       "emptyNotice": "Before using the download service, you need to add at least one download server.",
+      "manageSavePathsBtn": "Manage Save Paths",
       "remove": {
         "multi": "Are you sure to delete these {count} download servers?",
         "single": "Are you sure to delete this download server?"

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -398,8 +398,10 @@
     "noDownloader": "没有可用的下载器，请先在设置中添加下载器。",
     "noDownloaderForSite": "当前站点没有可用的下载器，请检查下载器设置中的站点过滤配置。",
     "pauseOnAdd": "添加时默认暂停",
+    "quickSavePaths": "快捷保存路径",
+    "quickSavePathsHint": "显示该下载器保存路径列表的前 5 个",
     "savePath": "保存路径",
-    "savePathHint": "不设置则为该下载服务器的默认路径",
+    "savePathHint": "可选择或输入新路径；新路径发送后会保存到该下载器。不设置则为该下载服务器的默认路径",
     "selectDownloader": "选择下载器",
     "selectDownloaderFirst": "请先选择下载器",
     "title": "为 {0} 个种子选择下载器"
@@ -550,6 +552,7 @@
       },
       "socialSiteSearchLabel": "社交站点搜索方式",
       "tableMultiSortNote": "多列排序使用方法：点击任意表头字段开始排序，字段上会显示数字“1”。再点击其他字段，依次显示“2”“3”，表示排序优先级。再次点击相同字段可切换升序、降序或取消排序。排序顺序由这些数字决定，数字越小优先级越高。",
+      "resetSidebarPosition": "重置悬浮按钮位置",
       "useLargeIcon": "使用大图标按键"
     },
     "userInfo": {
@@ -561,11 +564,22 @@
   "SetDownloader": {
     "PathAndTag": {
       "downloadPath": {
+        "add": "添加",
         "addInputLabel": "添加@:SetDownloader.PathAndTag.downloadPath.title",
         "addTitle": "已添加的@:SetDownloader.PathAndTag.downloadPath.title@:SetDownloader.PathAndTag.supportDragNote",
+        "addPlaceholder": "输入保存路径后回车，或点击添加",
         "autoImport": "一键导入下载器中已有的@:SetDownloader.PathAndTag.downloadPath.title",
         "autoImportFail": "@:SetDownloader.PathAndTag.downloadPath.autoImport 失败，请手动添加。",
+        "autoImportShort": "导入",
         "clear": "清空@:SetDownloader.PathAndTag.downloadPath.title",
+        "duplicate": "该保存路径已存在",
+        "empty": "暂无保存路径。添加后会在推送弹窗中可选，前 5 个会显示为快捷按钮。",
+        "moveDown": "下移",
+        "moveUp": "上移",
+        "pathLabel": "保存路径",
+        "quickBadge": "快捷",
+        "quickHint": "列表会持久化到该下载器；前 5 个保存路径会在“推送到下载器”弹窗里显示为快捷按钮。",
+        "remove": "删除保存路径",
         "title": "下载路径"
       },
       "note": {
@@ -634,6 +648,7 @@
       "changeDefaultDownloader": "更新默认下载服务器成功！如有必要请进一步设置下载地址和标签。",
       "editDefaultDownloaderBtn": "默认下载服务器设置",
       "emptyNotice": "在使用推送服务之前，您至少需要添加一个下载服务器。",
+      "manageSavePathsBtn": "保存路径管理",
       "remove": {
         "multi": "你确定删除这{count}个下载服务器吗？",
         "single": "确认要删除这个下载服务器吗？"


### PR DESCRIPTION
## Summary
- Add per-downloader save path selection when sending torrents to a downloader.
- Persist newly entered paths in existing downloader `suggestFolders` metadata and expose a settings dialog to manage saved paths.
- Add quick path chips for the first five saved paths and a reset action for floating button position.

## Validation
- npm run check
- npm run build:dist
- git diff --check
- Manual Edge validation with migrated user data for path persistence and floating action position reset

## Notes
- No PR template or CONTRIBUTING file is present in the repository.
- The repository CI for PRs to master runs pnpm check, pnpm build:dist, and pnpm build:dist-firefox.

## Summary by Sourcery

Introduce richer management and reuse of downloader save paths and tags, including per-downloader path persistence and quick path selection in the send dialog.

New Features:
- Allow users to add, edit, reorder, and clear saved download paths per downloader, with quick badges for the first five paths.
- Persist newly used save paths back into the downloader's suggested folders when sending torrents, enabling reuse across sessions.
- Expose a settings action to open the save path management dialog for the currently selected (or only) downloader.
- Add UI chips in the send-to-downloader dialog for quickly selecting among the first five saved paths.
- Add a control in UI settings to reset the floating sidebar/content script position to its default.

Enhancements:
- Improve placeholder replacement logic in send-to-downloader utilities to be safer and reusable.
- Default the path/tag settings expansion panel to the path section and normalize stored tags and paths to deduplicate and trim values.
- Ensure last-downloader options saved from the send dialog copy nested advanced options instead of reusing references.