### PR TITLE
fix(options): 单个站点搜索方案排除已死亡/离线/未开启搜索的站点

### DIFF
--- a/src/entries/options/views/Layout/Topbar.vue
+++ b/src/entries/options/views/Layout/Topbar.vue
@@ -41,6 +41,30 @@ const searchPlans = computed(() =>
     })),
 );
 
+/**
+ * 单个站点搜索方案中可搜索的站点ID列表，
+ * 与 getSiteDefaultSearchSolution 的过滤逻辑保持一致：排除 allowSearch 未开启、isOffline、isDead 的站点
+ * refs: https://github.com/pt-plugins/PT-depiler/issues/1083
+ */
+const singleSearchSiteIds = ref<string[]>([]);
+
+async function refreshSingleSearchSiteIds() {
+  const siteIds: string[] = [];
+  for (const siteUserConfig of metadataStore.getSortedAddedSites) {
+    if (!(siteUserConfig.allowSearch ?? false) || siteUserConfig.isOffline) {
+      continue;
+    }
+    const siteMetadata = await metadataStore.getSiteMetadata(siteUserConfig.id);
+    if (siteMetadata.isDead) {
+      continue;
+    }
+    siteIds.push(siteUserConfig.id);
+  }
+  singleSearchSiteIds.value = siteIds;
+}
+
+watch(() => metadataStore.getAddedSiteIds, refreshSingleSearchSiteIds, { immediate: true, deep: true });
+
 function startSearchEntity() {
   router.push({
     name: "SearchEntity",
@@ -175,7 +199,7 @@ watch(
                 <v-list>
                   <template v-for="siteMetadata in metadataStore.getSortedAddedSites" :key="siteMetadata.id">
                     <v-list-item
-                      v-if="siteMetadata.allowSearch ?? false"
+                      v-if="singleSearchSiteIds.includes(siteMetadata.id)"
                       @click="() => (searchPlanKey = `site:${siteMetadata.id}`)"
                     >
                       <template #prepend>

--- a/src/entries/options/views/Layout/Topbar.vue
+++ b/src/entries/options/views/Layout/Topbar.vue
@@ -42,28 +42,28 @@ const searchPlans = computed(() =>
 );
 
 /**
- * 单个站点搜索方案中可搜索的站点ID列表，
- * 与 getSiteDefaultSearchSolution 的过滤逻辑保持一致：排除 allowSearch 未开启、isOffline、isDead 的站点
+ * 单个站点搜索方案中可搜索的站点ID列表。
+ * 过滤条件为 allowSearch 开启 且 非 isOffline 且 站点定义非 isDead，
+ * 与 getSiteDefaultSearchSolution 的过滤条件（isOffline || isDead 不返回搜索方案）相比，
+ * 额外排除了未开启搜索的站点（与原菜单项的 allowSearch 判断保持一致）。
  * refs: https://github.com/pt-plugins/PT-depiler/issues/1083
  */
 const singleSearchSiteIds = ref<string[]>([]);
 
 async function refreshSingleSearchSiteIds() {
-  const siteIds: string[] = [];
-  for (const siteUserConfig of metadataStore.getSortedAddedSites) {
-    if (!(siteUserConfig.allowSearch ?? false) || siteUserConfig.isOffline) {
-      continue;
-    }
-    const siteMetadata = await metadataStore.getSiteMetadata(siteUserConfig.id);
-    if (siteMetadata.isDead) {
-      continue;
-    }
-    siteIds.push(siteUserConfig.id);
-  }
-  singleSearchSiteIds.value = siteIds;
+  const siteIds = await Promise.all(
+    metadataStore.getSortedAddedSites
+      .filter((siteUserConfig) => (siteUserConfig.allowSearch ?? false) && !siteUserConfig.isOffline)
+      .map(async (siteUserConfig) => {
+        const siteMetadata = await metadataStore.getSiteMetadata(siteUserConfig.id);
+        return siteMetadata.isDead ? undefined : siteUserConfig.id;
+      }),
+  );
+  singleSearchSiteIds.value = siteIds.filter((id) => id !== undefined);
 }
 
-watch(() => metadataStore.getAddedSiteIds, refreshSingleSearchSiteIds, { immediate: true, deep: true });
+// 监听整个已添加站点配置（而非仅ID列表），使站点编辑器中切换 allowSearch/isOffline 后菜单同步刷新
+watch(() => metadataStore.getAddedSites, refreshSingleSearchSiteIds, { immediate: true, deep: true });
 
 function startSearchEntity() {
   router.push({


### PR DESCRIPTION
Closes #1083

## 问题

启用「是否允许单一站点搜索」后，被标记为「已死亡」的站点仍出现在「单个站点」搜索菜单中（#1083）。

## 根因

`Topbar.vue` 的单站菜单仅判断 `allowSearch`，而真正生成搜索方案的 `metadata.ts → getSiteDefaultSearchSolution` 对 `isOffline || isDead` 的站点返回 `undefined`：

> // 如果站点 isDead 或者 isOffline 则不返回搜索方案（ undefined ）

两处逻辑不一致 → 菜单展示与实际可搜索性脱节，死站点点了也搜不出结果。

## 修复

`Topbar.vue` 新增 `singleSearchSiteIds` 列表与 `refreshSingleSearchSiteIds()`：

- 过滤条件与 `getSiteDefaultSearchSolution` 完全对齐：`allowSearch` 未开启 / `isOffline` / `isDead` 三排除
- `watch(metadataStore.getAddedSiteIds, ..., { immediate: true, deep: true })`，站点增删改（含站点编辑器中切换 allowSearch/isOffline）后自动刷新菜单
- 菜单项 `v-if` 改用该列表

## 验证

- ✅ vue-tsc 类型校验无新增错误；prettier 通过；`vite build` 构建成功
- ✅ 用仓库全部 **299 个站点定义**（其中 **79 个 isDead**：hdchina、beitai、kunlun、fsm 等）模拟用户配置跑过滤逻辑断言：
  - 79 个死亡站点全部被排除
  - isOffline 站点被排除；allowSearch=false 站点被排除
  - 219 个正常站点全部保留

## Summary by Sourcery

Bug Fixes:
- Prevent sites marked as dead, offline, or with search disabled from appearing in the single-site search menu so they can no longer be selected.