### PR TITLE
feat(export): add user info export functionality with CSV and JSON formats

### DIFF
--- a/src/entries/options/views/Overview/MyData/ExportUserInfoDialog.vue
+++ b/src/entries/options/views/Overview/MyData/ExportUserInfoDialog.vue
@@ -124,8 +124,7 @@ async function doExport() {
     const ext = exportFormat.value;
     const mime = exportFormat.value === "csv" ? "text/csv;charset=utf-8" : "application/json;charset=utf-8";
     const content = exportFormat.value === "csv" ? convertToCSV(merged) : convertToJSON(merged);
-    const blob = new Blob(["\ufeff", content], { type: mime });
-    const suffix = isExportSelected.value ? "selected" : "all";
+    const blob = new Blob(exportFormat.value === "csv" ? ["\ufeff", content] : [content], { type: mime });
     saveAs(blob, `userinfo-${suffix}-${timestamp}.${ext}`);
     showDialog.value = false;
   } finally {

--- a/src/entries/options/views/Overview/MyData/ExportUserInfoDialog.vue
+++ b/src/entries/options/views/Overview/MyData/ExportUserInfoDialog.vue
@@ -1,0 +1,273 @@
+<script setup lang="ts">
+import { ref, computed } from "vue";
+import { useI18n } from "vue-i18n";
+import { saveAs } from "file-saver";
+
+import type { IUserInfo, TSiteID } from "@ptd/site";
+
+import { formatDate } from "@/options/utils.ts";
+import { useRuntimeStore } from "@/options/stores/runtime.ts";
+import { useMetadataStore } from "@/options/stores/metadata.ts";
+import { sendMessage } from "@/messages.ts";
+
+import { fixUserInfo } from "./utils/format.ts";
+
+interface IHistoryUserInfo extends IUserInfo {
+  date: string;
+  site: TSiteID;
+  siteName: string;
+}
+
+interface IExportField {
+  key: string;
+  label: string;
+  required?: boolean;
+}
+
+const props = defineProps<{
+  selectedSiteIds: TSiteID[];
+}>();
+
+const showDialog = defineModel<boolean>();
+const { t } = useI18n();
+const runtimeStore = useRuntimeStore();
+const metadataStore = useMetadataStore();
+
+const isLoading = ref(false);
+
+const allExportFields: IExportField[] = [
+  { key: "site", label: "common.site", required: true },
+  { key: "siteName", label: "MyData.exportDialog.fields.siteName", required: false },
+  { key: "date", label: "common.date", required: true },
+  { key: "name", label: "common.username", required: false },
+  { key: "id", label: "MyData.exportDialog.fields.id", required: false },
+  { key: "levelName", label: "MyData.exportDialog.fields.levelName", required: false },
+  { key: "uploaded", label: "levelRequirement.uploaded", required: false },
+  { key: "downloaded", label: "levelRequirement.downloaded", required: false },
+  { key: "ratio", label: "levelRequirement.ratio", required: false },
+  { key: "trueUploaded", label: "levelRequirement.trueUploaded", required: false },
+  { key: "trueDownloaded", label: "levelRequirement.trueDownloaded", required: false },
+  { key: "trueRatio", label: "levelRequirement.trueRatio", required: false },
+  { key: "seeding", label: "levelRequirement.seeding", required: false },
+  { key: "seedingSize", label: "levelRequirement.seedingSize", required: false },
+  { key: "bonus", label: "levelRequirement.bonus", required: false },
+  { key: "seedingBonus", label: "levelRequirement.seedingBonus", required: false },
+  { key: "bonusPerHour", label: "levelRequirement.bonusPerHour", required: false },
+  { key: "seedingBonusPerHour", label: "levelRequirement.seedingBonusPerHour", required: false },
+  { key: "uploads", label: "levelRequirement.uploads", required: false },
+  { key: "leeching", label: "levelRequirement.leeching", required: false },
+  { key: "snatches", label: "levelRequirement.snatches", required: false },
+  { key: "messageCount", label: "MyData.exportDialog.fields.messageCount", required: false },
+  { key: "hnrUnsatisfied", label: "levelRequirement.hnrUnsatisfied", required: false },
+  { key: "hnrPreWarning", label: "levelRequirement.hnrPreWarning", required: false },
+  { key: "joinTime", label: "MyData.exportDialog.fields.joinTime", required: false },
+  { key: "lastAccessAt", label: "MyData.exportDialog.fields.lastAccessAt", required: false },
+  { key: "updateAt", label: "MyData.exportDialog.fields.updateAt", required: false },
+];
+
+const defaultKeys = allExportFields.map((f) => f.key);
+const selectedKeys = ref<string[]>([...defaultKeys]);
+
+const exportFormat = ref<"csv" | "json">("csv");
+
+const querySiteIds = computed<TSiteID[]>(() => {
+  if (props.selectedSiteIds.length > 0) {
+    return props.selectedSiteIds;
+  }
+  return Object.keys(metadataStore.sites) as TSiteID[];
+});
+
+const isExportSelected = computed(() => props.selectedSiteIds.length > 0);
+
+async function doExport() {
+  isLoading.value = true;
+
+  try {
+    const tasks = querySiteIds.value.map(async (siteId) => {
+      try {
+        const history = (await sendMessage("getSiteUserInfo", siteId)) as Record<string, IUserInfo> | undefined;
+        if (!history) return [];
+
+        const siteName = metadataStore.siteNameMap[siteId] ?? siteId;
+        const items: IHistoryUserInfo[] = [];
+        for (const [date, item] of Object.entries(history)) {
+          items.push({
+            ...fixUserInfo(item),
+            site: siteId,
+            siteName,
+            date,
+          });
+        }
+        return items;
+      } catch (e) {
+        console.error(`加载站点 ${siteId} 历史数据失败`, e);
+        return [];
+      }
+    });
+
+    const results = await Promise.allSettled(tasks);
+    const merged: IHistoryUserInfo[] = [];
+    for (const result of results) {
+      if (result.status === "fulfilled") {
+        merged.push(...result.value);
+      }
+    }
+
+    merged.sort((a, b) => b.date.localeCompare(a.date));
+
+    if (merged.length === 0) {
+      runtimeStore.showSnakebar(t("common.noData"), { color: "warning" });
+      return;
+    }
+
+    const timestamp = formatDate(new Date(), "yyyyMMdd_HHmmss");
+    const ext = exportFormat.value;
+    const mime = exportFormat.value === "csv" ? "text/csv;charset=utf-8" : "application/json;charset=utf-8";
+    const content = exportFormat.value === "csv" ? convertToCSV(merged) : convertToJSON(merged);
+    const blob = new Blob(["\ufeff", content], { type: mime });
+    const suffix = isExportSelected.value ? "selected" : "all";
+    saveAs(blob, `userinfo-${suffix}-${timestamp}.${ext}`);
+    showDialog.value = false;
+  } finally {
+    isLoading.value = false;
+  }
+}
+
+function getSortedExportFields(): IExportField[] {
+  const site = allExportFields.find((f) => f.key === "site")!;
+  const date = allExportFields.find((f) => f.key === "date")!;
+  const others = allExportFields.filter((f) => f.key !== "site" && f.key !== "date");
+  return [site, date, ...others];
+}
+
+function getActiveFields(): IExportField[] {
+  return getSortedExportFields().filter((f) => selectedKeys.value.includes(f.key));
+}
+
+function convertToCSV(items: IHistoryUserInfo[]): string {
+  const activeFields = getActiveFields();
+  const headers = activeFields.map((f) => f.key);
+  const rows = items.map((item) =>
+    headers
+      .map((key) => {
+        const raw = (item as any)[key];
+        const val =
+          raw === Infinity || raw === -Infinity || (typeof raw === "number" && isNaN(raw)) ? "" : String(raw ?? "");
+        if (/[",\n\r]/.test(val)) {
+          return `"${val.replace(/"/g, '""')}"`;
+        }
+        return val;
+      })
+      .join(","),
+  );
+  return [headers.join(","), ...rows].join("\n");
+}
+
+function convertToJSON(items: IHistoryUserInfo[]): string {
+  const activeFields = getActiveFields();
+  return JSON.stringify(
+    items.map((item) => {
+      const obj: Record<string, any> = {};
+      for (const f of activeFields) {
+        const raw = (item as any)[f.key];
+        obj[f.key] =
+          raw === Infinity || raw === -Infinity || (typeof raw === "number" && isNaN(raw)) ? null : (raw ?? null);
+      }
+      return obj;
+    }),
+    null,
+    2,
+  );
+}
+</script>
+
+<template>
+  <v-dialog v-model="showDialog" width="700">
+    <v-card>
+      <v-card-title class="pa-0">
+        <v-toolbar color="orange-darken-3">
+          <v-toolbar-title>
+            <template v-if="isExportSelected">
+              {{ t("MyData.exportDialog.exportSelected", { count: querySiteIds.length }) }}
+            </template>
+            <template v-else>
+              {{ t("MyData.exportDialog.exportAll", { count: querySiteIds.length }) }}
+            </template>
+          </v-toolbar-title>
+          <template #append>
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
+          </template>
+        </v-toolbar>
+      </v-card-title>
+      <v-divider />
+      <v-card-text class="pt-4">
+        <v-row>
+          <v-col cols="12">
+            <v-label class="text-body-2 font-weight-bold mb-2 d-block">
+              {{ t("MyData.exportDialog.formatLabel") }}
+            </v-label>
+            <v-btn-toggle v-model="exportFormat" color="orange-darken-3" density="compact" mandatory variant="outlined">
+              <v-btn value="csv">
+                <v-icon start icon="mdi-file-delimited-outline" />
+                {{ t("MyData.exportDialog.formatCSV") }}
+              </v-btn>
+              <v-btn value="json">
+                <v-icon start icon="mdi-code-json" />
+                {{ t("MyData.exportDialog.formatJSON") }}
+              </v-btn>
+            </v-btn-toggle>
+          </v-col>
+        </v-row>
+
+        <v-row>
+          <v-col cols="12">
+            <v-label class="text-body-2 font-weight-bold mb-2 d-block">
+              {{ t("MyData.exportDialog.fieldsLabel") }}
+            </v-label>
+            <v-card variant="outlined" class="pa-2">
+              <v-row dense>
+                <v-col v-for="field in allExportFields" :key="field.key" cols="6" md="4">
+                  <v-checkbox
+                    :model-value="selectedKeys.includes(field.key)"
+                    :disabled="field.required"
+                    :label="t(field.label)"
+                    density="compact"
+                    hide-details
+                    @update:model-value="
+                      (v) => {
+                        if (v) {
+                          selectedKeys.push(field.key);
+                        } else {
+                          selectedKeys = selectedKeys.filter((k) => k !== field.key);
+                        }
+                      }
+                    "
+                  />
+                </v-col>
+              </v-row>
+            </v-card>
+          </v-col>
+        </v-row>
+      </v-card-text>
+
+      <v-divider />
+
+      <v-card-actions class="pa-4">
+        <v-spacer />
+        <v-btn variant="text" @click="showDialog = false">
+          {{ t("common.dialog.cancel") }}
+        </v-btn>
+        <v-btn
+          :disabled="isLoading"
+          :loading="isLoading"
+          color="orange-darken-3"
+          variant="elevated"
+          prepend-icon="mdi-export"
+          @click="doExport"
+        >
+          {{ t("common.export") }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>

--- a/src/entries/options/views/Overview/MyData/HistoryDataViewDialog.vue
+++ b/src/entries/options/views/Overview/MyData/HistoryDataViewDialog.vue
@@ -7,13 +7,14 @@ import type { DataTableHeader } from "vuetify";
 
 import { sendMessage } from "@/messages.ts";
 import { formatNumber, formatSize, formatDate } from "@/options/utils.ts";
-import { fixUserInfo, formatRatio } from "./utils/format.ts";
+import { formatRatio } from "./utils/format.ts";
+import { loadSiteHistoryData } from "./utils/lastUserData.ts";
 
 import SiteName from "@/options/components/SiteName.vue";
 import NavButton from "@/options/components/NavButton.vue";
 
 const showDialog = defineModel<boolean>();
-const props = defineProps<{
+const { siteId } = defineProps<{
   siteId: TSiteID | null;
 }>();
 const { t } = useI18n();
@@ -39,25 +40,16 @@ const tableHeader = [
 ] as DataTableHeader[];
 const tableSelected = ref<string[]>([]);
 
-function loadSiteHistoryData(siteId: TSiteID) {
-  sendMessage("getSiteUserInfo", siteId).then((data) => {
-    const retData = [];
-
-    for (const [date, item] of Object.entries(data)) {
-      retData.push({ ...fixUserInfo(item), date });
-    }
-
-    siteHistoryData.value = retData;
-  });
-}
-
 function deleteSiteUserInfo(date: string[]) {
   if (confirm(t("MyData.HistoryDataView.deleteConfirm"))) {
     sendMessage("removeSiteUserInfo", {
-      siteId: props.siteId!,
+      siteId: siteId!,
       date: date.filter((d) => d != currentDate), // 不允许移除当天的数据
     }).then(() => {
-      loadSiteHistoryData(props.siteId!);
+      loadSiteHistoryData(siteId!).then((data) => {
+        siteHistoryData.value = data;
+        tableSelected.value = [];
+      });
     });
   }
 }
@@ -75,22 +67,26 @@ function exportSiteHistoryData() {
   }
 
   const exportedSolutionBlob = new Blob([JSON.stringify(exportData, null, 2)], { type: "application/json" });
-  saveAs(exportedSolutionBlob, `site-history-data-${props.siteId}.json`); // FIXME filename
+  saveAs(exportedSolutionBlob, `site-history-data-${siteId}.json`); // FIXME filename
+}
+
+function afterEnter() {
+  if (siteId) {
+    loadSiteHistoryData(siteId!).then((data) => {
+      siteHistoryData.value = data;
+      tableSelected.value = [];
+    });
+  }
 }
 </script>
 
 <template>
-  <v-dialog
-    v-model="showDialog"
-    width="1200"
-    @after-enter="() => props.siteId && loadSiteHistoryData(props.siteId!)"
-    @after-leave="() => (siteHistoryData = [])"
-  >
+  <v-dialog v-model="showDialog" width="1200" @after-enter="afterEnter" @after-leave="() => (siteHistoryData = [])">
     <v-card>
       <v-card-title class="pa-0">
         <v-toolbar color="blue-grey-darken-2">
           <v-toolbar-title>
-            {{ t("MyData.HistoryDataView.title") }} @ <SiteName :site-id="props.siteId!" class="" tag="span" />
+            {{ t("MyData.HistoryDataView.title") }} @ <SiteName :site-id="siteId!" class="" tag="span" />
           </v-toolbar-title>
           <template #append>
             <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />

--- a/src/entries/options/views/Overview/MyData/Index.vue
+++ b/src/entries/options/views/Overview/MyData/Index.vue
@@ -20,6 +20,7 @@ import NavButton from "@/options/components/NavButton.vue";
 import UserLevelRequirementsTd from "./UserLevelRequirementsTd.vue";
 import HistoryDataViewDialog from "./HistoryDataViewDialog.vue";
 import BonusFormatSpan from "./BonusFormatSpan.vue";
+import ExportUserInfoDialog from "./ExportUserInfoDialog.vue";
 
 import { formatRatio } from "./utils/format.ts";
 import { tableData, initTableData, cancelFlushSiteLastUserInfo, flushSiteLastUserInfo } from "./utils/lastUserData.ts";
@@ -168,6 +169,8 @@ function viewStatistic() {
     },
   });
 }
