### PR TITLE
fix(options): 修复辅种任务勾选删除无效的问题

### DIFF
--- a/src/entries/options/views/Overview/KeepUploadTask/Index.vue
+++ b/src/entries/options/views/Overview/KeepUploadTask/Index.vue
@@ -3,7 +3,7 @@ import { ref, onMounted } from "vue";
 import { useI18n } from "vue-i18n";
 import type { CAddTorrentOptions } from "@ptd/downloader";
 
-import type { IKeepUploadTask } from "@/shared/types.ts";
+import type { IKeepUploadTask, TKeepUploadTaskKey } from "@/shared/types.ts";
 import { sendMessage } from "@/messages.ts";
 import { formatSize, formatDate } from "@/options/utils.ts";
 import { useRuntimeStore } from "@/options/stores/runtime.ts";
@@ -16,7 +16,8 @@ const runtimeStore = useRuntimeStore();
 const metadataStore = useMetadataStore();
 
 const tasks = ref<IKeepUploadTask[]>([]);
-const selectedTasks = ref<IKeepUploadTask[]>([]);
+// v-data-table 设置了 item-value="id"，因此 v-model 中保存的是任务ID（TKeepUploadTaskKey）而非任务对象
+const selectedTasks = ref<TKeepUploadTaskKey[]>([]);
 const expanded = ref<string[]>([]);
 const loading = ref(false);
 const tableKey = ref(0); // 用于强制刷新表格
@@ -63,10 +64,10 @@ async function deleteSelectedTasks() {
   if (!confirm(t("KeepUploadTask.deleteSelectedConfirm", { count: selectedTasks.value.length }))) return;
 
   try {
-    for (const task of selectedTasks.value) {
-      await sendMessage("deleteKeepUploadTask", task.id);
+    for (const taskId of selectedTasks.value) {
+      await sendMessage("deleteKeepUploadTask", taskId);
     }
-    tasks.value = tasks.value.filter((t) => !selectedTasks.value.includes(t));
+    tasks.value = tasks.value.filter((t) => !selectedTasks.value.includes(t.id));
     selectedTasks.value = [];
     runtimeStore.showSnakebar(t("KeepUploadTask.deleteSuccess"), { color: "success" });
   } catch (e) {


### PR DESCRIPTION
Closes #1393

## 问题

勾选辅种任务后点击左上角删除按钮，提示「删除成功」但任务仍在（#1393）。单独删除和「清空全部」正常。

## 根因

`KeepUploadTask/Index.vue` 的 `v-data-table` 设置了 `item-value="id"`，此时 `v-model` 选区中保存的是**任务ID（string）而非任务对象**，但 `deleteSelectedTasks` 按对象使用：

```ts
for (const task of selectedTasks.value) {
  await sendMessage("deleteKeepUploadTask", task.id);  // 字符串上取 .id → undefined
}
tasks.value = tasks.value.filter((t) => !selectedTasks.value.includes(t)); // 对象与ID比对，永不相等
```

- 后台 `delete tasks[undefined]` 是无副作用的空操作，却不抛错 → 前端提示「删除成功」
- 前端 filter 用对象与 ID 数组比对永远为真 → 任务行全部保留

与 issue 描述完全一致：**显示删除成功但任务还在**。

## 修复

- `selectedTasks` 类型改为 `TKeepUploadTaskKey[]`（与 v-data-table 实际行为一致），附注释说明
- 遍历直接发送任务ID；过滤改按 `t.id` 比对

## E2E 验证（Chrome for Testing 149 + 实际构建扩展）

注入 2 个辅种任务（t1/t2）→ 真实鼠标事件勾选两行 → 点击删除 → confirm 显示「确认删除选中的 **2** 个辅种任务吗？」→ 接受：

| 检查点 | 结果 |
|---|---|
| 存储中剩余任务 | ✅ `[]`（两个任务均删除） |
| UI 表格 | ✅ 显示「暂无辅种任务」空状态 |
| 单删/清空全部 | 未改动（原有逻辑） |

另注：验证过程中确认 Vuetify `item-value` 行为 —— 选区模型确实保存 ID 值（UiWindow.vue 中 `:item-value="(item) => item"` 的写法即为让选区保存对象的对照例）。

## Summary by Sourcery

Bug Fixes:
- Ensure bulk deletion of selected keep upload tasks works when v-data-table selection returns task IDs instead of task objects.