### PR TITLE
feat: add seeding-points total series to data statistics chart

### DIFF
--- a/src/entries/options/views/Overview/MyData/UserDataStatistic/Index.vue
+++ b/src/entries/options/views/Overview/MyData/UserDataStatistic/Index.vue
@@ -113,22 +113,24 @@ const totalSiteBaseInfoChartOptions = computed(() => {
   const uploaded = getTotalDataByField("uploaded");
   const downloaded = getTotalDataByField("downloaded");
   const bonus = getTotalDataByField("bonus");
+  const seedingBonus = getTotalDataByField("seedingBonus");
 
   return {
     title: {
       text: `[${configStore.userName}] ${t("UserDataStatistic.chart.totalSiteBase")}`,
-      subtext: `${t("UserDataStatistic.chart.uploadLabel")}: ${formatSize(uploaded.at(-1)!)}, ${t("UserDataStatistic.chart.downloadLabel")}: ${formatSize(downloaded.at(-1)!)}, ${t("levelRequirement.bonus")}: ${(bonus.at(-1) ?? 0).toFixed(2)}`,
+      subtext: `${t("UserDataStatistic.chart.uploadLabel")}: ${formatSize(uploaded.at(-1)!)}, ${t("UserDataStatistic.chart.downloadLabel")}: ${formatSize(downloaded.at(-1)!)}, ${t("levelRequirement.bonus")}: ${(bonus.at(-1) ?? 0).toFixed(2)}, ${t("levelRequirement.seedingBonus")}: ${(seedingBonus.at(-1) ?? 0).toFixed(2)}`,
       left: "center", // 设置标题居中
     },
     tooltip: {
       trigger: "axis",
-      formatter: createTotalInfoTooltipFormatter(["size", "size", "number"]),
+      formatter: createTotalInfoTooltipFormatter(["size", "size", "number", "number"]),
     },
     legend: {
       data: [
         t("UserDataStatistic.chart.uploadLabel"),
         t("UserDataStatistic.chart.downloadLabel"),
         t("levelRequirement.bonus"),
+        t("levelRequirement.seedingBonus"),
       ],
       bottom: 10,
       orient: "horizontal",
@@ -153,6 +155,7 @@ const totalSiteBaseInfoChartOptions = computed(() => {
       { name: t("UserDataStatistic.chart.uploadLabel"), type: "line", smooth: true, data: uploaded, yAxisIndex: 0 },
       { name: t("UserDataStatistic.chart.downloadLabel"), type: "line", smooth: true, data: downloaded, yAxisIndex: 0 },
       { name: t("levelRequirement.bonus"), type: "line", smooth: true, data: bonus, yAxisIndex: 1 },
+      { name: t("levelRequirement.seedingBonus"), type: "line", smooth: true, data: seedingBonus, yAxisIndex: 1 },
     ],
   } as EChartsLineChartOption;
 });


### PR DESCRIPTION
## Summary

Adds a 做种积分 (seeding-points / `seedingBonus`) total series to the aggregate summary chart in `UserDataStatistic/Index.vue`. The summary chart previously totalled only `uploaded`, `downloaded`, and `bonus` (魔力); this adds the `seedingBonus` total alongside them, sharing the existing bonus (right) y-axis.

The new series mirrors the existing `bonus` series exactly: it sums per-site `seedingBonus` via the existing `getTotalDataByField` helper, and is added to the chart subtext, legend, tooltip formatter, and series list.

## Why this matters

Issue #1270 asks for both 分享率 (share ratio) and 做种积分 (seeding points) on the data statistics page. In that thread the maintainer noted share-ratio is problematic (extreme values, and not every site exposes ratio so it must be derived from up/down) but confirmed seeding points is fine to add ("做种积分 这个倒是没问题"). This PR implements the maintainer-approved seeding-points half only; the share-ratio half is intentionally left out per the stated concerns.

`seedingBonus` is already a tracked numeric field and already appears in the per-site charts (`perSiteChartField`), so surfacing it on the summary chart is a natural, low-risk addition.

## Testing

- `pnpm run check` (vue-tsc) passes with no errors.
- Prettier formatting clean on the touched file.
- Sites that do not report `seedingBonus` contribute 0 via the existing `getTotalDataByField` summing/`filter(isNumber)` logic, so the series renders as a flat/zero line rather than throwing when no data is present.

Refs #1270

## Summary by Sourcery

Add seeding-points totals to the user data statistics aggregate chart and display them alongside existing upload, download, and bonus series.

New Features:
- Display a seedingBonus total line series on the overall user data statistics chart.
- Show the latest seedingBonus total in the chart subtitle and legend using the existing numeric axis shared with bonus values.