### PR TITLE
fix(pkg/site): 更新下水道站点用户升级条件

### DIFF
--- a/src/packages/site/definitions/sewerpt.ts
+++ b/src/packages/site/definitions/sewerpt.ts
@@ -35,10 +35,12 @@ export const siteMetadata: ISiteMetadata = {
       nameAka: ["Power User"],
       interval: "P4W",
       downloaded: "50GB",
+      seedingBonus: 40000,
       ratio: 1.05,
       privilege:
         "得到一个邀请名额；可以直接发布种子；可以查看NFO文档；可以查看用户列表；可以请求续种； " +
-        '可以发送邀请； 可以查看排行榜；可以查看其它用户的种子历史(如果用户隐私等级未设置为"强")； 可以删除自己上传的字幕。',
+        '可以发送邀请； 可以查看排行榜；可以查看其它用户的种子历史(如果用户隐私等级未设置为"强")； 可以删除自己上传的字幕。' +
+        "当条件符合时将被自动提升。注意，无论何时，如果你的分享率低于0.95，你将自动降级。",
     },
     {
       id: 2,
@@ -46,8 +48,10 @@ export const siteMetadata: ISiteMetadata = {
       nameAka: ["Elite User"],
       interval: "P8W",
       downloaded: "120GB",
+      seedingBonus: 80000,
       ratio: 1.55,
-      privilege: "Elite User及以上用户封存账号后不会被删除。",
+      privilege:
+        "Elite User及以上用户封存账号后不会被删除。当条件符合时将被自动提升。注意，无论何时，如果你的分享率低于1.45，你将自动降级。",
     },
     {
       id: 3,
@@ -55,8 +59,10 @@ export const siteMetadata: ISiteMetadata = {
       nameAka: ["Crazy User"],
       interval: "P15W",
       downloaded: "300GB",
+      seedingBonus: 150000,
       ratio: 2.05,
-      privilege: "得到两个邀请名额；可以在做种/下载/发布的时候选择匿名模式。",
+      privilege:
+        "得到两个邀请名额；可以在做种/下载/发布的时候选择匿名模式。当条件符合时将被自动提升。注意，无论何时，如果你的分享率低于1.95，你将自动降级。",
     },
     {
       id: 4,
@@ -64,8 +70,9 @@ export const siteMetadata: ISiteMetadata = {
       nameAka: ["Insane User"],
       interval: "P25W",
       downloaded: "500GB",
+      seedingBonus: 250000,
       ratio: 2.55,
-      privilege: "可以查看普通日志。",
+      privilege: "可以查看普通日志。当条件符合时将被自动提升。注意，无论何时，如果你的分享率低于2.45，你将自动降级。",
     },
     {
       id: 5,
@@ -73,9 +80,11 @@ export const siteMetadata: ISiteMetadata = {
       nameAka: ["Veteran User"],
       interval: "P40W",
       downloaded: "750GB",
+      seedingBonus: 400000,
       ratio: 3.05,
       isKept: true,
-      privilege: "得到三个邀请名额；可以查看其它用户的评论、帖子历史。Veteran User及以上用户会永远保留账号。",
+      privilege:
+        "得到三个邀请名额；可以查看其它用户的评论、帖子历史。Veteran User及以上用户会永远保留账号。当条件符合时将被自动提升。注意，无论何时，如果你的分享率低于2.95，你将自动降级。",
     },
     {
       id: 6,
@@ -83,9 +92,11 @@ export const siteMetadata: ISiteMetadata = {
       nameAka: ["Extreme User"],
       interval: "P60W",
       downloaded: "1TB",
+      seedingBonus: 600000,
       ratio: 3.55,
       isKept: true,
-      privilege: "可以更新过期的外部信息；可以查看Extreme User论坛。",
+      privilege:
+        "可以更新过期的外部信息；可以查看Extreme User论坛。当条件符合时将被自动提升。注意，无论何时，如果你的分享率低于3.45，你将自动降级。",
     },
     {
       id: 7,
@@ -93,9 +104,10 @@ export const siteMetadata: ISiteMetadata = {
       nameAka: ["Ultimate User"],
       interval: "P80W",
       downloaded: "1.5TB",
+      seedingBonus: 900000,
       ratio: 4.05,
       isKept: true,
-      privilege: "得到五个邀请名额。",
+      privilege: "得到五个邀请名额。当条件符合时将被自动提升。注意，无论何时，如果你的分享率低于3.95，你将自动降级。",
     },
     {
       id: 8,
@@ -103,9 +115,10 @@ export const siteMetadata: ISiteMetadata = {
       nameAka: ["Nexus Master"],
       interval: "P100W",
       downloaded: "3TB",
+      seedingBonus: 1500000,
       ratio: 4.55,
       isKept: true,
-      privilege: "得到十个邀请名额。",
+      privilege: "得到十个邀请名额。当条件符合时将被自动提升。注意，无论何时，如果你的分享率低于4.45，你将自动降级。",
     },
   ],
 };


### PR DESCRIPTION
## 修改说明

更新下水道（sewerpt）站点用户等级升级条件，按官方等级要求页同步：

### 新增做种积分（seedingBonus）要求

| 等级 | 注册时长 | 下载量 | 做种积分 | 分享率 |
|---|---|---|---|---|
| 大工 (Power User) | 4周 | 50GB | 40,000 | >1.05 |
| 技工 (Elite User) | 8周 | 120GB | 80,000 | >1.55 |
| 安全员 (Crazy User) | 15周 | 300GB | 150,000 | >2.05 |
| 技术员 (Insane User) | 25周 | 500GB | 250,000 | >2.55 |
| 工长 (Veteran User) | 40周 | 750GB | 400,000 | >3.05 |
| 包工头 (Extreme User) | 60周 | 1TB | 600,000 | >3.55 |
| 工程师 (Ultimate User) | 80周 | 1.5TB | 900,000 | >4.05 |
| 老板 (Nexus Master) | 100周 | 3TB | 1,500,000 | >4.55 |

### 其他变更

- 各等级 `privilege` 中补充「当条件符合时将被自动提升」及分享率降级阈值说明（0.95 / 1.45 / 1.95 / 2.45 / 2.95 / 3.45 / 3.95 / 4.45）
- 注册时长、下载量、分享率数值与现有定义一致，未改动
- `seedingBonus` 字段由 NexusPHP schema 原生支持，会自动从站点用户页「做种积分」解析实际值参与升级条件计算

## 校验

- ✅ prettier 格式检查通过
- ✅ vue-tsc 类型校验无新增错误（存量 4 个 mediaServer 相关错误与本次修改无关）

## Summary by Sourcery

Update sewerpt site user level upgrade conditions to match the official requirements, including seeding bonus thresholds and clearer promotion/demotion rules.

Enhancements:
- Add seeding bonus (seedingBonus) requirements for all sewerpt user levels based on official grading rules.
- Extend privilege descriptions for sewerpt user levels to document automatic promotion behavior and share ratio-based demotion thresholds.