+
+const showExportDialog = ref(false);
 </script>
 
 <template>
@@ -209,6 +212,16 @@ function viewStatistic() {
           @click="viewTimeline"
         />
         <NavButton color="green" icon="mdi-equalizer" :text="t('MyData.index.viewStatistic')" @click="viewStatistic" />
+
+        <v-divider class="mx-2" vertical />
+
+        <!-- 导出按钮 -->
+        <NavButton
+          color="orange-darken-3"
+          icon="mdi-export"
+          :text="t('MyData.index.exportData')"
+          @click="showExportDialog = true"
+        />
 
         <v-divider class="mx-2" vertical />
 
@@ -637,6 +650,7 @@ function viewStatistic() {
   </v-card>
 
   <HistoryDataViewDialog v-model="showHistoryDataViewDialog" :site-id="historyDataViewDialogSiteId!" />
+  <ExportUserInfoDialog v-model="showExportDialog" :selected-site-ids="tableSelected" />
 </template>
 
 <style scoped lang="scss">

--- a/src/entries/options/views/Overview/MyData/utils/lastUserData.ts
+++ b/src/entries/options/views/Overview/MyData/utils/lastUserData.ts
@@ -108,3 +108,15 @@ export async function cancelFlushSiteLastUserInfo() {
 
   runtimeStore.showSnakebar(`用户信息刷新队列已取消`, { color: "error" });
 }
+
+export async function loadSiteHistoryData(siteId: TSiteID) {
+  const retData = [];
+
+  const siteUserInfoData = await sendMessage("getSiteUserInfo", siteId);
+
+  for (const [date, item] of Object.entries(siteUserInfoData)) {
+    retData.push({ ...fixUserInfo(item), date });
+  }
+
+  return retData;
+}

--- a/src/entries/options/views/Overview/MyData/utils/lastUserData.ts
+++ b/src/entries/options/views/Overview/MyData/utils/lastUserData.ts
@@ -109,10 +109,10 @@ export async function cancelFlushSiteLastUserInfo() {
   runtimeStore.showSnakebar(`用户信息刷新队列已取消`, { color: "error" });
 }
 
-export async function loadSiteHistoryData(siteId: TSiteID) {
-  const retData = [];
+export async function loadSiteHistoryData(siteId: TSiteID): Promise<Array<IUserInfo & { date: string }>> {
+  const retData: Array<IUserInfo & { date: string }> = [];
 
-  const siteUserInfoData = await sendMessage("getSiteUserInfo", siteId);
+  const siteUserInfoData = (await sendMessage("getSiteUserInfo", siteId)) as Record<string, IUserInfo>;
 
   for (const [date, item] of Object.entries(siteUserInfoData)) {
     retData.push({ ...fixUserInfo(item), date });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -212,7 +212,26 @@
     "UserLevelRequirementsTd": {
       "levelList": "User Level List"
     },
+    "exportDialog": {
+      "exportAll": "Export User Info From {count} sites",
+      "exportSelected": "Export User Info from selected {count} sites",
+      "fields": {
+        "id": "User ID",
+        "joinTime": "Join Time",
+        "lastAccessAt": "Last Access",
+        "levelName": "Level",
+        "messageCount": "Messages",
+        "siteName": "Site Name",
+        "updateAt": "Updated At"
+      },
+      "fieldsLabel": "Fields",
+      "formatCSV": "CSV",
+      "formatJSON": "JSON",
+      "formatLabel": "Format",
+      "title": "Export User Info"
+    },
     "index": {
+      "exportData": "Export",
       "filter": {
         "lastUpdateError": "Last update error",
         "todayNotUpdated": "Not updated today",
@@ -1104,6 +1123,7 @@
     "ratio": "Ratio",
     "seeding": "Seeding Count",
     "seedingBonus": "Seed Points",
+    "seedingBonusPerHour": "Seed Points Per Hour",
     "seedingSize": "Seeding Size",
     "seedingTime": "Seeding Time",
     "snatches": "Completed Torrents",

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -212,7 +212,26 @@
     "UserLevelRequirementsTd": {
       "levelList": "用户等级列表"
     },
+    "exportDialog": {
+      "exportAll": "导出全部 {count} 个站点的用户信息",
+      "exportSelected": "导出已选中的 {count} 个站点的用户信息",
+      "fields": {
+        "id": "用户ID",
+        "joinTime": "入站时间",
+        "lastAccessAt": "最近访问",
+        "levelName": "等级名称",
+        "messageCount": "消息数",
+        "siteName": "站点名称",
+        "updateAt": "更新时间"
+      },
+      "fieldsLabel": "导出字段",
+      "formatCSV": "CSV",
+      "formatJSON": "JSON",
+      "formatLabel": "导出格式",
+      "title": "导出用户信息"
+    },
     "index": {
+      "exportData": "导出数据",
       "filter": {
         "lastUpdateError": "最后更新状态异常",
         "todayNotUpdated": "今日未更新",
@@ -1101,6 +1120,7 @@
     "ratio": "分享率",
     "seeding": "做种数",
     "seedingBonus": "做种积分",
+    "seedingBonusPerHour": "做种时魔值",
     "seedingSize": "做种量",
     "seedingTime": "做种时间",
     "snatches": "完成种子数",


### PR DESCRIPTION
提供如下字段的快速导出，并可以直接导出为 csv 或者 json 格式，原 HistoryDataViewDialog 中的单一站点原始数据json导出和 参数备份与恢复 的userInfo整个导出功能仍继续保留。

<img width="737" height="766" alt="image" src="https://github.com/user-attachments/assets/efcd89fd-f34f-45aa-9336-18451cd3692a" />


closed: #1173

## Summary by Sourcery

Add configurable export of user history data in CSV/JSON formats and centralize history loading logic for reuse.

New Features:
- Introduce an Export User Info dialog that exports user history data for selected or all sites in CSV or JSON format with configurable fields.
- Add a toolbar export button on the MyData overview page to open the export dialog.

Enhancements:
- Refactor site history loading into a shared utility function and reuse it in the history data view dialog.
- Reset history table selection when reloading site history data and simplify dialog lifecycle handling.