### PR TITLE
fix(pkg/site): 更新 Simurg 用户等级

### DIFF
--- a/src/packages/site/definitions/simurg.ts
+++ b/src/packages/site/definitions/simurg.ts
@@ -146,4 +146,47 @@ export const siteMetadata: ISiteMetadata = {
       },
     },
   },
+
+  levelRequirements: [
+    {
+      id: 1,
+      name: "User",
+      privilege: "Initial class for regular members.",
+    },
+    {
+      id: 2,
+      name: "Member",
+      interval: "P1W",
+      uploaded: "10 GiB",
+      ratio: 0.7,
+      privilege: "Create requests and bookmarks; use the ZIP collector; purchase eligible Bonus Shop items.",
+    },
+    {
+      id: 3,
+      name: "Power User",
+      interval: "P2W",
+      uploaded: "25 GiB",
+      ratio: 1.05,
+      uploads: 5,
+      privilege: "Access upload notifications and the private Power User forum; create collages and forum polls.",
+    },
+    {
+      id: 4,
+      name: "Elite",
+      interval: "P4W",
+      uploaded: "100 GiB",
+      ratio: 1.05,
+      uploads: 50,
+      privilege: "View the Advanced Top 10; edit catalogue metadata; access the Elite and Invitations forums.",
+    },
+    {
+      id: 5,
+      name: "Torrent Master",
+      interval: "P8W",
+      uploaded: "500 GiB",
+      ratio: 1.05,
+      uploads: 500,
+      privilege: "Access the Torrent Masters forum; purchase custom titles for free.",
+    },
+  ],
 };


### PR DESCRIPTION
## 概述

- 根据 Simurg User Classes Wiki 新增 User、Member、Power User、Elite、Torrent Master 等级配置
- 补充各等级的账号时长、有效上传量、分享率和发布数要求
- 补充各等级主要权限说明
- Power TM、Elite TM、Ultimate TM 的要求仍在站点审核中，本次不写入未公布门槛

## 验证

- pnpm exec prettier --check src/packages/site/definitions/simurg.ts
- pnpm check

参考：https://simurg.world/wiki.php?action=article&name=userclasses

## Summary by Sourcery

Update Simurg site metadata with explicit user level requirement definitions.

New Features:
- Introduce structured configuration for Simurg user classes: User, Member, Power User, Elite, and Torrent Master.

Enhancements:
- Document tenure, upload, ratio, and upload count thresholds for each Simurg user level along with their main privileges.