### PR TITLE
fix(pkg/site/keepfrds): restore user info parsing

### DIFF
--- a/src/packages/site/definitions/keepfrds.ts
+++ b/src/packages/site/definitions/keepfrds.ts
@@ -1,10 +1,11 @@
-import { type ISiteMetadata } from "../types";
+import { type ISiteMetadata, type IUserInfo } from "../types";
 import NexusPHP, {
   CategoryInclbookmarked,
   CategoryIncldead,
   SchemaMetadata,
   subTitleRemoveExtraElement,
 } from "../schemas/NexusPHP.ts";
+import { parseKeepfrdsTorrentListCount } from "./utils/keepfrds.ts";
 
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,
@@ -402,6 +403,26 @@ export const siteMetadata: ISiteMetadata = {
 };
 
 export default class Keepfrds extends NexusPHP {
+  protected override async parseUserInfoForUploads(flushUserInfo: Partial<IUserInfo>): Promise<Partial<IUserInfo>> {
+    const { data: userUploadsDocument } = await this.request<Document>({
+      url: "/torrents.php",
+      params: { "option-torrents": 10, userid: flushUserInfo.id },
+      responseType: "document",
+    });
+
+    const paginationTexts = Array.from(
+      userUploadsDocument.querySelectorAll<HTMLAnchorElement>("a[href*='option-torrents=10'][href*='page=']"),
+      (element) => element.textContent ?? "",
+    );
+    const detailHrefs = Array.from(
+      userUploadsDocument.querySelectorAll<HTMLAnchorElement>("table.torrents a[href*='details.php?id=']"),
+      (element) => element.getAttribute("href") ?? "",
+    );
+
+    flushUserInfo.uploads = parseKeepfrdsTorrentListCount(paginationTexts, detailHrefs);
+    return flushUserInfo;
+  }
+
   protected override guessSearchFieldIndexConfig(): Record<string, string[]> {
     return {
       author: ['a[href*="sort=9"]'], // 发布者

--- a/src/packages/site/definitions/utils/keepfrds.ts
+++ b/src/packages/site/definitions/utils/keepfrds.ts
@@ -1,0 +1,34 @@
+const PAGE_RANGE_PATTERN = /\d[\d,]*\s*[-–]\s*(\d[\d,]*)/g;
+
+export function parseKeepfrdsTorrentListCount(
+  paginationTexts: Iterable<string>,
+  detailHrefs: Iterable<string>,
+): number {
+  let lastItem = 0;
+
+  for (const paginationText of paginationTexts) {
+    for (const match of paginationText.matchAll(PAGE_RANGE_PATTERN)) {
+      const rangeEnd = Number.parseInt(match[1].replace(/,/g, ""), 10);
+      if (Number.isFinite(rangeEnd)) {
+        lastItem = Math.max(lastItem, rangeEnd);
+      }
+    }
+  }
+
+  if (lastItem > 0) {
+    return lastItem;
+  }
+
+  const torrentIds = new Set<string>();
+  for (const detailHref of detailHrefs) {
+    const queryString = detailHref.match(/details\.php\?([^#]+)/)?.[1];
+    if (!queryString) continue;
+
+    const torrentId = new URLSearchParams(queryString).get("id");
+    if (torrentId) {
+      torrentIds.add(torrentId);
+    }
+  }
+
+  return torrentIds.size;
+}

--- a/tests/packages/site/keepfrds.utils.test.ts
+++ b/tests/packages/site/keepfrds.utils.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseKeepfrdsTorrentListCount } from "../../../src/packages/site/definitions/utils/keepfrds.ts";
+
+test("returns zero when the published torrent list is empty", () => {
+  assert.equal(parseKeepfrdsTorrentListCount([], []), 0);
+});
+
+test("counts unique torrents on a single page", () => {
+  assert.equal(
+    parseKeepfrdsTorrentListCount(
+      [],
+      ["details.php?id=101&hit=1", "details.php?id=101&hit=1&cmtpage=1#startcomments", "details.php?id=102&hit=1"],
+    ),
+    2,
+  );
+});
+
+test("uses the last pagination range for a multi-page list", () => {
+  assert.equal(
+    parseKeepfrdsTorrentListCount(["1\u00a0-\u00a050", "51\u00a0-\u00a099"], ["details.php?id=101&hit=1"]),
+    99,
+  );
+});


### PR DESCRIPTION
## Summary

- replace the removed user torrent AJAX endpoint with the current published-torrent list page
- derive upload counts from pagination ranges with a unique-torrent fallback
- add regression coverage for empty, single-page, and paginated results

## Testing

- `pnpm exec tsx --test tests/packages/site/keepfrds.utils.test.ts`
- `pnpm run check`
- `pnpm run build:dist`
- verified against current KEEPFRDS empty and paginated list page structures

## Summary by Sourcery

Restore KEEPFRDS user upload parsing by deriving upload counts from the published torrent list page instead of the removed AJAX endpoint.

New Features:
- Add a utility to compute KEEPFRDS published torrent counts from pagination text and torrent detail links.

Bug Fixes:
- Fix KEEPFRDS user upload statistics parsing against the current published torrent list page structure.

Enhancements:
- Override KEEPFRDS user info parsing to use the new torrent count utility for upload totals.

Tests:
- Add regression tests covering empty, single-page, and paginated KEEPFRDS torrent list scenarios.