### PR TITLE
feat(backup): implement auto backup functionality

### DIFF
--- a/src/entries/background/utils/alarms.ts
+++ b/src/entries/background/utils/alarms.ts
@@ -4,7 +4,7 @@ import { EResultParseStatus, type TSiteID } from "@ptd/site/types/base.ts";
 
 import { extStorage } from "@/storage.ts";
 import { onMessage, sendMessage } from "@/messages.ts";
-import { IDownloadTorrentOption } from "@/shared/types.ts";
+import { IDownloadTorrentOption, IMetadataPiniaStorageSchema } from "@/shared/types.ts";
 
 import { setupOffscreenDocument } from "./offscreen.ts";
 import { sleep } from "~/helper.ts";
@@ -12,6 +12,7 @@ import { sleep } from "~/helper.ts";
 export enum EJobType {
   FlushUserInfo = "flushUserInfo",
   ReDownloadTorrent = "reDownloadTorrent",
+  AutoBackup = "autoBackup",
 }
 
 const jobs = defineJobScheduler();
@@ -128,6 +129,59 @@ jobs.scheduleJob({
   duration: 1000 * 60 * 10, // check every 10 minutes
   immediate: true,
   execute: autoFlushUserInfo(),
+});
+
+/**
+ * 自动备份：检查所有已启用且设置了备份间隔的备份服务器，在满足条件时触发备份
+ */
+function autoBackup() {
+  return async () => {
+    await setupOffscreenDocument();
+
+    const metadataStore = (await extStorage.getItem("metadata")) as IMetadataPiniaStorageSchema | undefined;
+    if (!metadataStore?.backupServers) {
+      return;
+    }
+
+    const now = Date.now();
+
+    for (const [serverId, serverConfig] of Object.entries(metadataStore.backupServers)) {
+      // 仅处理已启用且有备份间隔的服务器
+      if (!serverConfig.enabled || !serverConfig.backupInterval || serverConfig.backupInterval <= 0) {
+        continue;
+      }
+
+      const intervalMs = serverConfig.backupInterval * 60 * 60 * 1000;
+      const lastBackup = serverConfig.lastBackupAt ?? 0;
+
+      if (now - lastBackup >= intervalMs) {
+        sendMessage("logger", {
+          msg: `Auto-backup triggered for [${serverConfig.name}] (interval: ${serverConfig.backupInterval}h)`,
+        }).catch();
+
+        try {
+          const backupFields = serverConfig.backupFields ?? [];
+          await sendMessage("exportBackupData", {
+            backupServerId: serverId,
+            backupFields,
+          });
+        } catch (e) {
+          sendMessage("logger", {
+            msg: `Auto-backup failed for [${serverConfig.name}]: ${e}`,
+          }).catch();
+        }
+      }
+    }
+  };
+}
+
+// noinspection JSIgnoredPromiseFromCall
+jobs.scheduleJob({
+  id: EJobType.AutoBackup,
+  type: "interval",
+  duration: 1000 * 60 * 10, // check every 10 minutes
+  immediate: true,
+  execute: autoBackup(),
 });
 
 function doReDownloadTorrent(downloadOption: IDownloadTorrentOption) {

--- a/src/entries/background/utils/alarms.ts
+++ b/src/entries/background/utils/alarms.ts
@@ -161,13 +161,20 @@ function autoBackup() {
 
         try {
           const backupFields = serverConfig.backupFields ?? [];
-          await sendMessage("exportBackupData", {
+          const ok = await sendMessage("exportBackupData", {
             backupServerId: serverId,
             backupFields,
           });
+
+          if (!ok) {
+            sendMessage("logger", {
+              msg: `Auto-backup failed for [${serverConfig.name}] (returned false)`,
+            }).catch();
+          }
         } catch (e) {
+          const errMsg = e instanceof Error ? e.message : String(e);
           sendMessage("logger", {
-            msg: `Auto-backup failed for [${serverConfig.name}]: ${e}`,
+            msg: `Auto-backup failed for [${serverConfig.name}]: ${errMsg}`,
           }).catch();
         }
       }

--- a/src/entries/options/views/Settings/SetBackup/Editor.vue
+++ b/src/entries/options/views/Settings/SetBackup/Editor.vue
@@ -97,7 +97,25 @@ async function checkConnect() {
           </v-col>
         </v-row>
 
+        <v-divider class="my-2" />
+
         <v-label class="my-2">{{ t("SetBackup.Editor.backupConfig") }}</v-label>
+
+        <v-row no-gutters>
+          <v-col cols="12">
+            <v-text-field
+              v-model.number="clientConfig.backupInterval"
+              :label="t('SetBackup.Editor.backupInterval')"
+              :messages="t('SetBackup.Editor.backupIntervalHint')"
+              :min="0"
+              :max="48"
+              clearable
+              hide-details="auto"
+              suffix="h"
+              type="number"
+            />
+          </v-col>
+        </v-row>
 
         <v-row no-gutters>
           <v-col v-for="backupField in BackupFields" :key="backupField" cols="12" md="4">

--- a/src/entries/options/views/Settings/SetBackup/Index.vue
+++ b/src/entries/options/views/Settings/SetBackup/Index.vue
@@ -32,7 +32,14 @@ const showDeleteDialog = ref<boolean>(false);
 const fullTableHeader = [
   { title: t("common.type"), key: "type", align: "center" },
   { title: t("common.name"), key: "name", align: "start" },
-  { title: t("SetBackup.table.backupFields"), key: "backupFields", align: "start", sortable: false },
+  {
+    title: t("SetBackup.table.backupFields"),
+    key: "backupFields",
+    align: "start",
+    sortable: false,
+    cellProps: { class: "pt-1" },
+  },
+  { title: t("SetBackup.table.backupInterval"), key: "backupInterval", align: "center" },
   { title: t("SetBackup.table.lastBackupAt"), key: "lastBackupAt", align: "end" },
   { title: t("common.enable"), key: "enabled", align: "center" },
   { title: t("common.action"), key: "action", sortable: false },
@@ -134,11 +141,16 @@ async function confirmDeleteBackupServer(id: TBackupServerKey) {
       </template>
 
       <template #item.backupFields="{ item }">
-        <v-chip-group show-arrows>
-          <v-chip v-for="backupField in item.backupFields" label :key="backupField">
-            {{ t(`SetBackup.fields.${backupField}`) }}
-          </v-chip>
-        </v-chip-group>
+        <v-chip v-for="backupField in item.backupFields" label :key="backupField" class="mr-1 mb-1">
+          {{ t(`SetBackup.fields.${backupField}`) }}
+        </v-chip>
+      </template>
+
+      <template #item.backupInterval="{ item }">
+        <template v-if="item.backupInterval && item.backupInterval > 0">
+          {{ t("SetBackup.table.everyNHour", { n: item.backupInterval }) }}
+        </template>
+        <span v-else class="text-disabled">—</span>
       </template>
 
       <template #item.lastBackupAt="{ item }">

--- a/src/entries/shared/types/storages/metadata.ts
+++ b/src/entries/shared/types/storages/metadata.ts
@@ -91,6 +91,7 @@ export interface IBackupServerMetadata extends IBackupConfig {
   backupFields: TBackupFields[]; // 备份的字段
 
   lastBackupAt?: number; // 上次备份时间
+  backupInterval?: number; // 自动备份间隔（小时），不设置或为 0 表示不自动备份
 }
 
 export interface IMetadataPiniaStorageSchema {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -407,20 +407,13 @@
     "title": "Select downloader for {0} torrents"
   },
   "SetBackup": {
-    "fields": {
-      "config": "Extension configuration (config)",
-      "cookies": "Site cookies (cookies)",
-      "downloadHistory": "Download history (downloadHistory)",
-      "keepUploadTask": "Reseed tasks (keepUploadTask)",
-      "metadata": "Site and service configuration (metadata)",
-      "searchResultSnapshot": "Search result snapshots (searchResultSnapshot)",
-      "userInfo": "User information (userInfo)"
-    },
     "AddDialog": {
       "title": "Add Backup Server"
     },
     "Editor": {
       "backupConfig": "Backup Configuration",
+      "backupInterval": "Auto Backup Interval",
+      "backupIntervalHint": "Set auto-backup interval (hours). Leave empty or 0 to disable auto backup. Max 48 hours.",
       "serverConfig": "Server Configuration"
     },
     "HistoryDialog": {
@@ -453,6 +446,15 @@
       "title": "Restore from Backup File",
       "versionWarning": "Backup data version is higher than the current extension version. Restoring may cause data incompatibility or loss. Continue?"
     },
+    "fields": {
+      "config": "Extension configuration (config)",
+      "cookies": "Site cookies (cookies)",
+      "downloadHistory": "Download history (downloadHistory)",
+      "keepUploadTask": "Reseed tasks (keepUploadTask)",
+      "metadata": "Site and service configuration (metadata)",
+      "searchResultSnapshot": "Search result snapshots (searchResultSnapshot)",
+      "userInfo": "User information (userInfo)"
+    },
     "localExport": "Local Export",
     "localImport": "Local Import",
     "snackbar": {
@@ -465,6 +467,8 @@
         "viewHistoryBackup": "View History Backups"
       },
       "backupFields": "Backup Content",
+      "backupInterval": "Auto Backup Interval",
+      "everyNHour": "Every {n} h",
       "lastBackupAt": "Last Backup Time",
       "notBackup": "Not Backed Up"
     }
@@ -1024,9 +1028,9 @@
     "SocialSiteParseResultsDialog": {
       "defaultSeasonTitle": "Season",
       "searchEntryTitle": "Search {title}",
-      "searchPlan": "Search Plan",
       "searchExternalId": "Search External ID",
       "searchId": "Search ID",
+      "searchPlan": "Search Plan",
       "searchTitle": "Search Title",
       "title": "Quick Search"
     },

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -407,20 +407,13 @@
     "title": "为 {0} 个种子选择下载器"
   },
   "SetBackup": {
-    "fields": {
-      "config": "插件配置（config）",
-      "cookies": "站点 Cookies（cookies）",
-      "downloadHistory": "下载历史（downloadHistory）",
-      "keepUploadTask": "辅种任务（keepUploadTask）",
-      "metadata": "站点与服务配置（metadata）",
-      "searchResultSnapshot": "搜索结果快照（searchResultSnapshot）",
-      "userInfo": "用户信息（userInfo）"
-    },
     "AddDialog": {
       "title": "添加备份服务器"
     },
     "Editor": {
       "backupConfig": "备份配置",
+      "backupInterval": "自动备份间隔",
+      "backupIntervalHint": "设置自动备份间隔（小时），留空或为 0 表示不自动备份，最大 48 小时",
       "serverConfig": "服务器配置"
     },
     "HistoryDialog": {
@@ -453,6 +446,15 @@
       "title": "从备份文件中恢复",
       "versionWarning": "备份数据版本高于当前扩展版本，恢复可能会导致数据不兼容或丢失，是否继续？"
     },
+    "fields": {
+      "config": "插件配置（config）",
+      "cookies": "站点 Cookies（cookies）",
+      "downloadHistory": "下载历史（downloadHistory）",
+      "keepUploadTask": "辅种任务（keepUploadTask）",
+      "metadata": "站点与服务配置（metadata）",
+      "searchResultSnapshot": "搜索结果快照（searchResultSnapshot）",
+      "userInfo": "用户信息（userInfo）"
+    },
     "localExport": "本地导出",
     "localImport": "本地导入",
     "snackbar": {
@@ -465,6 +467,8 @@
         "viewHistoryBackup": "查看历史备份"
       },
       "backupFields": "备份内容",
+      "backupInterval": "自动备份间隔",
+      "everyNHour": "每 {n} 小时",
       "lastBackupAt": "最近一次备份时间",
       "notBackup": "未备份"
     }
@@ -1021,9 +1025,9 @@
     "SocialSiteParseResultsDialog": {
       "defaultSeasonTitle": "单季",
       "searchEntryTitle": "搜索{title}",
-      "searchPlan": "搜索方案",
       "searchExternalId": "搜索外部ID",
       "searchId": "搜索ID",
+      "searchPlan": "搜索方案",
       "searchTitle": "搜索标题",
       "title": "快速搜索"
     },

--- a/src/packages/social/entity/tmdb.ts
+++ b/src/packages/social/entity/tmdb.ts
@@ -121,7 +121,8 @@ async function fetchTmdbBaseTitles(docUrl: string): Promise<{ displayTitle?: str
       responseType: "document",
       withCredentials: true,
     });
-    const displayTitle = baseDoc.querySelector('meta[property="og:title"]')?.getAttribute("content")?.trim() || undefined;
+    const displayTitle =
+      baseDoc.querySelector('meta[property="og:title"]')?.getAttribute("content")?.trim() || undefined;
     const originalTitle = getOriginalTitleText(baseDoc) || undefined;
 
     return { displayTitle, originalTitle };
@@ -156,7 +157,9 @@ async function pageParser(doc: Document): Promise<ISocialSitePageInformation | I
   const ogTitle = doc.querySelector('meta[property="og:title"]')?.getAttribute("content")?.trim() ?? "";
   const originalTitleText = getOriginalTitleText(doc);
   const shouldUseBaseTitles = mediaType === "tv" && /\/(seasons|season\/\d+)(?:\?.*)?$/.test(doc.URL);
-  const { displayTitle: baseDisplayTitle, originalTitle: baseOriginalTitle } = shouldUseBaseTitles ? await fetchTmdbBaseTitles(doc.URL) : {};
+  const { displayTitle: baseDisplayTitle, originalTitle: baseOriginalTitle } = shouldUseBaseTitles
+    ? await fetchTmdbBaseTitles(doc.URL)
+    : {};
   const displayTitle = baseDisplayTitle || ogTitle;
   const originalTitle = baseOriginalTitle || originalTitleText;
   const external_ids = await fetchTmdbExternalIds(doc.URL);
@@ -171,21 +174,19 @@ async function pageParser(doc: Document): Promise<ISocialSitePageInformation | I
         return [];
       }
 
-      const titles = uniq([
-        `${displayTitle} ${seasonTitle}`.trim(),
-      ]).filter(isNonEmptyString);
+      const titles = uniq([`${displayTitle} ${seasonTitle}`.trim()]).filter(isNonEmptyString);
 
       if (titles.length === 0) {
         return [];
       }
 
-        return [
-          {
-            site: "tmdb",
-            id: baseId,
-            mediaType,
-            titles,
-            external_ids,
+      return [
+        {
+          site: "tmdb",
+          id: baseId,
+          mediaType,
+          titles,
+          external_ids,
           pageCategory: "season_list",
           seriesTitle: displayTitle,
           entryTitle: seasonTitle,
@@ -202,7 +203,9 @@ async function pageParser(doc: Document): Promise<ISocialSitePageInformation | I
     const seasonCode = formatSeasonCode(doc.URL);
     const seasonDisplayTitle = (await fetchTmdbSeriesOgTitleFromSeasons(doc.URL)) ?? displayTitle;
     const currentSeasonTitle =
-      doc.querySelector("h2 a[href*='/season/']")?.textContent?.trim() ?? doc.querySelector("section.header h2")?.textContent?.trim() ?? "";
+      doc.querySelector("h2 a[href*='/season/']")?.textContent?.trim() ??
+      doc.querySelector("section.header h2")?.textContent?.trim() ??
+      "";
 
     if (seasonCode) {
       return {
@@ -270,7 +273,9 @@ export async function fetchInformation(
       responseType: "document",
       timeout: config.timeout ?? 10e3,
     });
-    const ldJson = JSON.parse(data.querySelector('script[type="application/ld+json"]')?.textContent ?? "{}") as ITmdbLdJson;
+    const ldJson = JSON.parse(
+      data.querySelector('script[type="application/ld+json"]')?.textContent ?? "{}",
+    ) as ITmdbLdJson;
     const pageInfo = await pageParser(data);
     const firstPageInfo = Array.isArray(pageInfo) ? pageInfo[0] : pageInfo;
 


### PR DESCRIPTION
## Summary by Sourcery

Add automatic backup scheduling based on per-server intervals and update backup settings UI and metadata schema to support the new configuration.

New Features:
- Introduce an AutoBackup background job that periodically checks enabled backup servers and triggers backups according to configured intervals.

Enhancements:
- Extend backup server metadata and options UI to configure and display automatic backup intervals and improve backup field chip presentation.
- Adjust TMDB social entity parsing logic to correctly build and return season list information while preserving title handling.

Documentation:
- Update i18n locale strings to cover new backup interval labels and hints.