### PR TITLE
fix(pkg/site/keepfrds): 适配月月新版站点用户信息更新

### DIFF
--- a/src/packages/site/definitions/keepfrds.ts
+++ b/src/packages/site/definitions/keepfrds.ts
@@ -1,4 +1,4 @@
-import { type ISiteMetadata } from "../types";
+import { type ISiteMetadata, type IUserInfo } from "../types";
 import NexusPHP, {
   CategoryInclbookmarked,
   CategoryIncldead,
@@ -195,6 +195,7 @@ export const siteMetadata: ISiteMetadata = {
     selectors: {
       ...SchemaMetadata.userInfo!.selectors,
       messageCount: {
+        text: 0,
         selector: ["a[href*='messages.php'] b span[style*='color: red']"],
       },
       bonus: {
@@ -216,29 +217,10 @@ export const siteMetadata: ISiteMetadata = {
         selector: ["a[href='/torrents.php?option-torrents=3']"],
         filters: [{ name: "parseNumber" }],
       },
-      seedingSize: {
-        selector: [
-          "td.rowhead:contains('当前做种') + td, td.rowhead:contains('Current Seeding') + td, td.rowhead:contains('目前做種') + td",
-        ],
-        filters: [{ name: "parseSize" }],
-      },
+
       bonusPerHour: {
-        selector: ["tbody:has(>tr>td.embedded>i.fab.fa-btc)"],
-        filters: [
-          (query: string | number) => {
-            const queryMatch = String(query || "")
-              .replace(/,/g, "")
-              .match(/[\d.]+/g);
-            if (!queryMatch) return 0;
-            let bonusPerHour = 0;
-            if (queryMatch.length === 5) {
-              bonusPerHour = parseFloat(queryMatch[2]) + parseFloat(queryMatch[4]);
-            } else if (queryMatch.length >= 3) {
-              bonusPerHour = parseFloat(queryMatch[2]);
-            }
-            return bonusPerHour;
-          },
-        ],
+        selector: ["#info_block #perBonus", "#perBonus"],
+        filters: [{ name: "parseNumber" }],
       },
     },
     process: [
@@ -260,7 +242,6 @@ export const siteMetadata: ISiteMetadata = {
           "seedingBonus",
           "joinTime",
           "seeding",
-          "seedingSize",
           "hnrUnsatisfied",
           "hnrPreWarning",
           "bonusPerHour", // 使用我们自定义的 selector 和 filter
@@ -412,5 +393,19 @@ export default class Keepfrds extends NexusPHP {
       size: ["div.famfamfam-silk.cd"], // 大小
       time: ["div.famfamfam-silk.date"], // 发布时间 （仅生成 selector， 后面会覆盖）
     };
+  }
+
+  /**
+   * 新版站点已移除 getusertorrentlistajax.php 接口，且 userdetails 页面不再提供做种体积/发布数。
+   * 覆写基类的回退逻辑，避免请求已失效的接口导致用户信息更新失败。
+   */
+  protected override async parseUserInfoForSeedingStatus(
+    flushUserInfo: Partial<IUserInfo>,
+  ): Promise<Partial<IUserInfo>> {
+    return flushUserInfo; // seeding 由 selector 提供，seedingSize 新版页面不提供
+  }
+
+  protected override async parseUserInfoForUploads(flushUserInfo: Partial<IUserInfo>): Promise<Partial<IUserInfo>> {
+    return flushUserInfo; // uploads 新版页面不提供，跳过失效接口
   }
 }


### PR DESCRIPTION
## 问题

朋友站点 pt.keepfrds.com 用户信息「更新」一直失败。真实数据抓包（index.php / userdetails.php / mybonus.php）确认：

- 新版站点已移除 `getusertorrentlistajax.php` 接口（返回 404）
- `userdetails.php` 改版后不再展示「当前做种（体积）」行，原 `seedingSize` 选择器失效
- `uploads`（发布数）在新版页面无来源

以上导致 `NexusPHP.getUserInfoResult` 回退到已失效的 AJAX 接口并抛出 `Network Error: 404`，整个更新流程被 reject（`status: parseError`），表现为「更新一直无法成功」。

## 修复

- 移除失效的 `seedingSize` 选择器与字段，覆写 `parseUserInfoForSeedingStatus`，避免回退请求死接口（做种数仍由 `a[href='/torrents.php?option-torrents=3']` 提供）
- 覆写 `parseUserInfoForUploads`，跳过失效接口（新版页面不提供发布数，展示为 `-`）
- `bonusPerHour` 改用 `#info_block #perBonus` 精确取值，替换原先依赖数字 token 位置的脆弱解析
- `messageCount` 无未读消息时回退为 `0`

## 验证

用真实页面 HTML + jsdom 复现：修复前 `status: parseError`（404 抛错），修复后 `status: success`，`id/name/uploaded/downloaded/bonus/bonusPerHour/seeding/levelName` 等字段均正确解析。

## Summary by Sourcery

Adapt keepfrds site user info parsing to the updated site layout and removed AJAX endpoints to restore successful user info updates.

Bug Fixes:
- Prevent user info updates from failing when the legacy getusertorrentlistajax.php endpoint returns 404 by skipping obsolete fallback parsing for seeding status and uploads.

Enhancements:
- Update selectors for bonus per hour and message count to use stable, explicit page elements and provide sensible defaults when values are absent.