### PR TITLE
fix(yemapt): migrate integration to OpenAPI

### DIFF
--- a/src/packages/site/definitions/yemapt.ts
+++ b/src/packages/site/definitions/yemapt.ts
@@ -98,12 +98,6 @@ const levelRequirements: ILevelRequirement[] = [
   },
 ];
 
-interface IFetchUserPointAccResp {
-  hourBasePoint: number;
-  hourOwnerPoint: number;
-  hourPoint: number;
-}
-
 const promotionOptions = [
   { name: "无", value: "none" },
   { name: "50%", value: "half" },
@@ -215,10 +209,10 @@ export const siteMetadata: ISiteMetadata = {
     keywordPath: "data.keyword",
     requestConfig: {
       method: "POST",
-      url: "/api/torrent/fetchOpenTorrentList",
+      url: "/openApi/torrent/fetchOpenTorrentList.json",
       responseType: "json",
       data: {
-        pageParam: { current: 1, pageSize: 40, total: 1000 },
+        pageParam: { current: 1, pageSize: 40 },
         sorter: { order: "descend", field: "listingTime" },
       },
     },
@@ -284,7 +278,11 @@ export const siteMetadata: ISiteMetadata = {
   userInfo: {
     process: [
       {
-        requestConfig: { url: "/api/consumer/fetchSelfDetail", responseType: "json" },
+        requestConfig: {
+          url: "/openApi/user/fetchBasicInfo.json",
+          method: "POST",
+          responseType: "json",
+        },
         selectors: {
           id: { selector: "data.id" },
           name: { selector: "data.name" },
@@ -297,42 +295,10 @@ export const siteMetadata: ISiteMetadata = {
             selector: "data.registerTime",
             filters: [{ name: "parseTime", args: ["yyyy-MM-dd'T'HH:mm:ss.SSSXXX"] }],
           },
-          invites: { selector: "data.invitedNum" },
+          invites: { selector: "data.availableInviteNum" },
           uploaded: { selector: "data.promotionUploadSize" },
           downloaded: { selector: "data.promotionDownloadSize" },
-          trueUploaded: { selector: "data.uploadSize" },
-          trueDownloaded: { selector: "data.downloadSize" },
           bonus: { selector: "data.bonus" },
-        },
-      },
-      {
-        requestConfig: {
-          url: "/api/torrent/fetchSelfTorrentCount",
-          method: "POST",
-          data: {}, // 需要传一个空对象，否则请求会报错
-          responseType: "json",
-        },
-        selectors: {
-          uploads: { selector: "data" },
-        },
-      },
-      {
-        requestConfig: { url: "/api/userTorrent/fetchSeedTorrentInfo", method: "POST", responseType: "json" },
-        selectors: {
-          seeding: { selector: "data.num" },
-          seedingSize: { selector: "data.fileSize" },
-        },
-      },
-      {
-        requestConfig: { url: "/api/consumer/fetchUserPointAcc", responseType: "json" },
-        selectors: {
-          bonusPerHour: {
-            selector: "data",
-            filters: [
-              (query: IFetchUserPointAccResp) =>
-                query ? query.hourPoint + query.hourBasePoint + query.hourOwnerPoint : 0,
-            ],
-          },
         },
       },
     ],
@@ -413,8 +379,8 @@ export default class YemaPT extends PrivateSite {
 
   public override async getTorrentDownloadLink(torrent: ITorrent): Promise<string> {
     const { data } = await this.request<IYemaApiResp<string | { key?: string; token?: string }>>({
-      url: "/api/torrent/generateDownloadKey",
-      method: "GET",
+      url: "/openApi/torrent/generateDownloadKey.json",
+      method: "POST",
       responseType: "json",
       params: { id: torrent.id },
     });


### PR DESCRIPTION
## 变更内容

  - 将种子搜索迁移至 `/openApi/torrent/fetchOpenTorrentList.json`
  - 将用户信息获取迁移至 `/openApi/user/fetchBasicInfo.json`
  - 使用 POST 请求 `/openApi/torrent/generateDownloadKey.json` 生成下载凭证
  - 邀请数量改为读取 `availableInviteNum`
  - 移除 OpenAPI 未提供的站内统计接口请求
  - 移除分页请求中未定义的 `total` 参数

  ## 验证

  - `vue-tsc --noEmit` 通过
  - `git diff --check` 通过

## Summary by Sourcery

Migrate YemaPT integration to the site's OpenAPI endpoints and simplify user statistics handling.

New Features:
- Use the OpenAPI torrent list endpoint for seed search requests.
- Use the OpenAPI user basic info endpoint for fetching user profile data.
- Use the OpenAPI torrent download key endpoint for generating download credentials.

Bug Fixes:
- Stop sending an undefined total field in torrent list pagination requests.

Enhancements:
- Read invite counts from the availableInviteNum field instead of the previous invitedNum field.
- Remove unsupported internal statistics and seeding-related requests from the user info pipeline.
- Drop unused per-hour bonus aggregation logic tied to deprecated user point APIs.