### PR TITLE
fix: guard undefined chrome.contextMenus/omnibox so Firefox Android background loads and backup restore works

### DIFF
--- a/src/entries/background/utils/contextMenus.ts
+++ b/src/entries/background/utils/contextMenus.ts
@@ -18,15 +18,17 @@ const contextMenusClickEventBus = new Map<
   (info: chrome.contextMenus.OnClickData, tab: chrome.tabs.Tab) => void
 >();
 
-chrome.contextMenus.onClicked.addListener((info, tab) => {
-  if (!info.menuItemId || !contextMenusClickEventBus.has(info.menuItemId)) {
-    return;
-  }
-  const clickHandler = contextMenusClickEventBus.get(info.menuItemId);
-  if (clickHandler) {
-    clickHandler(info, tab!);
-  }
-});
+if (chrome.contextMenus) {
+  chrome.contextMenus.onClicked.addListener((info, tab) => {
+    if (!info.menuItemId || !contextMenusClickEventBus.has(info.menuItemId)) {
+      return;
+    }
+    const clickHandler = contextMenusClickEventBus.get(info.menuItemId);
+    if (clickHandler) {
+      clickHandler(info, tab!);
+    }
+  });
+}
 
 function addContextMenu(data: chrome.contextMenus.CreateProperties) {
   if (!data.id) {
@@ -409,8 +411,10 @@ async function initContextMenus(tab: chrome.tabs.Tab) {
   }
 }
 
-chrome.tabs.onActivated.addListener((actionInfo: chrome.tabs.OnActivatedInfo) => {
-  chrome.tabs.get(actionInfo.tabId, (tab: chrome.tabs.Tab) => {
-    initContextMenus(tab).catch((err) => console.error("Failed to initialize context menus:", err));
+if (chrome.contextMenus) {
+  chrome.tabs.onActivated.addListener((actionInfo: chrome.tabs.OnActivatedInfo) => {
+    chrome.tabs.get(actionInfo.tabId, (tab: chrome.tabs.Tab) => {
+      initContextMenus(tab).catch((err) => console.error("Failed to initialize context menus:", err));
+    });
   });
-});
+}

--- a/src/entries/background/utils/contextMenus.ts
+++ b/src/entries/background/utils/contextMenus.ts
@@ -18,17 +18,15 @@ const contextMenusClickEventBus = new Map<
   (info: chrome.contextMenus.OnClickData, tab: chrome.tabs.Tab) => void
 >();
 
-if (chrome.contextMenus) {
-  chrome.contextMenus.onClicked.addListener((info, tab) => {
-    if (!info.menuItemId || !contextMenusClickEventBus.has(info.menuItemId)) {
-      return;
-    }
-    const clickHandler = contextMenusClickEventBus.get(info.menuItemId);
-    if (clickHandler) {
-      clickHandler(info, tab!);
-    }
-  });
-}
+chrome.contextMenus?.onClicked.addListener((info, tab) => {
+  if (!info.menuItemId || !contextMenusClickEventBus.has(info.menuItemId)) {
+    return;
+  }
+  const clickHandler = contextMenusClickEventBus.get(info.menuItemId);
+  if (clickHandler) {
+    clickHandler(info, tab!);
+  }
+});
 
 function addContextMenu(data: chrome.contextMenus.CreateProperties) {
   if (!data.id) {
@@ -41,21 +39,21 @@ function addContextMenu(data: chrome.contextMenus.CreateProperties) {
     delete data.onclick; // 删除 onclick 属性，因为 chrome.contextMenus.create 不支持直接传入 onclick
   }
 
-  chrome.contextMenus.create(data);
+  chrome.contextMenus?.create(data);
   return data.id;
 }
 
 onMessage("addContextMenu", async ({ data }) => addContextMenu(data));
 
 function removeContextMenu(id: string) {
-  chrome.contextMenus.remove(id).catch();
+  chrome.contextMenus?.remove(id).catch();
   contextMenusClickEventBus.delete(id);
 }
 
 onMessage("removeContextMenu", async ({ data }) => removeContextMenu(data));
 
 function clearContextMenus() {
-  chrome.contextMenus.removeAll().catch();
+  chrome.contextMenus?.removeAll().catch();
   contextMenusClickEventBus.clear();
 }
 
@@ -141,7 +139,7 @@ async function createSearchMenu(baseMenuId: string, options: ICreateSearchMenuOp
     title: chrome.i18n.getMessage("contextMenuSearchInDefault"),
     contexts: ["selection"],
     ...extraCreateMenuProperties,
-    onclick: (info: chrome.contextMenus.OnClickData, tab: chrome.tabs.Tab) => {
+    onclick: (info) => {
       openOptionsPage({
         path: "/search-entity",
         query: { search: selectionTextFilterFn(info), flush: 1 },
@@ -169,7 +167,7 @@ async function createSearchMenu(baseMenuId: string, options: ICreateSearchMenuOp
         title: solution.name,
         contexts: ["selection"],
         ...extraCreateMenuProperties,
-        onclick: (info: chrome.contextMenus.OnClickData, tab: chrome.tabs.Tab) => {
+        onclick: (info) => {
           openOptionsPage({
             path: "/search-entity",
             query: { search: selectionTextFilterFn(info), plan: solution.id, flush: 1 },
@@ -211,7 +209,7 @@ async function createSearchMenu(baseMenuId: string, options: ICreateSearchMenuOp
         title: siteTitle,
         contexts: ["selection"],
         ...extraCreateMenuProperties,
-        onclick: (info: chrome.contextMenus.OnClickData, tab: chrome.tabs.Tab) => {
+        onclick: (info) => {
           openOptionsPage({
             path: "/search-entity",
             query: { search: selectionTextFilterFn(info), plan: `site:${site.id}`, flush: 1 },
@@ -228,7 +226,7 @@ async function createSearchMenu(baseMenuId: string, options: ICreateSearchMenuOp
       title: chrome.i18n.getMessage("contextMenuSearchInThisSite"),
       contexts: ["selection"],
       ...extraCreateMenuProperties,
-      onclick: (info: chrome.contextMenus.OnClickData, tab: chrome.tabs.Tab) => {
+      onclick: (info) => {
         openOptionsPage({
           path: "/search-entity",
           query: { search: info.selectionText, plan: `site:${thisTabSiteId}`, flush: 1 },
@@ -336,7 +334,7 @@ async function initContextMenus(tab: chrome.tabs.Tab) {
         parentId: baseLinkDownloadPushMenuId,
         title: chrome.i18n.getMessage("contextMenuSendToDownloaderAdvanced"),
         contexts: ["link"],
-        onclick: (info: chrome.contextMenus.OnClickData, tab: chrome.tabs.Tab) => {
+        onclick: (info) => {
           openOptionsPage({ path: "/link-push", query: { link: info.linkUrl! } });
         },
       });
@@ -359,7 +357,7 @@ async function initContextMenus(tab: chrome.tabs.Tab) {
           title: chrome.i18n.getMessage("contextMenuSendToDownloaderIn", [downloader.name, downloader.address]),
           contexts: ["link"],
           // 此处不用担心子目录问题，因为如果有子目录，此处的 onclick 不会被 chrome 触发
-          onclick: (info: chrome.contextMenus.OnClickData, tab: chrome.tabs.Tab) => {
+          onclick: (info, tab) => {
             downloadLinkPush(info.linkUrl!, downloader, undefined, tab?.title, tab?.url);
           },
         });
@@ -400,7 +398,7 @@ async function initContextMenus(tab: chrome.tabs.Tab) {
               parentId: downloaderPushSubMenuId,
               title: `-> ${suggestFolder || chrome.i18n.getMessage("contextMenuSendToDownloaderDefaultFolder")}`, // 如果是空字符串，则显示为 "默认文件夹"
               contexts: ["link"],
-              onclick: (info: chrome.contextMenus.OnClickData, tab: chrome.tabs.Tab) => {
+              onclick: (info, tab) => {
                 downloadLinkPush(info.linkUrl!, downloader, suggestFolder, tab?.title, tab?.url);
               },
             });
@@ -410,10 +408,9 @@ async function initContextMenus(tab: chrome.tabs.Tab) {
     }
   }
 }
-
 if (chrome.contextMenus) {
   chrome.tabs.onActivated.addListener((actionInfo: chrome.tabs.OnActivatedInfo) => {
-    chrome.tabs.get(actionInfo.tabId, (tab: chrome.tabs.Tab) => {
+    chrome.tabs.get(actionInfo.tabId, (tab) => {
       initContextMenus(tab).catch((err) => console.error("Failed to initialize context menus:", err));
     });
   });

--- a/src/entries/background/utils/omnibox.ts
+++ b/src/entries/background/utils/omnibox.ts
@@ -39,41 +39,39 @@ async function getSearchSolution(getAll = false) {
   return solutionsList;
 }
 
-if (chrome.omnibox) {
-  chrome.omnibox.onInputChanged.addListener(async (text, suggest) => {
-    if (!text) return;
+chrome.omnibox?.onInputChanged.addListener(async (text, suggest) => {
+  if (!text) return;
 
-    const solutions = await getSearchSolution();
-    let result: chrome.omnibox.SuggestResult[] = solutions.map((x) => ({
-      content: `${x.name}${splitString}${text}`,
-      description: chrome.i18n.getMessage("omniboxSearch", [x.name, text]),
-    }));
+  const solutions = await getSearchSolution();
+  let result: chrome.omnibox.SuggestResult[] = solutions.map((x) => ({
+    content: `${x.name}${splitString}${text}`,
+    description: chrome.i18n.getMessage("omniboxSearch", [x.name, text]),
+  }));
 
-    suggest(result);
-  });
+  suggest(result);
+});
 
-  // 当用户接收关键字建议时触发
-  chrome.omnibox.onInputEntered.addListener(async (text) => {
-    let solutionName = "";
-    let solutionId = "default";
-    let key = "";
+// 当用户接收关键字建议时触发
+chrome.omnibox?.onInputEntered.addListener(async (text) => {
+  let solutionName = "";
+  let solutionId = "default";
+  let key = "";
 
-    if (text.indexOf(splitString) != -1) {
-      const solutions = await getSearchSolution(true);
+  if (text.indexOf(splitString) != -1) {
+    const solutions = await getSearchSolution(true);
 
-      [solutionName, key] = text.split(splitString);
+    [solutionName, key] = text.split(splitString);
 
-      let solution = solutions.find((item: ISearchSolution) => {
-        return item.name == solutionName;
-      });
-      if (solution) {
-        solutionId = solution.value;
-      }
-    } else {
-      key = text;
+    let solution = solutions.find((item: ISearchSolution) => {
+      return item.name == solutionName;
+    });
+    if (solution) {
+      solutionId = solution.value;
     }
+  } else {
+    key = text;
+  }
 
-    // 按关键字进行搜索
-    openOptionsPage({ path: "/search-entity", query: { search: key, plan: solutionId, flush: 1 } });
-  });
-}
+  // 按关键字进行搜索
+  openOptionsPage({ path: "/search-entity", query: { search: key, plan: solutionId, flush: 1 } });
+});

--- a/src/entries/background/utils/omnibox.ts
+++ b/src/entries/background/utils/omnibox.ts
@@ -39,39 +39,41 @@ async function getSearchSolution(getAll = false) {
   return solutionsList;
 }
 
-chrome.omnibox.onInputChanged.addListener(async (text, suggest) => {
-  if (!text) return;
+if (chrome.omnibox) {
+  chrome.omnibox.onInputChanged.addListener(async (text, suggest) => {
+    if (!text) return;
 
-  const solutions = await getSearchSolution();
-  let result: chrome.omnibox.SuggestResult[] = solutions.map((x) => ({
-    content: `${x.name}${splitString}${text}`,
-    description: chrome.i18n.getMessage("omniboxSearch", [x.name, text]),
-  }));
+    const solutions = await getSearchSolution();
+    let result: chrome.omnibox.SuggestResult[] = solutions.map((x) => ({
+      content: `${x.name}${splitString}${text}`,
+      description: chrome.i18n.getMessage("omniboxSearch", [x.name, text]),
+    }));
 
-  suggest(result);
-});
+    suggest(result);
+  });
 
-// 当用户接收关键字建议时触发
-chrome.omnibox.onInputEntered.addListener(async (text) => {
-  let solutionName = "";
-  let solutionId = "default";
-  let key = "";
+  // 当用户接收关键字建议时触发
+  chrome.omnibox.onInputEntered.addListener(async (text) => {
+    let solutionName = "";
+    let solutionId = "default";
+    let key = "";
 
-  if (text.indexOf(splitString) != -1) {
-    const solutions = await getSearchSolution(true);
+    if (text.indexOf(splitString) != -1) {
+      const solutions = await getSearchSolution(true);
 
-    [solutionName, key] = text.split(splitString);
+      [solutionName, key] = text.split(splitString);
 
-    let solution = solutions.find((item: ISearchSolution) => {
-      return item.name == solutionName;
-    });
-    if (solution) {
-      solutionId = solution.value;
+      let solution = solutions.find((item: ISearchSolution) => {
+        return item.name == solutionName;
+      });
+      if (solution) {
+        solutionId = solution.value;
+      }
+    } else {
+      key = text;
     }
-  } else {
-    key = text;
-  }
 
-  // 按关键字进行搜索
-  openOptionsPage({ path: "/search-entity", query: { search: key, plan: solutionId, flush: 1 } });
-});
+    // 按关键字进行搜索
+    openOptionsPage({ path: "/search-entity", query: { search: key, plan: solutionId, flush: 1 } });
+  });
+}


### PR DESCRIPTION
## Summary

Guards `chrome.contextMenus` and `chrome.omnibox` usage in the background script so the extension loads on Firefox for Android, where those APIs are not available. Previously the background script threw on startup when registering context-menu and omnibox listeners, which broke the whole background page and left features like backup restore unresponsive.

## Why this matters

Issue #858 reports that on Firefox Android, backup restore does nothing. The root cause is that the background script unconditionally calls `chrome.contextMenus.*` and `chrome.omnibox.*` at startup. Firefox Android does not implement those extension APIs, so the calls throw, the background page fails to initialize, and every background-driven action (including restore) silently does nothing.

This wraps the context-menu and omnibox registration in existence checks (`chrome.contextMenus`/`chrome.omnibox` present before use), so on platforms without those APIs the background page still loads and the rest of the extension keeps working. On Chrome and desktop Firefox the behavior is unchanged.

## Testing

TypeScript type-check and the Chrome extension build both pass. The change is limited to defensive existence guards around the two optional APIs; on Chrome the guarded code paths run exactly as before, and on a platform lacking the APIs the background page now initializes instead of throwing.

Fixes #858

## Summary by Sourcery

Guard background omnibox and context menu registration behind availability checks so the extension runs on browsers where those APIs are missing.

Bug Fixes:
- Prevent background script crashes on platforms without chrome.omnibox by conditionally registering omnibox listeners.
- Avoid context menu initialization on platforms lacking chrome.contextMenus to keep the background page functional.