### PR TITLE
Parse lastAccessAt from BeyondHD and nCore user profile fields

### DIFF
--- a/src/packages/site/definitions/beyondhd.ts
+++ b/src/packages/site/definitions/beyondhd.ts
@@ -285,6 +285,14 @@ export const siteMetadata: ISiteMetadata = {
           { name: "parseTime", args: ["yyyy-MM-dd"] },
         ],
       },
+      lastAccessAt: {
+        selector: ["td.bhd-user-left:contains('Last Active') + td .bhd-sub-cell"],
+        filters: [
+          { name: "split", args: ["(", 0] },
+          (text: string) => text.replace(/\s+/g, " ").trim(),
+          { name: "parseTime", args: ["EEE, MMM d, yyyy h:mm a"] },
+        ],
+      },
       seedingSize: {
         selector: ["td.bhd-user-left:contains('Active Seed Size') + td span.badge-user"],
         filters: [{ name: "parseSize" }],

--- a/src/packages/site/definitions/ncore.ts
+++ b/src/packages/site/definitions/ncore.ts
@@ -1,4 +1,5 @@
 import type { ISiteMetadata } from "../types";
+import { parseTimeToLiveToDate } from "../utils/datetime.ts";
 
 export const siteMetadata: ISiteMetadata = {
   id: "ncore",
@@ -31,6 +32,22 @@ export const siteMetadata: ISiteMetadata = {
             selector: ["div.userbox_tartalom_mini:nth-child(2) > div:nth-child(2) span"],
             attr: "title",
             filters: [{ name: "parseTime" }],
+          },
+          lastAccessAt: {
+            selector: ["#profil_left .userbox_tartalom_mini > div:nth-child(4) span"],
+            filters: [
+              (query: string) => {
+                const text = String(query).trim();
+                if (/épp itt van/i.test(text)) return Date.now();
+                const normalized = text
+                  .replace(/(\d+)\s*éve?/gi, "$1 years")
+                  .replace(/(\d+)\s*hete?/gi, "$1 weeks")
+                  .replace(/(\d+)\s*napja?/gi, "$1 days")
+                  .replace(/(\d+)\s*órája?/gi, "$1 hours")
+                  .replace(/(\d+)\s*perce?/gi, "$1 minutes");
+                return parseTimeToLiveToDate(normalized);
+              },
+            ],
           },
           uploaded: {
             selector: ["div.userbox_tartalom_mini:nth-child(2) > div:nth-child(8) span"],


### PR DESCRIPTION
This pull request adds support for extracting and parsing the "last access" or "last active" time for users on the BeyondHD and nCore sites. The extraction logic handles different date formats and localizations, improving the accuracy of user activity data.

**Enhancements to user activity parsing:**

* Added a `lastAccessAt` field to the BeyondHD site definition, with a selector and filters to parse the "Last Active" date in the expected format.
* Added a `lastAccessAt` field to the nCore site definition, including logic to handle Hungarian time expressions, convert them to English, and parse relative times (e.g., "just now", "2 days ago") using the `parseTimeToLiveToDate` utility.
* Imported the `parseTimeToLiveToDate` utility in the nCore site definition to support the new parsing logic.

## Summary by Sourcery

Add support for parsing user last access times from BeyondHD and nCore profiles to improve user activity tracking.

New Features:
- Capture lastAccessAt from nCore profiles, including localized relative time expressions converted and parsed to dates.
- Capture lastAccessAt from BeyondHD profiles using the site-specific last active field format.

Enhancements:
- Normalize Hungarian relative time phrases in nCore profiles before converting them to concrete timestamps.