### PR TITLE
fix:recommendation pic fix

### DIFF
--- a/src/entries/offscreen/utils/socialRecommendations.ts
+++ b/src/entries/offscreen/utils/socialRecommendations.ts
@@ -4,8 +4,11 @@ import { getSocialRecommendations } from "@ptd/social";
 import type { ISocialRecommendationItem } from "@ptd/social";
 
 import { onMessage } from "@/messages.ts";
+import { setupReplaceUnsafeHeader } from "~/extends/axios/replaceUnsafeHeader.ts";
 import { logger } from "./logger.ts";
 import { getSocialInformation } from "./socialInformation.ts";
+
+setupReplaceUnsafeHeader(axios);
 
 type TRecommendationEnrichmentMode = "all" | "none" | "visible";
 
@@ -69,6 +72,10 @@ function getPosterFetchOptions(enrichment: TRecommendationEnrichmentMode) {
       };
 }
 
+function isDoubanPosterUrl(poster?: string) {
+  return !!poster && /doubanio\.com/.test(poster);
+}
+
 async function getSocialInformationSafely(item: ISocialRecommendationItem) {
   try {
     return await getSocialInformation(item.site, item.id, {
@@ -118,6 +125,7 @@ async function fetchPosterDataUrl(
   for (const candidate of candidates) {
     try {
       const response = await axios.get<Blob>(candidate, {
+        headers: isDoubanPosterUrl(candidate) ? { Referer: "https://m.douban.com/" } : undefined,
         responseType: "blob",
         timeout: posterFetchOptions.timeout,
       });
@@ -149,7 +157,7 @@ async function enrichRecommendation(
 
   return {
     ...item,
-    poster: poster || item.poster,
+    poster: poster || (isDoubanPosterUrl(item.poster) ? undefined : item.poster),
     summary: socialInformation?.summary || item.summary,
     releaseYear: socialInformation?.releaseYear || item.releaseYear,
     region: socialInformation?.region || item.region,

--- a/src/entries/options/views/Layout/RecommendationMenu.vue
+++ b/src/entries/options/views/Layout/RecommendationMenu.vue
@@ -162,6 +162,14 @@ function getRecommendationRegionClass(region?: string) {
     : "hot-recommendation-chip-region-foreign";
 }
 
+function getRecommendationPosterSrc(item: ISocialRecommendationItem) {
+  if (!item.poster || /doubanio\.com/.test(item.poster)) {
+    return "/icons/movie_placeholder.png";
+  }
+
+  return item.poster;
+}
+
 watch(isRecommendationMenuOpen, (isOpen) => {
   if (isOpen) {
     loadRecommendations();
@@ -239,7 +247,7 @@ watch(isRecommendationMenuOpen, (isOpen) => {
               >
                 <template #prepend>
                   <v-img
-                    :src="item.poster || '/icons/movie_placeholder.png'"
+                    :src="getRecommendationPosterSrc(item)"
                     class="hot-recommendation-poster mr-2"
                     cover
                     referrerpolicy="no-referrer"


### PR DESCRIPTION
修复豆瓣图片加载报错问题

## Summary by Sourcery

Fix handling of recommendation posters from Douban to avoid image loading errors and ensure safe header usage for Axios requests.

Bug Fixes:
- Add a Douban-specific Referer header when fetching poster blobs to prevent image load failures.
- Avoid reusing original Douban poster URLs when enrichment fails, falling back to placeholders instead.

Enhancements:
- Initialize Axios with a helper that replaces unsafe headers in the offscreen social recommendations module.
- Centralize recommendation poster src selection in the options UI and default to a placeholder for invalid or Douban-hosted images.