### PR TITLE
feat: add search plan into social search entry

### DIFF
--- a/src/entries/content-script/app/components/SocialSiteParseResultsDialog.vue
+++ b/src/entries/content-script/app/components/SocialSiteParseResultsDialog.vue
@@ -1,31 +1,23 @@
 <script setup lang="ts">
 import { ISocialSitePageInformation } from "@ptd/social";
 import { doKeywordSearch, type IPtdData } from "../utils.ts";
-import { computed, inject, onMounted, ref } from "vue";
+import { computed, inject } from "vue";
 import { useI18n } from "vue-i18n";
 import { useMetadataStore } from "@/options/stores/metadata.ts";
-import { sendMessage } from "@/messages.ts";
 
 const { t } = useI18n();
 const metadataStore = useMetadataStore();
-const metadataReady = ref(false);
 
 const showDialog = defineModel<boolean>();
-const { parseResults, defaultPlan = "default" } = defineProps<{
+const { parseResults, searchPlan = "default" } = defineProps<{
   parseResults: ISocialSitePageInformation[];
-  defaultPlan?: string;
+  searchPlan?: string;
 }>();
 
 const ptdData = inject<IPtdData>("ptd_data", {});
 
-onMounted(() => {
-  metadataStore.$onReady(() => {
-    metadataReady.value = true;
-  });
-});
-
 const customSearchPlans = computed(() => {
-  if (!metadataReady.value) {
+  if (!metadataStore.$ready) {
     return [];
   }
 
@@ -34,7 +26,7 @@ const customSearchPlans = computed(() => {
     .sort((a, b) => b.sort - a.sort)
     .map((solution) => ({
       id: solution.id,
-      name: metadataStore.getSearchSolutionName(solution.id),
+      name: solution.name ?? solution.id,
     }));
 });
 
@@ -62,7 +54,9 @@ function shouldCollapseTitles(result: ISocialSitePageInformation) {
 
 function getCollapseTitle(result: ISocialSitePageInformation) {
   if (ptdData.socialSite === "tmdb" && result.pageCategory === "season_list") {
-    return `搜索${result.entryTitle || "单季"}`;
+    return t("contentScript.SocialSiteParseResultsDialog.searchEntryTitle", {
+      title: result.entryTitle || t("contentScript.SocialSiteParseResultsDialog.defaultSeasonTitle"),
+    });
   }
 
   return t("contentScript.SocialSiteParseResultsDialog.searchTitle");
@@ -70,24 +64,6 @@ function getCollapseTitle(result: ISocialSitePageInformation) {
 
 function getResultKey(result: ISocialSitePageInformation, index: number) {
   return `${result.id}|${result.pageCategory ?? "default"}|${result.titles[0] ?? index}`;
-}
-
-function searchByPlan(keyword: string, plan: string = defaultPlan) {
-  if (plan === "default") {
-    doKeywordSearch(keyword);
-    return;
-  }
-
-  if (!keyword) {
-    keyword = prompt("未解析到搜索关键词，请输入：", "")!;
-  }
-
-  if (keyword) {
-    sendMessage("openOptionsPage", {
-      path: "/search-entity",
-      query: { search: keyword, plan, flush: 1 },
-    }).catch();
-  }
 }
 
 function shouldShowSiteId(result: ISocialSitePageInformation, index: number) {
@@ -128,7 +104,7 @@ function shouldShowSeriesTitle(result: ISocialSitePageInformation, index: number
             <v-list-item
               v-if="shouldShowSiteId(result, index)"
               :title="`${ptdData.socialSite}: ${result.id}`"
-              @click="() => searchByPlan(buildSiteSearchKeyword(result))"
+              @click="() => doKeywordSearch(buildSiteSearchKeyword(result), searchPlan)"
             >
               <template #append>
                 <v-chip color="indigo">{{ t("contentScript.SocialSiteParseResultsDialog.searchId") }}</v-chip>
@@ -140,7 +116,7 @@ function shouldShowSeriesTitle(result: ISocialSitePageInformation, index: number
                     v-for="plan in searchPlans"
                     :key="`${result.id}|id|${plan.id}`"
                     :title="plan.name"
-                    @click.stop="searchByPlan(buildSiteSearchKeyword(result), plan.id)"
+                    @click.stop="doKeywordSearch(buildSiteSearchKeyword(result), plan.id)"
                   />
                 </v-list>
               </v-menu>
@@ -150,7 +126,7 @@ function shouldShowSeriesTitle(result: ISocialSitePageInformation, index: number
                 v-for="(externalId, externalType) in result.external_ids"
                 :key="`${result.id}|${externalType}|${externalId}`"
                 :title="`${externalType}: ${externalId}`"
-                @click="() => searchByPlan(`${externalType}|${externalId}`)"
+                @click="() => doKeywordSearch(`${externalType}|${externalId}`, searchPlan)"
               >
                 <template #append>
                   <v-chip color="green">{{ t("contentScript.SocialSiteParseResultsDialog.searchExternalId") }}</v-chip>
@@ -162,7 +138,7 @@ function shouldShowSeriesTitle(result: ISocialSitePageInformation, index: number
                       v-for="plan in searchPlans"
                       :key="`${result.id}|${externalType}|${plan.id}`"
                       :title="plan.name"
-                      @click.stop="searchByPlan(`${externalType}|${externalId}`, plan.id)"
+                      @click.stop="doKeywordSearch(`${externalType}|${externalId}`, plan.id)"
                     />
                   </v-list>
                 </v-menu>
@@ -171,7 +147,7 @@ function shouldShowSeriesTitle(result: ISocialSitePageInformation, index: number
             <v-list-item
               v-if="shouldShowSeriesTitle(result, index)"
               :title="result.seriesTitle"
-              @click="() => searchByPlan(result.seriesTitle!)"
+              @click="() => doKeywordSearch(result.seriesTitle!, searchPlan)"
             >
               <template #append>
                 <v-chip color="blue-grey">{{ t("contentScript.SocialSiteParseResultsDialog.searchTitle") }}</v-chip>
@@ -183,7 +159,7 @@ function shouldShowSeriesTitle(result: ISocialSitePageInformation, index: number
                     v-for="plan in searchPlans"
                     :key="`${result.id}|series|${plan.id}`"
                     :title="plan.name"
-                    @click.stop="searchByPlan(result.seriesTitle!, plan.id)"
+                    @click.stop="doKeywordSearch(result.seriesTitle!, plan.id)"
                   />
                 </v-list>
               </v-menu>
@@ -197,7 +173,7 @@ function shouldShowSeriesTitle(result: ISocialSitePageInformation, index: number
                   <v-expansion-panel-text class="pa-0">
                     <v-list density="compact">
                       <template v-for="title in result.titles" :key="`${result.id}|${title}`">
-                        <v-list-item :title="title" @click="() => searchByPlan(title)">
+                        <v-list-item :title="title" @click="() => doKeywordSearch(title, searchPlan)">
                           <template #append>
                             <v-chip color="blue-grey">{{
                               t("contentScript.SocialSiteParseResultsDialog.searchTitle")
@@ -210,7 +186,7 @@ function shouldShowSeriesTitle(result: ISocialSitePageInformation, index: number
                                 v-for="plan in searchPlans"
                                 :key="`${result.id}|${title}|${plan.id}`"
                                 :title="plan.name"
-                                @click.stop="searchByPlan(title, plan.id)"
+                                @click.stop="doKeywordSearch(title, plan.id)"
                               />
                             </v-list>
                           </v-menu>
@@ -222,7 +198,7 @@ function shouldShowSeriesTitle(result: ISocialSitePageInformation, index: number
               </v-expansion-panels>
             </template>
             <template v-else v-for="title in result.titles" :key="`${result.id}|${title}`">
-              <v-list-item :title="title" @click="() => searchByPlan(title)">
+              <v-list-item :title="title" @click="() => doKeywordSearch(title, searchPlan)">
                 <template #append>
                   <v-chip color="blue-grey">{{ t("contentScript.SocialSiteParseResultsDialog.searchTitle") }}</v-chip>
                 </template>
@@ -233,7 +209,7 @@ function shouldShowSeriesTitle(result: ISocialSitePageInformation, index: number
                       v-for="plan in searchPlans"
                       :key="`${result.id}|${title}|${plan.id}`"
                       :title="plan.name"
-                      @click.stop="searchByPlan(title, plan.id)"
+                      @click.stop="doKeywordSearch(title, plan.id)"
                     />
                   </v-list>
                 </v-menu>

--- a/src/entries/content-script/app/components/SocialSiteParseResultsDialog.vue
+++ b/src/entries/content-script/app/components/SocialSiteParseResultsDialog.vue
@@ -1,15 +1,52 @@
 <script setup lang="ts">
 import { ISocialSitePageInformation } from "@ptd/social";
 import { doKeywordSearch, type IPtdData } from "../utils.ts";
-import { inject } from "vue";
+import { computed, inject, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
+import { useMetadataStore } from "@/options/stores/metadata.ts";
+import { sendMessage } from "@/messages.ts";
 
 const { t } = useI18n();
+const metadataStore = useMetadataStore();
+const metadataReady = ref(false);
 
 const showDialog = defineModel<boolean>();
-const { parseResults } = defineProps<{ parseResults: ISocialSitePageInformation[] }>();
+const { parseResults, defaultPlan = "default" } = defineProps<{
+  parseResults: ISocialSitePageInformation[];
+  defaultPlan?: string;
+}>();
 
 const ptdData = inject<IPtdData>("ptd_data", {});
+
+onMounted(() => {
+  metadataStore.$onReady(() => {
+    metadataReady.value = true;
+  });
+});
+
+const searchPlans = computed(() => {
+  if (!metadataReady.value) {
+    return [{ id: "default", name: t("layout.header.searchPlan.default") }];
+  }
+
+  const plans = [{ id: "default", name: t("layout.header.searchPlan.default") }];
+
+  if (metadataStore.defaultSolutionId !== "default") {
+    plans.push({ id: "all", name: t("layout.header.searchPlan.all") });
+  }
+
+  plans.push(
+    ...metadataStore.getSearchSolutions
+      .filter((solution) => !!solution.enabled)
+      .sort((a, b) => b.sort - a.sort)
+      .map((solution) => ({
+        id: solution.id,
+        name: metadataStore.getSearchSolutionName(solution.id),
+      })),
+  );
+
+  return plans;
+});
 
 function buildSiteSearchKeyword(result: ISocialSitePageInformation) {
   return `${ptdData.socialSite!}|${result.id}`;
@@ -29,6 +66,24 @@ function getCollapseTitle(result: ISocialSitePageInformation) {
 
 function getResultKey(result: ISocialSitePageInformation, index: number) {
   return `${result.id}|${result.pageCategory ?? "default"}|${result.titles[0] ?? index}`;
+}
+
+function searchByPlan(keyword: string, plan: string = defaultPlan) {
+  if (plan === "default") {
+    doKeywordSearch(keyword);
+    return;
+  }
+
+  if (!keyword) {
+    keyword = prompt("未解析到搜索关键词，请输入：", "")!;
+  }
+
+  if (keyword) {
+    sendMessage("openOptionsPage", {
+      path: "/search-entity",
+      query: { search: keyword, plan, flush: 1 },
+    }).catch();
+  }
 }
 
 function shouldShowSiteId(result: ISocialSitePageInformation, index: number) {
@@ -69,32 +124,65 @@ function shouldShowSeriesTitle(result: ISocialSitePageInformation, index: number
             <v-list-item
               v-if="shouldShowSiteId(result, index)"
               :title="`${ptdData.socialSite}: ${result.id}`"
-              @click="() => doKeywordSearch(buildSiteSearchKeyword(result))"
+              @click="() => searchByPlan(buildSiteSearchKeyword(result))"
             >
               <template #append>
                 <v-chip color="indigo">{{ t("contentScript.SocialSiteParseResultsDialog.searchId") }}</v-chip>
               </template>
+              <v-menu activator="parent" location="end" open-on-hover>
+                <v-list density="compact">
+                  <v-list-subheader>{{ t("contentScript.SocialSiteParseResultsDialog.searchPlan") }}</v-list-subheader>
+                  <v-list-item
+                    v-for="plan in searchPlans"
+                    :key="`${result.id}|id|${plan.id}`"
+                    :title="plan.name"
+                    @click.stop="searchByPlan(buildSiteSearchKeyword(result), plan.id)"
+                  />
+                </v-list>
+              </v-menu>
             </v-list-item>
             <template v-if="result.external_ids && shouldShowExternalIds(result, index)">
               <v-list-item
                 v-for="(externalId, externalType) in result.external_ids"
                 :key="`${result.id}|${externalType}|${externalId}`"
                 :title="`${externalType}: ${externalId}`"
-                @click="() => doKeywordSearch(`${externalType}|${externalId}`)"
+                @click="() => searchByPlan(`${externalType}|${externalId}`)"
               >
                 <template #append>
                   <v-chip color="green">{{ t("contentScript.SocialSiteParseResultsDialog.searchExternalId") }}</v-chip>
                 </template>
+                <v-menu activator="parent" location="end" open-on-hover>
+                  <v-list density="compact">
+                    <v-list-subheader>{{ t("contentScript.SocialSiteParseResultsDialog.searchPlan") }}</v-list-subheader>
+                    <v-list-item
+                      v-for="plan in searchPlans"
+                      :key="`${result.id}|${externalType}|${plan.id}`"
+                      :title="plan.name"
+                      @click.stop="searchByPlan(`${externalType}|${externalId}`, plan.id)"
+                    />
+                  </v-list>
+                </v-menu>
               </v-list-item>
             </template>
             <v-list-item
               v-if="shouldShowSeriesTitle(result, index)"
               :title="result.seriesTitle"
-              @click="() => doKeywordSearch(result.seriesTitle!)"
+              @click="() => searchByPlan(result.seriesTitle!)"
             >
               <template #append>
                 <v-chip color="blue-grey">{{ t("contentScript.SocialSiteParseResultsDialog.searchTitle") }}</v-chip>
               </template>
+              <v-menu activator="parent" location="end" open-on-hover>
+                <v-list density="compact">
+                  <v-list-subheader>{{ t("contentScript.SocialSiteParseResultsDialog.searchPlan") }}</v-list-subheader>
+                  <v-list-item
+                    v-for="plan in searchPlans"
+                    :key="`${result.id}|series|${plan.id}`"
+                    :title="plan.name"
+                    @click.stop="searchByPlan(result.seriesTitle!, plan.id)"
+                  />
+                </v-list>
+              </v-menu>
             </v-list-item>
             <template v-if="shouldCollapseTitles(result)">
               <v-expansion-panels variant="accordion" flat>
@@ -105,12 +193,23 @@ function shouldShowSeriesTitle(result: ISocialSitePageInformation, index: number
                   <v-expansion-panel-text class="pa-0">
                     <v-list density="compact">
                       <template v-for="title in result.titles" :key="`${result.id}|${title}`">
-                        <v-list-item :title="title" @click="() => doKeywordSearch(title)">
+                        <v-list-item :title="title" @click="() => searchByPlan(title)">
                           <template #append>
                             <v-chip color="blue-grey">{{
                               t("contentScript.SocialSiteParseResultsDialog.searchTitle")
                             }}</v-chip>
                           </template>
+                          <v-menu activator="parent" location="end" open-on-hover>
+                            <v-list density="compact">
+                              <v-list-subheader>{{ t("contentScript.SocialSiteParseResultsDialog.searchPlan") }}</v-list-subheader>
+                              <v-list-item
+                                v-for="plan in searchPlans"
+                                :key="`${result.id}|${title}|${plan.id}`"
+                                :title="plan.name"
+                                @click.stop="searchByPlan(title, plan.id)"
+                              />
+                            </v-list>
+                          </v-menu>
                         </v-list-item>
                       </template>
                     </v-list>
@@ -119,10 +218,21 @@ function shouldShowSeriesTitle(result: ISocialSitePageInformation, index: number
               </v-expansion-panels>
             </template>
             <template v-else v-for="title in result.titles" :key="`${result.id}|${title}`">
-              <v-list-item :title="title" @click="() => doKeywordSearch(title)">
+              <v-list-item :title="title" @click="() => searchByPlan(title)">
                 <template #append>
                   <v-chip color="blue-grey">{{ t("contentScript.SocialSiteParseResultsDialog.searchTitle") }}</v-chip>
                 </template>
+                <v-menu activator="parent" location="end" open-on-hover>
+                  <v-list density="compact">
+                    <v-list-subheader>{{ t("contentScript.SocialSiteParseResultsDialog.searchPlan") }}</v-list-subheader>
+                    <v-list-item
+                      v-for="plan in searchPlans"
+                      :key="`${result.id}|${title}|${plan.id}`"
+                      :title="plan.name"
+                      @click.stop="searchByPlan(title, plan.id)"
+                    />
+                  </v-list>
+                </v-menu>
               </v-list-item>
             </template>
             <v-divider v-if="index != parseResults.length - 1" inset />

--- a/src/entries/content-script/app/components/SocialSiteParseResultsDialog.vue
+++ b/src/entries/content-script/app/components/SocialSiteParseResultsDialog.vue
@@ -24,29 +24,33 @@ onMounted(() => {
   });
 });
 
-const searchPlans = computed(() => {
+const customSearchPlans = computed(() => {
   if (!metadataReady.value) {
-    return [{ id: "default", name: t("layout.header.searchPlan.default") }];
+    return [];
   }
 
+  return metadataStore.getSearchSolutions
+    .filter((solution) => !!solution.enabled)
+    .sort((a, b) => b.sort - a.sort)
+    .map((solution) => ({
+      id: solution.id,
+      name: metadataStore.getSearchSolutionName(solution.id),
+    }));
+});
+
+const searchPlans = computed(() => {
   const plans = [{ id: "default", name: t("layout.header.searchPlan.default") }];
 
   if (metadataStore.defaultSolutionId !== "default") {
     plans.push({ id: "all", name: t("layout.header.searchPlan.all") });
   }
 
-  plans.push(
-    ...metadataStore.getSearchSolutions
-      .filter((solution) => !!solution.enabled)
-      .sort((a, b) => b.sort - a.sort)
-      .map((solution) => ({
-        id: solution.id,
-        name: metadataStore.getSearchSolutionName(solution.id),
-      })),
-  );
+  plans.push(...customSearchPlans.value);
 
   return plans;
 });
+
+const shouldShowSearchPlanMenu = computed(() => customSearchPlans.value.length > 0);
 
 function buildSiteSearchKeyword(result: ISocialSitePageInformation) {
   return `${ptdData.socialSite!}|${result.id}`;
@@ -129,7 +133,7 @@ function shouldShowSeriesTitle(result: ISocialSitePageInformation, index: number
               <template #append>
                 <v-chip color="indigo">{{ t("contentScript.SocialSiteParseResultsDialog.searchId") }}</v-chip>
               </template>
-              <v-menu activator="parent" location="end" open-on-hover>
+              <v-menu v-if="shouldShowSearchPlanMenu" activator="parent" location="end" open-on-hover>
                 <v-list density="compact">
                   <v-list-subheader>{{ t("contentScript.SocialSiteParseResultsDialog.searchPlan") }}</v-list-subheader>
                   <v-list-item
@@ -151,7 +155,7 @@ function shouldShowSeriesTitle(result: ISocialSitePageInformation, index: number
                 <template #append>
                   <v-chip color="green">{{ t("contentScript.SocialSiteParseResultsDialog.searchExternalId") }}</v-chip>
                 </template>
-                <v-menu activator="parent" location="end" open-on-hover>
+                <v-menu v-if="shouldShowSearchPlanMenu" activator="parent" location="end" open-on-hover>
                   <v-list density="compact">
                     <v-list-subheader>{{ t("contentScript.SocialSiteParseResultsDialog.searchPlan") }}</v-list-subheader>
                     <v-list-item
@@ -172,7 +176,7 @@ function shouldShowSeriesTitle(result: ISocialSitePageInformation, index: number
               <template #append>
                 <v-chip color="blue-grey">{{ t("contentScript.SocialSiteParseResultsDialog.searchTitle") }}</v-chip>
               </template>
-              <v-menu activator="parent" location="end" open-on-hover>
+              <v-menu v-if="shouldShowSearchPlanMenu" activator="parent" location="end" open-on-hover>
                 <v-list density="compact">
                   <v-list-subheader>{{ t("contentScript.SocialSiteParseResultsDialog.searchPlan") }}</v-list-subheader>
                   <v-list-item
@@ -199,7 +203,7 @@ function shouldShowSeriesTitle(result: ISocialSitePageInformation, index: number
                               t("contentScript.SocialSiteParseResultsDialog.searchTitle")
                             }}</v-chip>
                           </template>
-                          <v-menu activator="parent" location="end" open-on-hover>
+                          <v-menu v-if="shouldShowSearchPlanMenu" activator="parent" location="end" open-on-hover>
                             <v-list density="compact">
                               <v-list-subheader>{{ t("contentScript.SocialSiteParseResultsDialog.searchPlan") }}</v-list-subheader>
                               <v-list-item
@@ -222,7 +226,7 @@ function shouldShowSeriesTitle(result: ISocialSitePageInformation, index: number
                 <template #append>
                   <v-chip color="blue-grey">{{ t("contentScript.SocialSiteParseResultsDialog.searchTitle") }}</v-chip>
                 </template>
-                <v-menu activator="parent" location="end" open-on-hover>
+                <v-menu v-if="shouldShowSearchPlanMenu" activator="parent" location="end" open-on-hover>
                   <v-list density="compact">
                     <v-list-subheader>{{ t("contentScript.SocialSiteParseResultsDialog.searchPlan") }}</v-list-subheader>
                     <v-list-item

--- a/src/entries/content-script/app/utils.ts
+++ b/src/entries/content-script/app/utils.ts
@@ -80,7 +80,7 @@ export function wrapperConfirmFn(fn: () => any, message = "确定要执行此操
   }
 }
 
-export function doKeywordSearch(keywords: string) {
+export function doKeywordSearch(keywords: string, plan: string = "default") {
   if (!keywords) {
     keywords = prompt("未解析到搜索关键词，请输入：", "")!;
   }
@@ -88,7 +88,7 @@ export function doKeywordSearch(keywords: string) {
   if (keywords) {
     sendMessage("openOptionsPage", {
       path: "/search-entity",
-      query: { search: toValue(keywords), flush: 1 },
+      query: { search: toValue(keywords), plan, flush: 1 },
     }).catch();
   } else {
     const runtimeStore = useRuntimeStore();

--- a/src/entries/content-script/app/utils.ts
+++ b/src/entries/content-script/app/utils.ts
@@ -80,7 +80,7 @@ export function wrapperConfirmFn(fn: () => any, message = "确定要执行此操
   }
 }
 
-export function doKeywordSearch(keywords: string, plan: string = "default") {
+export function doKeywordSearch(keywords: string, plan = "default") {
   if (!keywords) {
     keywords = prompt("未解析到搜索关键词，请输入：", "")!;
   }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1011,6 +1011,8 @@
       "title": "Customize batch actions for {0} torrents"
     },
     "SocialSiteParseResultsDialog": {
+      "defaultSeasonTitle": "Season",
+      "searchEntryTitle": "Search {title}",
       "searchPlan": "Search Plan",
       "searchExternalId": "Search External ID",
       "searchId": "Search ID",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1011,6 +1011,7 @@
       "title": "Customize batch actions for {0} torrents"
     },
     "SocialSiteParseResultsDialog": {
+      "searchPlan": "Search Plan",
       "searchExternalId": "Search External ID",
       "searchId": "Search ID",
       "searchTitle": "Search Title",

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -1008,6 +1008,8 @@
       "title": "为 {0} 个种子自定义批量操作行为"
     },
     "SocialSiteParseResultsDialog": {
+      "defaultSeasonTitle": "单季",
+      "searchEntryTitle": "搜索{title}",
       "searchPlan": "搜索方案",
       "searchExternalId": "搜索外部ID",
       "searchId": "搜索ID",

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -1008,6 +1008,7 @@
       "title": "为 {0} 个种子自定义批量操作行为"
     },
     "SocialSiteParseResultsDialog": {
+      "searchPlan": "搜索方案",
       "searchExternalId": "搜索外部ID",
       "searchId": "搜索ID",
       "searchTitle": "搜索标题",


### PR DESCRIPTION
为社交页面提交搜索时增加搜索方案选项 直接点击为默认
存在自定义搜索方案时 出现侧边选择框
<img width="1680" height="881" alt="image" src="https://github.com/user-attachments/assets/502d5343-8a39-4270-ad04-71f8165b1d82" />

## Summary by Sourcery

Add configurable search plans to social page search entries and wire social search actions through the selected or default plan.

New Features:
- Allow selecting a search plan when triggering searches from the social site parse results dialog, with hover menu options per item.
- Support passing a search plan identifier into keyword searches so different search solutions can be used beyond the default configuration.

Enhancements:
- Load available search plans from metadata store and expose them in the social search UI with a default fallback when metadata is not yet ready.
- Localize the search plan label in the parse results dialog for both English and Chinese locales.