### PR TITLE
fix(userInfo): 刷新失败时保留上次成功刷新的数值字段

### DIFF
--- a/src/entries/offscreen/utils/userInfo.ts
+++ b/src/entries/offscreen/utils/userInfo.ts
@@ -1,6 +1,7 @@
 import PQueue from "p-queue";
 import { format } from "date-fns";
 import { isEmpty, unset } from "es-toolkit/compat";
+import { toMerged } from "es-toolkit";
 import type { IUserInfo } from "@ptd/site";
 import { EResultParseStatus } from "@ptd/site";
 
@@ -93,6 +94,21 @@ export async function setSiteLastUserInfo(userData: IUserInfo) {
 
     // 存储用户信息到 metadata 中（ pinia/webExtPersistence 会自动同步该部分信息 ）
     const metadataStore = ((await sendMessage("getExtStorage", "metadata")) ?? {}) as IMetadataPiniaStorageSchema;
+
+    /**
+     * 刷新失败（CF 拦截、需要登录、解析错误等）时，保留上次成功刷新的数值字段（上传量、下载量、魔力值等），
+     * 仅用错误对象中的字段（status/updateAt 及部分解析成功的新鲜字段）覆盖，
+     * 避免临时性错误导致 MyData 表格数值消失。历史存储（userInfo）仍只在成功时写入，不受影响。
+     * 仅当上次数据本身为 success 时合并，防止错误数据叠加。
+     * refs: https://github.com/pt-plugins/PT-depiler/issues/769
+     */
+    if (userData.status !== EResultParseStatus.success) {
+      const previous = metadataStore.lastUserInfo?.[site];
+      if (previous?.status === EResultParseStatus.success) {
+        userData = toMerged(previous, userData);
+      }
+    }
+
     (metadataStore as IMetadataPiniaStorageSchema).lastUserInfo ??= {};
     (metadataStore as IMetadataPiniaStorageSchema).lastUserInfo[site] = userData;
     await sendMessage("setExtStorage", { key: "metadata", value: metadataStore });


### PR DESCRIPTION
Closes #769

## 问题

站点用户信息刷新失败（Cloudflare 拦截、需要登录、解析错误等）时，`AbstractPrivateSite.getUserInfoResult` 返回仅含 `{status, updateAt, site}` 的最小错误对象，`setSiteLastUserInfo` 将其整体覆盖 `metadata.lastUserInfo`，导致 MyData 表格中上次成功获取的数值（上传量/下载量/分享率/魔力值等）消失（#769）。

正如报告者所述，站点被 CF 临时拦截是暂时性的，「过些时间就好了，但这段时间是没数据的」。

## 修复

`setSiteLastUserInfo` 中，当新数据 `status !== success` **且**上次数据为 `success` 时，将错误对象深合并到上次数据之上：

- 保留旧数值字段（uploaded/downloaded/bonus/seeding…）
- 错误对象中的字段优先（status/updateAt 及部分解析成功的新鲜字段）
- 防护条件 `previous.status === success` 防止错误数据叠加
- 成功路径不变，完整覆盖

效果：表格显示**最后已知值 + 错误状态徽章**（`<ResultParseStatus/>` 原有渲染，UI 零改动）。

## 设计说明

- **与既有设计一致**：`getSiteUserInfoResult` 中已有同语义的回退逻辑（站点不可查询时从历史挑最近一次 success 数据，见 userInfo.ts 原第 62-79 行「以避免 metadata.lastUserInfo 为 undefined」），本 PR 将该「最后已知值」语义延伸到刷新失败场景
- **Non-goal（明确不做）**：趋势图/统计的空档。历史存储（`userInfo`）仍仅在成功时写入——向历史写入非当期实测值属于伪造数据；图表数据源不受本 PR 影响

## E2E 验证（Chrome for Testing + 实际构建扩展，5 场景）

| 场景 | 断言 | 结果 |
|---|---|---|
| S1 失败保留旧值 | success 数据 → CFBlocked → uploaded/bonus/name 保留，status=6，updateAt 更新 | ✅ |
| S2 成功正常覆盖 | 新 success → 完整覆盖 | ✅ |
| S3 无旧数据 | 新站点直接写错误 → 原样写入不崩溃 | ✅ |
| S4 错误不叠错误 | 错误后再写错误 → 不合并（防护生效） | ✅ |
| S5 新鲜字段优先 | 错误对象携带部分新字段（name/seeding）→ 覆盖旧值，其余数值保留 | ✅ |

## 校验

- ✅ prettier 通过；vue-tsc 无新增错误

## Summary by Sourcery

Bug Fixes:
- 保留刷新失败前最近一次成功获取的用户数值字段，同时更新错误状态和时间信息。