### PR TITLE
fix(pkg/site/animebytes): disable imdb search fallback

### DIFF
--- a/src/packages/site/definitions/animebytes.ts
+++ b/src/packages/site/definitions/animebytes.ts
@@ -198,6 +198,10 @@ export const siteMetadata: ISiteMetadata = {
 
   search: {
     ...SchemaMetadata.search!,
+    advanceKeywordParams: {
+      ...SchemaMetadata.search!.advanceKeywordParams,
+      imdb: false,
+    },
     requestConfig: {
       url: "/scrape.php",
       responseType: "json",


### PR DESCRIPTION
## Summary
- disable AnimeBytes IMDb advanced search fallback
- prevent `imdb|tt...` searches from being sent to AnimeBytes as ordinary keyword searches

## Testing
- verified AnimeBytes keyword search works separately
- `git diff --check HEAD~1..HEAD`

## Summary by Sourcery

Bug Fixes:
- Prevent IMDb identifier searches (e.g., imdb|tt...) from being sent to AnimeBytes as ordinary keyword searches.