### PR TITLE
fix(pkg/site/kamept): overwrite seedingBonusPerHour

### DIFF
--- a/src/packages/site/definitions/kamept.ts
+++ b/src/packages/site/definitions/kamept.ts
@@ -144,6 +144,17 @@ export const siteMetadata: ISiteMetadata = {
     CategoryInclbookmarked,
   ],
 
+  userInfo: {
+    ...SchemaMetadata.userInfo,
+    selectors: {
+      ...SchemaMetadata.userInfo!.selectors,
+      seedingBonusPerHour: {
+        selector: ["h1:contains('每小时获得的合计魔力值') + div > table > tbody > tr:nth-child(2) > td:nth-child(4)"],
+        filters: [{ name: "parseNumber" }],
+      },
+    },
+  },
+
   searchEntry: {
     area_torrents: { name: "种子区", requestConfig: { url: "/torrents.php" } },
     area_special: { name: "特别区", requestConfig: { url: "/special.php" } },


### PR DESCRIPTION
做种积分并非魔力

## Summary by Sourcery

Bug Fixes:
- Fix seeding bonus per hour parsing on KamePT by overriding the userInfo selector configuration.