### PR TITLE
feat(downloader): add recheck, speedlimit, queue support

### DIFF
--- a/src/entries/messages.ts
+++ b/src/entries/messages.ts
@@ -16,7 +16,7 @@ import type {
 } from "@ptd/social";
 import type { IMediaServerId, IMediaServerSearchOptions, IMediaServerSearchResult } from "@ptd/mediaServer";
 import type { IBackupData, IBackupFileInfo } from "@ptd/backupServer";
-import type { CTorrent, TorrentClientStatus } from "@ptd/downloader";
+import type { CTorrent, TorrentClientStatus, TorrentQueueDirection, TorrentSpeedLimit } from "@ptd/downloader";
 
 // 可序列化的种子信息，用于辅种检测
 export interface ITorrentInfoForVerification {
@@ -119,9 +119,14 @@ interface ProtocolMap extends TMessageMap {
   getTorrentInfoForVerification(torrent: ITorrent): ITorrentInfoForVerification;
 
   getClientTorrents(downloaderId: string): CTorrent[];
+  getClientTorrentTrackers(data: { downloaderId: string; torrent: CTorrent }): string[];
   deleteClientTorrent(data: { downloaderId: string; id: any; removeData?: boolean }): boolean;
   pauseClientTorrent(data: { downloaderId: string; id: any }): boolean;
   resumeClientTorrent(data: { downloaderId: string; id: any }): boolean;
+  recheckClientTorrent(data: { downloaderId: string; id: any }): boolean;
+  moveClientTorrentInQueue(data: { downloaderId: string; id: any; direction: TorrentQueueDirection }): boolean;
+  setClientTorrentSpeedLimit(data: { downloaderId: string; id: any; limits: TorrentSpeedLimit }): boolean;
+  setClientTorrentLabel(data: { downloaderId: string; id: any; label: string }): boolean;
 
   downloadTorrent(data: IDownloadTorrentOption): IDownloadTorrentResult;
 

--- a/src/entries/offscreen/utils/download.ts
+++ b/src/entries/offscreen/utils/download.ts
@@ -9,6 +9,8 @@ import {
   type CTorrent,
   type CAddTorrentOptions,
   type TorrentClientStatus,
+  type TorrentQueueDirection,
+  type TorrentSpeedLimit,
 } from "@ptd/downloader";
 import type { ITorrent } from "@ptd/site";
 
@@ -140,6 +142,15 @@ onMessage("getClientTorrents", async ({ data: downloaderId }) => {
   return downloaderTorrents;
 });
 
+onMessage("getClientTorrentTrackers", async ({ data: { downloaderId, torrent } }) => {
+  let downloaderTrackers: string[] = [];
+  const downloaderInstance = await getDownloaderInstance(downloaderId);
+  if (downloaderInstance) {
+    downloaderTrackers = await downloaderInstance.getTorrentTrackers(torrent);
+  }
+  return downloaderTrackers;
+});
+
 onMessage("deleteClientTorrent", async ({ data: { downloaderId, id, removeData } }) => {
   let deleteStatus: boolean = false;
   const downloaderInstance = await getDownloaderInstance(downloaderId);
@@ -167,6 +178,46 @@ onMessage("resumeClientTorrent", async ({ data: { downloaderId, id } }) => {
   }
 
   return resumeStatus;
+});
+
+onMessage("recheckClientTorrent", async ({ data: { downloaderId, id } }) => {
+  let recheckStatus: boolean = false;
+  const downloaderInstance = await getDownloaderInstance(downloaderId);
+  if (downloaderInstance) {
+    recheckStatus = await downloaderInstance.recheckTorrent(id);
+  }
+
+  return recheckStatus;
+});
+
+onMessage("moveClientTorrentInQueue", async ({ data: { downloaderId, id, direction } }) => {
+  let moveStatus: boolean = false;
+  const downloaderInstance = await getDownloaderInstance(downloaderId);
+  if (downloaderInstance) {
+    moveStatus = await downloaderInstance.moveTorrentInQueue(id, direction as TorrentQueueDirection);
+  }
+
+  return moveStatus;
+});
+
+onMessage("setClientTorrentSpeedLimit", async ({ data: { downloaderId, id, limits } }) => {
+  let limitStatus: boolean = false;
+  const downloaderInstance = await getDownloaderInstance(downloaderId);
+  if (downloaderInstance) {
+    limitStatus = await downloaderInstance.setTorrentSpeedLimit(id, limits as TorrentSpeedLimit);
+  }
+
+  return limitStatus;
+});
+
+onMessage("setClientTorrentLabel", async ({ data: { downloaderId, id, label } }) => {
+  let labelStatus: boolean = false;
+  const downloaderInstance = await getDownloaderInstance(downloaderId);
+  if (downloaderInstance) {
+    labelStatus = await downloaderInstance.setTorrentLabel(id, label);
+  }
+
+  return labelStatus;
 });
 
 function buildDownloadHistory(downloadOption: IDownloadTorrentOption): ITorrentDownloadMetadata {

--- a/src/entries/options/views/Overview/MyClient/Index.vue
+++ b/src/entries/options/views/Overview/MyClient/Index.vue
@@ -1,9 +1,17 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
+import { useRoute, useRouter } from "vue-router";
 import type { DataTableHeader } from "vuetify";
 
-import { CTorrentState, type CTorrent, getDownloaderIcon } from "@ptd/downloader";
+import {
+  CTorrentState,
+  getDownloaderIcon,
+  getDownloaderMetaData,
+  type CTorrent,
+  type TorrentClientMetaData,
+  type TorrentQueueDirection,
+} from "@ptd/downloader";
 import { sendMessage } from "@/messages.ts";
 import { formatSize, formatDate } from "@/options/utils.ts";
 import { useMetadataStore } from "@/options/stores/metadata.ts";
@@ -14,10 +22,22 @@ import DeleteDialog from "./DeleteDialog.vue";
 import PushToDownloaderDialog from "./PushToDownloaderDialog.vue";
 import TorrentStateTd from "./TorrentStateTd.vue";
 import ClientStatusDialog from "./ClientStatusDialog.vue";
+import TorrentDetailDialog from "./TorrentDetailDialog.vue";
+import SpeedLimitDialog from "./SpeedLimitDialog.vue";
+import LabelDialog from "./LabelDialog.vue";
+import RecheckConfirmDialog from "./RecheckConfirmDialog.vue";
 
-import { torrents, autoRefreshRunning, globalRefreshInterval, useClientRefresh } from "./utils.ts";
+import {
+  torrents,
+  selectedDownloaderIds,
+  autoRefreshRunning,
+  globalRefreshInterval,
+  useClientRefresh,
+} from "./utils.ts";
 
 const { t } = useI18n();
+const route = useRoute();
+const router = useRouter();
 const metadataStore = useMetadataStore();
 const runtimeStore = useRuntimeStore();
 const configStore = useConfigStore();
@@ -44,14 +64,19 @@ const toDeleteTorrents = ref<CTorrent[]>([]);
 // push to downloader dialog
 const showPushToDownloaderDialog = ref(false);
 
-// raw JSON dialog
-const showRawDialog = ref(false);
-const rawTorrent = ref<CTorrent | null>(null);
+// detail dialog
+const showDetailDialog = ref(false);
+const detailTorrent = ref<CTorrent | null>(null);
 
-function openRawDialog(item: CTorrent) {
-  rawTorrent.value = item;
-  showRawDialog.value = true;
-}
+// speed limit dialog
+const showSpeedLimitDialog = ref(false);
+
+// label dialog
+const showLabelDialog = ref(false);
+
+// recheck confirm dialog
+const showRecheckDialog = ref(false);
+const toRecheckTorrents = ref<CTorrent[]>([]);
 
 // client status dialog
 const showClientStatusDialog = ref(false);
@@ -75,6 +100,28 @@ const filteredTorrents = computed(() => {
       t.savePath.toLowerCase().includes(q),
   );
 });
+
+// 当前选中种子的下载器类型对应的能力元数据（用于显示可用操作）
+const clientMetaMap = ref<Record<string, TorrentClientMetaData>>({});
+
+async function ensureClientMeta(clientId: string) {
+  const type = metadataStore.downloaders[clientId]?.type;
+  if (type && !clientMetaMap.value[type]) {
+    clientMetaMap.value[type] = await getDownloaderMetaData(type);
+  }
+}
+
+/** 判断某个 feature 在该下载器上是否可用 */
+function isFeatureAllowed(clientId: string, feature: keyof TorrentClientMetaData["feature"]): boolean {
+  const type = metadataStore.downloaders[clientId]?.type;
+  return clientMetaMap.value[type]?.feature?.[feature]?.allowed !== false;
+}
+
+// 在表格渲染时按需加载选中/可见种子的客户端能力元数据
+async function loadVisibleClientMeta() {
+  const ids = new Set(allTorrents.value.map((t) => t.clientId));
+  await Promise.all([...ids].map(ensureClientMeta));
+}
 
 // ── table headers ─────────────────────────────────────────────────────────
 const fullTableHeader = computed(
@@ -120,6 +167,7 @@ async function loadTorrents() {
     await Promise.allSettled(activeDownloaderIds.value.map((id) => loadSingleDownloader(id)));
   } finally {
     loading.value = false;
+    await loadVisibleClientMeta();
     if (autoRefreshRunning.value) {
       for (const id of activeDownloaderIds.value) {
         scheduleDownloaderRefresh(id);
@@ -129,7 +177,14 @@ async function loadTorrents() {
 }
 
 onMounted(() => {
-  if (configStore.download.initDownloaderTorrentOnEnter) {
+  // 支持从 SetDownloader 等页面通过 ?downloader=<id> 预选单个下载服务器
+  const queryDownloaderId = route.query.downloader as string | undefined;
+  if (queryDownloaderId && metadataStore.downloaders[queryDownloaderId]) {
+    selectedDownloaderIds.value = [queryDownloaderId];
+    // 预选是一次性导航行为，清除 URL query 避免刷新页面后重复预选
+    void router.replace({ path: "/my-client" });
+    loadTorrents();
+  } else if (configStore.download.initDownloaderTorrentOnEnter) {
     loadTorrents();
   }
 });
@@ -166,6 +221,44 @@ function openDeleteDialog(torrentList: CTorrent[]) {
   showDeleteDialog.value = true;
 }
 
+function openDetailDialog(item: CTorrent) {
+  detailTorrent.value = item;
+  showDetailDialog.value = true;
+}
+
+function openRecheckDialog(torrentList: CTorrent[]) {
+  if (torrentList.length === 0) return;
+  toRecheckTorrents.value = torrentList;
+  showRecheckDialog.value = true;
+}
+
+async function recheckTorrents() {
+  const torrentList = toRecheckTorrents.value;
+  if (torrentList.length === 0) return;
+  const results = await Promise.allSettled(
+    torrentList.map((t) => sendMessage("recheckClientTorrent", { downloaderId: t.clientId, id: t.id })),
+  );
+  const succeeded = results.filter((r) => r.status === "fulfilled" && Boolean(r.value)).length;
+  runtimeStore.showSnakebar(t("MyClient.action.recheckSelectedSuccess", { count: succeeded }), {
+    color: succeeded > 0 ? "success" : "error",
+  });
+  const affectedIds = [...new Set(torrentList.map((t) => t.clientId))];
+  await Promise.allSettled(affectedIds.map(loadSingleDownloader));
+}
+
+async function moveTorrentsInQueue(torrentList: CTorrent[], direction: TorrentQueueDirection) {
+  if (torrentList.length === 0) return;
+  const results = await Promise.allSettled(
+    torrentList.map((t) => sendMessage("moveClientTorrentInQueue", { downloaderId: t.clientId, id: t.id, direction })),
+  );
+  const succeeded = results.filter((r) => r.status === "fulfilled" && Boolean(r.value)).length;
+  runtimeStore.showSnakebar(t("MyClient.action.moveQueueSuccess", { count: succeeded }), {
+    color: succeeded > 0 ? "success" : "error",
+  });
+  const affectedIds = [...new Set(torrentList.map((t) => t.clientId))];
+  await Promise.allSettled(affectedIds.map(loadSingleDownloader));
+}
+
 // Called per-item by DeleteDialog
 async function confirmDeleteTorrent(torrentKey_: string, removeData: boolean): Promise<void> {
   const torrent = toDeleteTorrents.value.find((t) => torrentKey(t) === torrentKey_);
@@ -186,6 +279,12 @@ function clientIcon(clientId: string) {
   return type ? getDownloaderIcon(type) : undefined;
 }
 
+/** 清除下载器预选筛选（恢复显示全部下载器） */
+function clearDownloaderFilter() {
+  selectedDownloaderIds.value = [];
+  void loadTorrents();
+}
+
 function torrentKey(torrent: CTorrent) {
   return `${torrent.clientId}:${String(torrent.id)}`;
 }
@@ -194,6 +293,19 @@ function torrentKey(torrent: CTorrent) {
 <template>
   <v-alert :title="t('route.Overview.MyClient')" type="info">
     <template #append>
+      <v-chip
+        v-if="selectedDownloaderIds.length === 1"
+        :prepend-avatar="clientIcon(selectedDownloaderIds[0])"
+        class="mr-2"
+        closable
+        color="primary"
+        label
+        size="small"
+        @click:close="clearDownloaderFilter"
+      >
+        {{ clientName(selectedDownloaderIds[0]) }}
+      </v-chip>
+
       <v-btn
         :title="t('MyClient.clientStatusDialog.openBtn')"
         class="mr-2 status-btn"
@@ -249,6 +361,33 @@ function torrentKey(torrent: CTorrent) {
           icon="mdi-delete"
           variant="text"
           @click="() => openDeleteDialog(tableSelected)"
+        />
+
+        <v-btn
+          :disabled="tableSelected.length === 0"
+          :title="t('MyClient.recheckSelected')"
+          color="cyan"
+          icon="mdi-refresh"
+          variant="text"
+          @click="() => openRecheckDialog(tableSelected)"
+        />
+
+        <v-btn
+          :disabled="tableSelected.length === 0"
+          :title="t('MyClient.speedLimit.batchBtn')"
+          color="amber"
+          icon="mdi-speedometer"
+          variant="text"
+          @click="showSpeedLimitDialog = true"
+        />
+
+        <v-btn
+          :disabled="tableSelected.length === 0"
+          :title="t('MyClient.label.batchBtn')"
+          color="purple"
+          icon="mdi-label"
+          variant="text"
+          @click="showLabelDialog = true"
         />
 
         <v-divider vertical class="mx-2" />
@@ -456,12 +595,59 @@ function torrentKey(torrent: CTorrent) {
               @click="() => resumeTorrents([item])"
             />
 
+            <!-- 重新校验 -->
             <v-btn
-              :title="t('MyClient.action.viewRaw')"
-              color="grey"
-              icon="mdi-code-json"
+              v-if="isFeatureAllowed(item.clientId, 'Recheck')"
+              :title="t('MyClient.action.recheck')"
+              color="cyan"
+              icon="mdi-refresh"
               size="small"
-              @click="() => openRawDialog(item)"
+              @click="() => openRecheckDialog([item])"
+            />
+
+            <!-- 队列调整 -->
+            <v-menu location="bottom">
+              <template #activator="{ props: menuProps }">
+                <v-btn
+                  v-if="isFeatureAllowed(item.clientId, 'Queue')"
+                  v-bind="menuProps"
+                  :title="t('MyClient.action.queue')"
+                  color="orange"
+                  icon="mdi-swap-vertical"
+                  size="small"
+                />
+              </template>
+              <v-list density="compact">
+                <v-list-item
+                  :title="t('MyClient.action.queueTop')"
+                  prepend-icon="mdi-chevron-double-up"
+                  @click="() => moveTorrentsInQueue([item], 'top')"
+                />
+                <v-list-item
+                  :title="t('MyClient.action.queueUp')"
+                  prepend-icon="mdi-chevron-up"
+                  @click="() => moveTorrentsInQueue([item], 'up')"
+                />
+                <v-list-item
+                  :title="t('MyClient.action.queueDown')"
+                  prepend-icon="mdi-chevron-down"
+                  @click="() => moveTorrentsInQueue([item], 'down')"
+                />
+                <v-list-item
+                  :title="t('MyClient.action.queueBottom')"
+                  prepend-icon="mdi-chevron-double-down"
+                  @click="() => moveTorrentsInQueue([item], 'bottom')"
+                />
+              </v-list>
+            </v-menu>
+
+            <!-- 详情 -->
+            <v-btn
+              :title="t('MyClient.action.detail')"
+              color="grey"
+              icon="mdi-file-eye-outline"
+              size="small"
+              @click="() => openDetailDialog(item)"
             />
 
             <v-btn
@@ -488,22 +674,17 @@ function torrentKey(torrent: CTorrent) {
 
   <ClientStatusDialog v-model="showClientStatusDialog" />
 
-  <!-- Raw JSON dialog -->
-  <v-dialog v-model="showRawDialog" max-width="800" scrollable>
-    <v-card>
-      <v-card-title class="pa-0">
-        <v-toolbar color="blue-grey-darken-2">
-          <v-toolbar-title>{{ t("MyClient.action.viewRaw") }}</v-toolbar-title>
-          <template #append>
-            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showRawDialog = false" />
-          </template>
-        </v-toolbar>
-      </v-card-title>
-      <v-card-text class="pa-2">
-        <pre class="text-body-2">{{ rawTorrent ? JSON.stringify(rawTorrent, null, 2) : "" }}</pre>
-      </v-card-text>
-    </v-card>
-  </v-dialog>
+  <TorrentDetailDialog v-model="showDetailDialog" :torrent="detailTorrent" />
+
+  <SpeedLimitDialog v-model="showSpeedLimitDialog" :torrents="tableSelected" />
+
+  <LabelDialog v-model="showLabelDialog" :torrents="tableSelected" />
+
+  <RecheckConfirmDialog
+    v-model="showRecheckDialog"
+    :torrent-count="toRecheckTorrents.length"
+    :confirm-fn="recheckTorrents"
+  />
 </template>
 
 <style scoped lang="scss">

--- a/src/entries/options/views/Overview/MyClient/LabelDialog.vue
+++ b/src/entries/options/views/Overview/MyClient/LabelDialog.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { useI18n } from "vue-i18n";
+
+import type { CTorrent } from "@ptd/downloader";
+import { sendMessage } from "@/messages.ts";
+import { useRuntimeStore } from "@/options/stores/runtime.ts";
+
+const showDialog = defineModel<boolean>();
+const { torrents, suggestLabels } = defineProps<{
+  torrents: CTorrent[];
+  suggestLabels?: string[];
+}>();
+
+const { t } = useI18n();
+const runtimeStore = useRuntimeStore();
+
+const labelInput = ref<string>("");
+
+function dialogEnter() {
+  // 初始化为当前种子的标签（如果有的话）
+  const first = torrents[0];
+  labelInput.value = first?.label ?? "";
+}
+
+async function confirmSetLabel() {
+  const label = labelInput.value.trim();
+  if (!label) {
+    runtimeStore.showSnakebar(t("MyClient.label.emptyLabel"), { color: "warning" });
+    return;
+  }
+
+  const results = await Promise.allSettled(
+    torrents.map((torrent) =>
+      sendMessage("setClientTorrentLabel", {
+        downloaderId: torrent.clientId,
+        id: torrent.id,
+        label,
+      }),
+    ),
+  );
+  const succeeded = results.filter((r) => r.status === "fulfilled" && Boolean(r.value)).length;
+  runtimeStore.showSnakebar(t("MyClient.label.success", { count: succeeded }), {
+    color: succeeded > 0 ? "success" : "error",
+  });
+  showDialog.value = false;
+}
+</script>
+
+<template>
+  <v-dialog v-model="showDialog" max-width="480" @after-enter="dialogEnter">
+    <v-card>
+      <v-card-title class="pa-0">
+        <v-toolbar :title="t('MyClient.label.title', { count: torrents.length })" color="blue-grey-darken-2">
+          <template #append>
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
+          </template>
+        </v-toolbar>
+      </v-card-title>
+
+      <v-divider />
+
+      <v-card-text>
+        <v-combobox v-model="labelInput" :items="suggestLabels ?? []" :label="t('MyClient.label.input')" clearable />
+      </v-card-text>
+
+      <v-divider />
+
+      <v-card-actions>
+        <v-spacer />
+        <v-btn color="info" prepend-icon="mdi-close-circle" variant="text" @click="showDialog = false">
+          <span class="ml-1">{{ t("common.dialog.cancel") }}</span>
+        </v-btn>
+        <v-btn color="success" prepend-icon="mdi-check-circle-outline" variant="text" @click="confirmSetLabel">
+          <span class="ml-1">{{ t("common.dialog.ok") }}</span>
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<style scoped lang="scss"></style>

--- a/src/entries/options/views/Overview/MyClient/RecheckConfirmDialog.vue
+++ b/src/entries/options/views/Overview/MyClient/RecheckConfirmDialog.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { useI18n } from "vue-i18n";
+
+const showDialog = defineModel<boolean>();
+const { torrentCount, confirmFn } = defineProps<{
+  torrentCount: number;
+  confirmFn: () => Promise<void> | void;
+}>();
+
+const { t } = useI18n();
+
+const isRechecking = ref(false);
+
+async function confirmRecheck() {
+  isRechecking.value = true;
+  try {
+    await confirmFn();
+  } finally {
+    isRechecking.value = false;
+    showDialog.value = false;
+  }
+}
+
+function dialogEnter() {
+  isRechecking.value = false;
+}
+</script>
+
+<template>
+  <v-dialog v-model="showDialog" :persistent="isRechecking" width="420" @after-enter="dialogEnter">
+    <v-card>
+      <v-card-title class="bg-cyan-lighten-2">
+        {{ t("MyClient.recheckDialog.title") }}
+      </v-card-title>
+
+      <v-card-text class="text-body-1">
+        {{ t("MyClient.recheckDialog.text", { count: torrentCount }) }}
+      </v-card-text>
+
+      <v-divider />
+
+      <v-card-actions>
+        <v-spacer />
+        <v-btn color="info" prepend-icon="mdi-close-circle" variant="text" @click="showDialog = false">
+          <span class="ml-1">{{ t("common.dialog.cancel") }}</span>
+        </v-btn>
+        <v-btn :loading="isRechecking" color="cyan" prepend-icon="mdi-refresh" variant="text" @click="confirmRecheck">
+          <span class="ml-1">{{ t("common.dialog.ok") }}</span>
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<style scoped lang="scss"></style>

--- a/src/entries/options/views/Overview/MyClient/SpeedLimitDialog.vue
+++ b/src/entries/options/views/Overview/MyClient/SpeedLimitDialog.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { useI18n } from "vue-i18n";
+
+import type { CTorrent, TorrentSpeedLimit } from "@ptd/downloader";
+import { sendMessage } from "@/messages.ts";
+import { useRuntimeStore } from "@/options/stores/runtime.ts";
+
+const showDialog = defineModel<boolean>();
+const { torrents } = defineProps<{
+  torrents: CTorrent[];
+}>();
+
+const { t } = useI18n();
+const runtimeStore = useRuntimeStore();
+
+const uploadLimit = ref<number | null>(null);
+const downloadLimit = ref<number | null>(null);
+
+function dialogEnter() {
+  // 初始化为当前种子的限速（qBittorrent raw 中有 up_limit/dl_limit 字段，其他客户端留空）
+  const first = torrents[0];
+  const raw = first?.raw as Record<string, any> | undefined;
+  uploadLimit.value = typeof raw?.up_limit === "number" ? Math.round(raw.up_limit / 1024) : null;
+  downloadLimit.value = typeof raw?.dl_limit === "number" ? Math.round(raw.dl_limit / 1024) : null;
+}
+
+async function confirmSetLimit() {
+  const limits: TorrentSpeedLimit = {};
+  if (uploadLimit.value !== null) limits.upload = uploadLimit.value;
+  if (downloadLimit.value !== null) limits.download = downloadLimit.value;
+  if (Object.keys(limits).length === 0) {
+    runtimeStore.showSnakebar(t("MyClient.speedLimit.emptyLimit"), { color: "warning" });
+    return;
+  }
+
+  const results = await Promise.allSettled(
+    torrents.map((torrent) =>
+      sendMessage("setClientTorrentSpeedLimit", {
+        downloaderId: torrent.clientId,
+        id: torrent.id,
+        limits,
+      }),
+    ),
+  );
+  const succeeded = results.filter((r) => r.status === "fulfilled" && Boolean(r.value)).length;
+  runtimeStore.showSnakebar(t("MyClient.speedLimit.success", { count: succeeded }), {
+    color: succeeded > 0 ? "success" : "error",
+  });
+  showDialog.value = false;
+}
+</script>
+
+<template>
+  <v-dialog v-model="showDialog" max-width="480" @after-enter="dialogEnter">
+    <v-card>
+      <v-card-title class="pa-0">
+        <v-toolbar :title="t('MyClient.speedLimit.title', { count: torrents.length })" color="blue-grey-darken-2">
+          <template #append>
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
+          </template>
+        </v-toolbar>
+      </v-card-title>
+
+      <v-divider />
+
+      <v-card-text>
+        <v-alert type="info" variant="tonal" density="compact" class="mb-3">
+          {{ t("MyClient.speedLimit.unitNote") }}
+        </v-alert>
+
+        <v-text-field
+          v-model.number="uploadLimit"
+          :label="t('MyClient.speedLimit.upload')"
+          min="0"
+          type="number"
+          clearable
+        />
+        <v-text-field
+          v-model.number="downloadLimit"
+          :label="t('MyClient.speedLimit.download')"
+          min="0"
+          type="number"
+          clearable
+        />
+      </v-card-text>
+
+      <v-divider />
+
+      <v-card-actions>
+        <v-spacer />
+        <v-btn color="info" prepend-icon="mdi-close-circle" variant="text" @click="showDialog = false">
+          <span class="ml-1">{{ t("common.dialog.cancel") }}</span>
+        </v-btn>
+        <v-btn color="success" prepend-icon="mdi-check-circle-outline" variant="text" @click="confirmSetLimit">
+          <span class="ml-1">{{ t("common.dialog.ok") }}</span>
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<style scoped lang="scss"></style>

--- a/src/entries/options/views/Overview/MyClient/TorrentDetailDialog.vue
+++ b/src/entries/options/views/Overview/MyClient/TorrentDetailDialog.vue
@@ -1,0 +1,230 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { useI18n } from "vue-i18n";
+
+import type { CTorrent } from "@ptd/downloader";
+import { sendMessage } from "@/messages.ts";
+import { formatSize, formatDate } from "@/options/utils.ts";
+
+import TorrentStateTd from "./TorrentStateTd.vue";
+
+const showDialog = defineModel<boolean>();
+const { torrent } = defineProps<{
+  torrent: CTorrent | null;
+}>();
+
+const { t } = useI18n();
+
+const trackers = ref<string[]>([]);
+const trackersLoading = ref(false);
+const trackersLoaded = ref(false);
+
+async function loadTrackers() {
+  if (!torrent || trackersLoaded.value) return;
+  trackersLoading.value = true;
+  try {
+    trackers.value = await sendMessage("getClientTorrentTrackers", {
+      downloaderId: torrent.clientId,
+      torrent,
+    });
+    trackersLoaded.value = true;
+  } catch {
+    trackers.value = [];
+  } finally {
+    trackersLoading.value = false;
+  }
+}
+
+function resetDialog() {
+  trackers.value = [];
+  trackersLoaded.value = false;
+}
+
+async function copyToClipboard(text: string) {
+  await navigator.clipboard.writeText(text);
+}
+
+function magnetLink(torrent: CTorrent): string {
+  return `magnet:?xt=urn:btih:${torrent.infoHash}&dn=${encodeURIComponent(torrent.name)}`;
+}
+
+/** 格式化速度：0 / undefined 显示 "-"（避免 filesize(undefined) 抛错渲染为空） */
+function formatSpeed(speed: number | undefined): string {
+  return speed && speed > 0 ? `${formatSize(speed)}/s` : "-";
+}
+
+/** 格式化总量：undefined 显示 "-"，0 显示 "0 B" */
+function formatTotal(total: number | undefined): string {
+  return typeof total === "number" ? (formatSize(total) as string) : "-";
+}
+</script>
+
+<template>
+  <v-dialog v-model="showDialog" max-width="800" scrollable @after-enter="loadTrackers" @after-leave="resetDialog">
+    <v-card v-if="torrent">
+      <v-card-title class="pa-0">
+        <v-toolbar color="blue-grey-darken-2">
+          <v-toolbar-title>{{ t("MyClient.detail.title") }}</v-toolbar-title>
+          <template #append>
+            <v-btn icon="mdi-close" :title="t('common.dialog.close')" @click="showDialog = false" />
+          </template>
+        </v-toolbar>
+      </v-card-title>
+
+      <v-divider />
+
+      <v-card-text>
+        <!-- 基本信息 -->
+        <v-list density="compact">
+          <v-list-item>
+            <template #prepend>
+              <v-icon icon="mdi-file-document-outline" />
+            </template>
+            <v-list-item-title class="font-weight-bold">{{ torrent.name }}</v-list-item-title>
+          </v-list-item>
+
+          <v-list-item>
+            <template #prepend>
+              <v-icon icon="mdi-key-variant" />
+            </template>
+            <v-list-item-title class="d-flex align-center ga-2">
+              <code class="text-caption">{{ torrent.infoHash }}</code>
+              <v-btn
+                :title="t('MyClient.detail.copyHash')"
+                icon="mdi-content-copy"
+                size="x-small"
+                variant="text"
+                @click="copyToClipboard(torrent.infoHash)"
+              />
+              <v-btn
+                :title="t('MyClient.detail.copyMagnet')"
+                icon="mdi-magnet"
+                size="x-small"
+                variant="text"
+                @click="copyToClipboard(magnetLink(torrent))"
+              />
+            </v-list-item-title>
+          </v-list-item>
+
+          <v-divider />
+
+          <v-row class="ma-0">
+            <v-col cols="6">
+              <v-list-item>
+                <template #prepend>
+                  <v-icon icon="mdi-state-machine" />
+                </template>
+                <v-list-item-title>
+                  <TorrentStateTd :item="torrent" />
+                </v-list-item-title>
+              </v-list-item>
+              <v-list-item>
+                <template #prepend>
+                  <v-icon icon="mdi-progress-check" />
+                </template>
+                <v-list-item-title> {{ torrent.progress.toFixed(2) }}% </v-list-item-title>
+              </v-list-item>
+              <v-list-item>
+                <template #prepend>
+                  <v-icon icon="mdi-database" />
+                </template>
+                <v-list-item-title>
+                  {{ formatSize(torrent.totalSize) }}
+                </v-list-item-title>
+              </v-list-item>
+            </v-col>
+            <v-col cols="6">
+              <v-list-item>
+                <template #prepend>
+                  <v-icon color="green-darken-4" icon="mdi-chevron-up" />
+                </template>
+                <v-list-item-title>
+                  {{ formatSpeed(torrent.uploadSpeed) }}
+                  <span class="text-grey text-caption ml-1">({{ formatTotal(torrent.totalUploaded) }})</span>
+                </v-list-item-title>
+              </v-list-item>
+              <v-list-item>
+                <template #prepend>
+                  <v-icon color="red-darken-4" icon="mdi-chevron-down" />
+                </template>
+                <v-list-item-title>
+                  {{ formatSpeed(torrent.downloadSpeed) }}
+                  <span class="text-grey text-caption ml-1">({{ formatTotal(torrent.totalDownloaded) }})</span>
+                </v-list-item-title>
+              </v-list-item>
+              <v-list-item>
+                <template #prepend>
+                  <v-icon icon="mdi-chart-line" />
+                </template>
+                <v-list-item-title>
+                  <span :class="torrent.ratio >= 1 ? 'text-green' : 'text-red'">
+                    {{ torrent.ratio.toFixed(2) }}
+                  </span>
+                </v-list-item-title>
+              </v-list-item>
+            </v-col>
+          </v-row>
+
+          <v-divider />
+
+          <v-list-item>
+            <template #prepend>
+              <v-icon icon="mdi-folder" />
+            </template>
+            <v-list-item-title class="text-caption">{{ torrent.savePath }}</v-list-item-title>
+          </v-list-item>
+          <v-list-item>
+            <template #prepend>
+              <v-icon icon="mdi-label-outline" />
+            </template>
+            <v-list-item-title>{{ torrent.label || "-" }}</v-list-item-title>
+          </v-list-item>
+          <v-list-item>
+            <template #prepend>
+              <v-icon icon="mdi-calendar-plus" />
+            </template>
+            <v-list-item-title>{{ formatDate(torrent.dateAdded * 1000) }}</v-list-item-title>
+          </v-list-item>
+        </v-list>
+
+        <!-- Tracker 列表 -->
+        <v-expansion-panels class="mt-4">
+          <v-expansion-panel>
+            <v-expansion-panel-title>
+              {{ t("MyClient.detail.trackers") }}
+              <template #actions>
+                <v-progress-circular v-if="trackersLoading" indeterminate size="18" width="2" class="ml-2" />
+                <v-chip v-else-if="trackers.length > 0" size="small" color="info" class="ml-2">
+                  {{ trackers.length }}
+                </v-chip>
+              </template>
+            </v-expansion-panel-title>
+            <v-expansion-panel-text>
+              <v-list v-if="trackers.length > 0" density="compact">
+                <v-list-item v-for="(tracker, index) in trackers" :key="index">
+                  <template #prepend>
+                    <v-icon icon="mdi-radar" />
+                  </template>
+                  <v-list-item-title class="text-caption">{{ tracker }}</v-list-item-title>
+                </v-list-item>
+              </v-list>
+              <v-alert v-else type="info" variant="tonal" density="compact">
+                {{ t("MyClient.detail.noTrackers") }}
+              </v-alert>
+            </v-expansion-panel-text>
+          </v-expansion-panel>
+
+          <!-- 原始 JSON -->
+          <v-expansion-panel>
+            <v-expansion-panel-title>{{ t("MyClient.action.viewRaw") }}</v-expansion-panel-title>
+            <v-expansion-panel-text>
+              <pre class="text-body-2">{{ JSON.stringify(torrent, null, 2) }}</pre>
+            </v-expansion-panel-text>
+          </v-expansion-panel>
+        </v-expansion-panels>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+<style scoped lang="scss"></style>

--- a/src/entries/options/views/Settings/SetDownloader/Index.vue
+++ b/src/entries/options/views/Settings/SetDownloader/Index.vue
@@ -2,6 +2,7 @@
 import { computed, ref } from "vue";
 import { computedAsync } from "@vueuse/core";
 import { useI18n } from "vue-i18n";
+import { useRouter } from "vue-router";
 import { countBy } from "es-toolkit";
 import type { DataTableHeader } from "vuetify";
 
@@ -22,6 +23,7 @@ import DeleteDialog from "@/options/components/DeleteDialog.vue";
 import NavButton from "@/options/components/NavButton.vue";
 
 const { t } = useI18n();
+const router = useRouter();
 const metadataStore = useMetadataStore();
 const configStore = useConfigStore();
 
@@ -84,6 +86,11 @@ const toEditDownloaderId = ref<TDownloaderKey | null>(null);
 function editDownloader(downloaderId: TDownloaderKey) {
   toEditDownloaderId.value = downloaderId;
   showEditDialog.value = true;
+}
+
+function manageDownloader(downloaderId: TDownloaderKey) {
+  // 跳转到 MyClient 页面并预选该下载服务器，进行种子管理
+  void router.push({ path: "/my-client", query: { downloader: downloaderId } });
 }
 
 function editDownloaderPathAndTag(downloaderId: TDownloaderKey) {
@@ -260,10 +267,12 @@ async function confirmDeleteDownloader(downloaderId: TDownloaderKey) {
       <template #item.action="{ item }">
         <v-btn-group class="table-action" density="compact" variant="plain">
           <v-btn
-            :disabled="true"
+            :disabled="!item.enabled /* 未启用的下载服务器无法获取状态 */"
             :title="t('SetDownloader.index.table.action.status')"
+            color="green"
             icon="mdi-information-outline"
             size="small"
+            @click="manageDownloader(item.id)"
           />
 
           <v-btn

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -130,10 +130,19 @@
   "MyClient": {
     "action": {
       "delete": "Delete",
+      "detail": "Details",
+      "moveQueueSuccess": "Moved {count} torrent(s) in queue",
       "pause": "Pause",
       "pauseError": "Failed to pause",
       "pauseSelectedSuccess": "Paused {count} torrent(s)",
       "pauseSuccess": "Paused successfully",
+      "queue": "Queue Position",
+      "queueBottom": "Move to Bottom",
+      "queueDown": "Move Down",
+      "queueTop": "Move to Top",
+      "queueUp": "Move Up",
+      "recheck": "Recheck",
+      "recheckSelectedSuccess": "Rechecked {count} torrent(s)",
       "resume": "Resume",
       "resumeError": "Failed to resume",
       "resumeSelectedSuccess": "Resumed {count} torrent(s)",
@@ -160,8 +169,22 @@
     },
     "columnSelector": "Columns",
     "deleteSelected": "Delete",
+    "detail": {
+      "copyHash": "Copy Hash",
+      "copyMagnet": "Copy Magnet Link",
+      "noTrackers": "This downloader does not support fetching trackers or has no trackers",
+      "title": "Torrent Details",
+      "trackers": "Trackers"
+    },
     "dialog": {
       "removeData": "Also remove data"
+    },
+    "label": {
+      "batchBtn": "Set Label",
+      "emptyLabel": "Label cannot be empty",
+      "input": "Label",
+      "success": "Labeled {count} torrent(s)",
+      "title": "Set Label ({count} torrent(s))"
     },
     "pauseSelected": "Pause",
     "pushToDownloader": {
@@ -174,9 +197,23 @@
       "urlInputHint": "One URL or magnet link per line",
       "urlInputLabel": "URLs / Magnet Links"
     },
+    "recheckSelected": "Recheck",
+    "recheckDialog": {
+      "text": "Are you sure you want to recheck the selected {count} torrent(s)? Rechecking consumes downloader resources and may temporarily interrupt seeding.",
+      "title": "Confirm Recheck"
+    },
     "refresh": "Refresh",
     "resumeSelected": "Resume",
     "searchPlaceholder": "Search by name, hash, label, or path",
+    "speedLimit": {
+      "batchBtn": "Speed Limit",
+      "download": "Download Limit (KiB/s, 0 = unlimited)",
+      "emptyLimit": "Please fill in at least one of upload or download limit",
+      "success": "Limited {count} torrent(s)",
+      "title": "Set Speed Limit ({count} torrent(s))",
+      "unitNote": "Speed limit unit is KiB/s; 0 means unlimited, empty means do not change this direction.",
+      "upload": "Upload Limit (KiB/s, 0 = unlimited)"
+    },
     "state": {
       "checking": "Checking",
       "downloading": "Downloading",
@@ -678,7 +715,7 @@
           "setDefault": "Set this downloader server as Default Downloader.",
           "setPathAndTag": "Set Suggest Download Path and Tags",
           "setSiteFilter": "Set Site Filter",
-          "status": "Status"
+          "status": "Manage Download Server"
         },
         "autodl": "Auto DL ?",
         "downloaderCategory": "Downloader Category",

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -130,10 +130,19 @@
   "MyClient": {
     "action": {
       "delete": "删除",
+      "detail": "详情",
+      "moveQueueSuccess": "已调整 {count} 个种子的队列位置",
       "pause": "暂停",
       "pauseError": "暂停失败",
       "pauseSelectedSuccess": "已暂停 {count} 个种子",
       "pauseSuccess": "暂停成功",
+      "queue": "队列位置",
+      "queueBottom": "移至队尾",
+      "queueDown": "下移一位",
+      "queueTop": "移至队首",
+      "queueUp": "上移一位",
+      "recheck": "重新校验",
+      "recheckSelectedSuccess": "已重新校验 {count} 个种子",
       "resume": "开始",
       "resumeError": "开始失败",
       "resumeSelectedSuccess": "已开始 {count} 个种子",
@@ -160,8 +169,22 @@
     },
     "columnSelector": "自定义列",
     "deleteSelected": "删除",
+    "detail": {
+      "copyHash": "复制 Hash",
+      "copyMagnet": "复制磁力链接",
+      "noTrackers": "该下载器不支持获取 Tracker 列表或暂无 Tracker",
+      "title": "种子详情",
+      "trackers": "Tracker 列表"
+    },
     "dialog": {
       "removeData": "同时删除数据"
+    },
+    "label": {
+      "batchBtn": "批量设置标签",
+      "emptyLabel": "标签不能为空",
+      "input": "标签",
+      "success": "已设置 {count} 个种子的标签",
+      "title": "设置标签（{count} 个种子）"
     },
     "pauseSelected": "暂停",
     "pushToDownloader": {
@@ -174,9 +197,23 @@
       "urlInputHint": "每行一个链接或磁力链接",
       "urlInputLabel": "下载链接 / 磁力链接"
     },
+    "recheckSelected": "重新校验",
+    "recheckDialog": {
+      "text": "确定要重新校验选中的 {count} 个种子吗？重新校验会消耗下载服务器的资源，并可能暂时中断做种。",
+      "title": "确认重新校验"
+    },
     "refresh": "刷新",
     "resumeSelected": "开始",
     "searchPlaceholder": "搜索种子名称、Hash、标签、路径",
+    "speedLimit": {
+      "batchBtn": "批量限速",
+      "download": "下载限速（KiB/s，0 表示不限速）",
+      "emptyLimit": "请至少填写上传或下载限速中的一个",
+      "success": "已设置 {count} 个种子的限速",
+      "title": "设置限速（{count} 个种子）",
+      "unitNote": "限速单位为 KiB/s，填写 0 表示不限速；留空表示不修改该方向。",
+      "upload": "上传限速（KiB/s，0 表示不限速）"
+    },
     "state": {
       "checking": "检查中",
       "downloading": "下载中",
@@ -678,7 +715,7 @@
           "setDefault": "设置为默认下载服务器",
           "setPathAndTag": "设置预设的下载路径和标签",
           "setSiteFilter": "设置站点过滤",
-          "status": "状态"
+          "status": "管理下载服务器"
         },
         "autodl": "自动下载？",
         "downloaderCategory": "下载器分类",

--- a/src/packages/downloader/entity/Aria2.ts
+++ b/src/packages/downloader/entity/Aria2.ts
@@ -13,6 +13,8 @@ import {
   TorrentClientStatus,
   AbstractBittorrentClient,
   CAddTorrentResult,
+  TorrentQueueDirection,
+  TorrentSpeedLimit,
 } from "../types";
 import { getRemoteTorrentFile } from "../utils";
 import urlJoin from "url-join";
@@ -35,6 +37,18 @@ export const clientMetaData: TorrentClientMetaData = {
     },
     DefaultAutoStart: {
       allowed: true,
+    },
+    Recheck: {
+      allowed: false,
+    },
+    Queue: {
+      allowed: true,
+    },
+    SpeedLimit: {
+      allowed: true,
+    },
+    Label: {
+      allowed: false,
     },
   },
 };
@@ -326,6 +340,32 @@ export default class Aria2 extends AbstractBittorrentClient {
 
   async getTorrentTrackers(_torrent: CTorrent): Promise<string[]> {
     return [];
+  }
+
+  // 调整任务在队列中的位置（aria2.changePosition）
+  override async moveTorrentInQueue(id: any, direction: TorrentQueueDirection): Promise<boolean> {
+    const positionMap: Record<TorrentQueueDirection, [number, "POS_SET" | "POS_CUR" | "POS_END"]> = {
+      top: [0, "POS_SET"],
+      up: [-1, "POS_CUR"],
+      down: [1, "POS_CUR"],
+      bottom: [0, "POS_END"],
+    };
+    const [pos, how] = positionMap[direction];
+    await this.methodSend<string>("aria2.changePosition", [id, pos, how]);
+    return true;
+  }
+
+  // 设置单个任务的速度限制（单位 KiB/s，0 表示不限速；aria2 使用 K 后缀）
+  override async setTorrentSpeedLimit(id: any, limits: TorrentSpeedLimit): Promise<boolean> {
+    const options: Record<string, string> = {};
+    if (typeof limits.download !== "undefined") {
+      options["max-download-limit"] = limits.download > 0 ? `${limits.download}K` : "0";
+    }
+    if (typeof limits.upload !== "undefined") {
+      options["max-upload-limit"] = limits.upload > 0 ? `${limits.upload}K` : "0";
+    }
+    await this.methodSend("aria2.changeOption", [id, options]);
+    return true;
   }
 
   private parseRawTorrent(rawTask: rawTask): CTorrent<rawTask> {

--- a/src/packages/downloader/entity/Deluge.ts
+++ b/src/packages/downloader/entity/Deluge.ts
@@ -12,6 +12,7 @@ import {
   TorrentClientStatus,
   AbstractBittorrentClient,
   CAddTorrentResult,
+  TorrentSpeedLimit,
 } from "../types";
 import urlJoin from "url-join";
 import axios from "axios";
@@ -38,6 +39,18 @@ export const clientMetaData: TorrentClientMetaData = {
       description: CustomPathDescription,
     },
     DefaultAutoStart: {
+      allowed: true,
+    },
+    Recheck: {
+      allowed: true,
+    },
+    Queue: {
+      allowed: false,
+    },
+    SpeedLimit: {
+      allowed: true,
+    },
+    Label: {
       allowed: true,
     },
   },
@@ -128,6 +141,8 @@ type DelugeMethod =
   | "core.remove_torrent"
   | "core.pause_torrent"
   | "core.resume_torrent"
+  | "core.force_recheck"
+  | "core.set_torrent_options"
   | "daemon.info"
   | "core.get_libtorrent_version"
   | "label.set_torrent";
@@ -441,6 +456,40 @@ export default class Deluge extends AbstractBittorrentClient {
     if (!rawTrackers) return [];
 
     return rawTrackers.map((t) => t.url);
+  }
+
+  // 重新校验种子
+  override async recheckTorrent(id: any): Promise<boolean> {
+    try {
+      return await this.request<boolean>("core.force_recheck", [id]);
+    } catch (e) {
+      return false;
+    }
+  }
+
+  // 设置单个种子的速度限制（单位 KiB/s，0 表示不限速；Deluge 使用 KiB/s，-1 表示不限速）
+  override async setTorrentSpeedLimit(id: any, limits: TorrentSpeedLimit): Promise<boolean> {
+    try {
+      const options: Record<string, number> = {};
+      if (typeof limits.download !== "undefined") {
+        options.max_download_speed = limits.download > 0 ? limits.download : -1;
+      }
+      if (typeof limits.upload !== "undefined") {
+        options.max_upload_speed = limits.upload > 0 ? limits.upload : -1;
+      }
+      return await this.request<boolean>("core.set_torrent_options", [id, options]);
+    } catch (e) {
+      return false;
+    }
+  }
+
+  // 设置单个种子的标签
+  override async setTorrentLabel(id: any, label: string): Promise<boolean> {
+    try {
+      return await this.request<boolean>("label.set_torrent", [id, label]);
+    } catch (e) {
+      return false;
+    }
   }
 
   private async login(): Promise<boolean> {

--- a/src/packages/downloader/entity/Flood.ts
+++ b/src/packages/downloader/entity/Flood.ts
@@ -47,6 +47,18 @@ export const clientMetaData: TorrentClientMetaData = {
     DefaultAutoStart: {
       allowed: true,
     },
+    Recheck: {
+      allowed: false,
+    },
+    Queue: {
+      allowed: false,
+    },
+    SpeedLimit: {
+      allowed: false,
+    },
+    Label: {
+      allowed: false,
+    },
   },
 };
 

--- a/src/packages/downloader/entity/Transmission.ts
+++ b/src/packages/downloader/entity/Transmission.ts
@@ -9,6 +9,8 @@ import {
   CTorrentState,
   TorrentClientStatus,
   CAddTorrentResult,
+  TorrentQueueDirection,
+  TorrentSpeedLimit,
 } from "../types";
 import urlJoin from "url-join";
 import axios, { type AxiosResponse, isAxiosError } from "axios";
@@ -37,6 +39,18 @@ export const clientMetaData: TorrentClientMetaData = {
     DefaultAutoStart: {
       allowed: true,
     },
+    Recheck: {
+      allowed: true,
+    },
+    Queue: {
+      allowed: true,
+    },
+    SpeedLimit: {
+      allowed: true,
+    },
+    Label: {
+      allowed: true,
+    },
   },
 };
 
@@ -54,6 +68,10 @@ interface rawTorrent {
   totalSize: number;
   leftUntilDone: number;
   labels: string[];
+  /**
+   * 注意：Transmission RPC 实际接受的字段名不带 " (B/s)" 后缀（rpc-spec.md 中旧命名为 rateDownload (B/s)，
+   * 但实测 Transmission 4.x 返回的 key 为 rateDownload / rateUpload，带后缀的字段名会被静默忽略）
+   */
   rateDownload: number;
   rateUpload: number;
   /**
@@ -127,7 +145,12 @@ type TransmissionRequestMethod =
   | "torrent-start"
   | "torrent-stop"
   | "torrent-remove"
-  | "torrent-set";
+  | "torrent-verify"
+  | "torrent-set"
+  | "queue-move-top"
+  | "queue-move-up"
+  | "queue-move-down"
+  | "queue-move-bottom";
 
 interface TransmissionAddTorrentOptions {
   "download-dir": string;
@@ -193,8 +216,8 @@ type TransmissionTorrentsField =
   | "pieceSize"
   | "priorities"
   | "queuePosition"
-  | "rateDownload (B/s)"
-  | "rateUpload (B/s)"
+  | "rateDownload"
+  | "rateUpload"
   | "recheckProgress"
   | "secondsDownloading"
   | "secondsSeeding"
@@ -243,6 +266,11 @@ export default class Transmission extends AbstractBittorrentClient<TorrentClient
     "leftUntilDone",
     "labels",
     "trackers",
+    // 上传/下载速度与总量
+    "rateDownload",
+    "rateUpload",
+    "uploadedEver",
+    "downloadedEver",
   ];
 
   // 实例真实使用的rpc地址
@@ -489,6 +517,65 @@ export default class Transmission extends AbstractBittorrentClient<TorrentClient
     }
 
     return (trackers ?? []).map((t) => t.announce);
+  }
+
+  // 重新校验种子（Transmission RPC: torrent-verify）
+  override async recheckTorrent(id: any): Promise<boolean> {
+    const args: TransmissionTorrentArguments = {
+      ids: id,
+    };
+    await this.request("torrent-verify", args);
+    return true;
+  }
+
+  // 调整种子在队列中的位置（Transmission RPC: queue-move-*）
+  override async moveTorrentInQueue(id: any, direction: TorrentQueueDirection): Promise<boolean> {
+    const methodMap: Record<TorrentQueueDirection, TransmissionRequestMethod> = {
+      top: "queue-move-top",
+      up: "queue-move-up",
+      down: "queue-move-down",
+      bottom: "queue-move-bottom",
+    };
+    const args: TransmissionTorrentArguments = {
+      ids: id,
+    };
+    await this.request(methodMap[direction], args);
+    return true;
+  }
+
+  // 设置单个种子的速度限制（单位 KiB/s，0 表示不限速；Transmission 使用 KB/s）
+  override async setTorrentSpeedLimit(id: any, limits: TorrentSpeedLimit): Promise<boolean> {
+    const args: TransmissionTorrentArguments & {
+      "upload-limit"?: number;
+      "upload-limited"?: boolean;
+      "download-limit"?: number;
+      "download-limited"?: boolean;
+    } = {
+      ids: id,
+    };
+
+    if (typeof limits.upload !== "undefined") {
+      args["upload-limit"] = limits.upload;
+      args["upload-limited"] = limits.upload > 0;
+    }
+
+    if (typeof limits.download !== "undefined") {
+      args["download-limit"] = limits.download;
+      args["download-limited"] = limits.download > 0;
+    }
+
+    await this.request("torrent-set", args);
+    return true;
+  }
+
+  // 设置单个种子的标签
+  override async setTorrentLabel(id: any, label: string): Promise<boolean> {
+    const args = {
+      ids: id,
+      labels: [label],
+    };
+    await this.request("torrent-set", args);
+    return true;
   }
 
   async request<T>(method: TransmissionRequestMethod, args: any = {}): Promise<AxiosResponse<T>> {

--- a/src/packages/downloader/entity/qBittorrent.ts
+++ b/src/packages/downloader/entity/qBittorrent.ts
@@ -14,6 +14,8 @@ import {
   CTorrentState,
   TorrentClientStatus,
   CAddTorrentResult,
+  TorrentQueueDirection,
+  TorrentSpeedLimit,
 } from "../types";
 import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
 import urlJoin from "url-join";
@@ -53,6 +55,18 @@ export const clientMetaData: TorrentClientMetaData = {
         `（ qBittorrent 额外支持以 "${category_prefix}" 前缀的分类作为下载目录，当使用该前缀时，请在 qBittorrent 中预设分类信息。）`,
     },
     DefaultAutoStart: {
+      allowed: true,
+    },
+    Recheck: {
+      allowed: true,
+    },
+    Queue: {
+      allowed: true,
+    },
+    SpeedLimit: {
+      allowed: true,
+    },
+    Label: {
       allowed: true,
     },
   },
@@ -580,5 +594,65 @@ export default class QBittorrent extends AbstractBittorrentClient<TorrentClientC
     const hash = torrent.infoHash || (torrent.id as string);
     const { data } = await this.request<Array<{ url: string }>>("/torrents/trackers", { params: { hash } });
     return data.map((t) => t.url);
+  }
+
+  // 重新校验种子
+  override async recheckTorrent(id: any): Promise<boolean> {
+    await this.request("/torrents/recheck", {
+      method: "post",
+      data: { hashes: normalizePieces(id) },
+    });
+    return true;
+  }
+
+  // 调整种子在队列中的位置
+  override async moveTorrentInQueue(id: any, direction: TorrentQueueDirection): Promise<boolean> {
+    const endpointMap: Record<TorrentQueueDirection, string> = {
+      top: "/torrents/topPrio",
+      up: "/torrents/increasePrio",
+      down: "/torrents/decreasePrio",
+      bottom: "/torrents/bottomPrio",
+    };
+    await this.request(endpointMap[direction], {
+      method: "post",
+      data: { hashes: normalizePieces(id) },
+    });
+    return true;
+  }
+
+  // 设置单个种子的速度限制（单位 KiB/s，0 表示不限速；qBittorrent 使用 bytes/s，-1 表示不限速）
+  override async setTorrentSpeedLimit(id: any, limits: TorrentSpeedLimit): Promise<boolean> {
+    const hash = normalizePieces(id);
+    const requests: Promise<any>[] = [];
+
+    if (typeof limits.download !== "undefined") {
+      requests.push(
+        this.request("/torrents/setLimit", {
+          method: "post",
+          data: { hashes: hash, limit: limits.download > 0 ? limits.download * 1024 : -1 },
+        }),
+      );
+    }
+
+    if (typeof limits.upload !== "undefined") {
+      requests.push(
+        this.request("/torrents/setUploadLimit", {
+          method: "post",
+          data: { hashes: hash, limit: limits.upload > 0 ? limits.upload * 1024 : -1 },
+        }),
+      );
+    }
+
+    await Promise.all(requests);
+    return true;
+  }
+
+  // 设置单个种子的分类（qBittorrent 的 label 即 category）
+  override async setTorrentLabel(id: any, label: string): Promise<boolean> {
+    await this.request("/torrents/setCategory", {
+      method: "post",
+      data: { hashes: normalizePieces(id), category: label },
+    });
+    return true;
   }
 }

--- a/src/packages/downloader/entity/ruTorrent.ts
+++ b/src/packages/downloader/entity/ruTorrent.ts
@@ -12,6 +12,7 @@ import {
   CTorrentState,
   TorrentClientStatus,
   CAddTorrentResult,
+  TorrentSpeedLimit,
 } from "../types";
 import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
 import { getRemoteTorrentFile } from "../utils";
@@ -34,6 +35,18 @@ export const clientMetaData: TorrentClientMetaData = {
       description: CustomPathDescription,
     },
     DefaultAutoStart: {
+      allowed: true,
+    },
+    Recheck: {
+      allowed: true,
+    },
+    Queue: {
+      allowed: false,
+    },
+    SpeedLimit: {
+      allowed: true,
+    },
+    Label: {
       allowed: true,
     },
   },
@@ -348,5 +361,37 @@ export default class RuTorrent extends AbstractBittorrentClient<TorrentClientCon
 
   async getTorrentTrackers(_torrent: string | CTorrent): Promise<string[]> {
     return [];
+  }
+
+  // 重新校验种子（rTorrent: d.check_hash）
+  override async recheckTorrent(id: any): Promise<boolean> {
+    const postData = buildRequestXML([["d.check_hash", [id.toUpperCase()]]]);
+    await this.requestHttpRpc(postData);
+    return true;
+  }
+
+  // 设置单个种子的速度限制（单位 KiB/s，0 表示不限速；rTorrent: d.set_upload_limit / d.set_download_limit）
+  override async setTorrentSpeedLimit(id: any, limits: TorrentSpeedLimit): Promise<boolean> {
+    const upId = id.toUpperCase();
+    const calls: Array<[string, string[]?]> = [];
+
+    if (typeof limits.upload !== "undefined") {
+      calls.push(["d.set_upload_limit", [upId, String(limits.upload > 0 ? limits.upload : 0)]]);
+    }
+
+    if (typeof limits.download !== "undefined") {
+      calls.push(["d.set_download_limit", [upId, String(limits.download > 0 ? limits.download : 0)]]);
+    }
+
+    const postData = buildRequestXML(calls);
+    await this.requestHttpRpc(postData);
+    return true;
+  }
+
+  // 设置单个种子的标签（rTorrent: d.custom1.set）
+  override async setTorrentLabel(id: any, label: string): Promise<boolean> {
+    const postData = buildRequestXML([["d.custom1.set", [id.toUpperCase(), label]]]);
+    await this.requestHttpRpc(postData);
+    return true;
   }
 }

--- a/src/packages/downloader/entity/synologyDownloadStation.ts
+++ b/src/packages/downloader/entity/synologyDownloadStation.ts
@@ -40,6 +40,18 @@ export const clientMetaData: TorrentClientMetaData = {
     DefaultAutoStart: {
       allowed: true,
     },
+    Recheck: {
+      allowed: false,
+    },
+    Queue: {
+      allowed: false,
+    },
+    SpeedLimit: {
+      allowed: false,
+    },
+    Label: {
+      allowed: false,
+    },
   },
 };
 

--- a/src/packages/downloader/entity/uTorrent.ts
+++ b/src/packages/downloader/entity/uTorrent.ts
@@ -10,6 +10,8 @@ import {
   TorrentClientMetaData,
   CTorrentState,
   CAddTorrentResult,
+  TorrentQueueDirection,
+  TorrentSpeedLimit,
 } from "../types";
 import urlJoin from "url-join";
 import axios from "axios";
@@ -39,6 +41,18 @@ export const clientMetaData: TorrentClientMetaData = {
         "仅支持 µTorrent 3.x.x 及以上版本；<br /><br />1. 在 µTorrent 的 设置 -> 高级 -> 网页界面 添加一个下载目录，如：D:\\download\\ <br />2. 在助手里添加目录列表（仅支持相对路径），如：music\\ <br />3. 最终数据的保存目录为：D:\\download\\music\\",
     },
     DefaultAutoStart: {
+      allowed: true,
+    },
+    Recheck: {
+      allowed: true,
+    },
+    Queue: {
+      allowed: true,
+    },
+    SpeedLimit: {
+      allowed: true,
+    },
+    Label: {
       allowed: true,
     },
   },
@@ -371,5 +385,40 @@ export default class UTorrent extends AbstractBittorrentClient<TorrentClientConf
 
   async getTorrentTrackers(_torrent: string | CTorrent): Promise<string[]> {
     return [];
+  }
+
+  // 重新校验种子
+  override async recheckTorrent(id: string): Promise<boolean> {
+    await this.request<BaseUtorrentResponse>("recheck", { hash: id });
+    return true;
+  }
+
+  // 调整种子在队列中的位置
+  override async moveTorrentInQueue(id: string, direction: TorrentQueueDirection): Promise<boolean> {
+    const actionMap: Record<TorrentQueueDirection, string> = {
+      top: "queuetop",
+      up: "queueup",
+      down: "queuedown",
+      bottom: "queuebottom",
+    };
+    await this.request<BaseUtorrentResponse>(actionMap[direction], { hash: id });
+    return true;
+  }
+
+  // 设置单个种子的速度限制（单位 KiB/s，0 表示不限速；uTorrent 使用 bytes/s）
+  override async setTorrentSpeedLimit(id: string, limits: TorrentSpeedLimit): Promise<boolean> {
+    if (typeof limits.download !== "undefined") {
+      await this.setTorrentProp(id, { s: "dlrate", v: limits.download > 0 ? limits.download * 1024 : 0 });
+    }
+    if (typeof limits.upload !== "undefined") {
+      await this.setTorrentProp(id, { s: "ulrate", v: limits.upload > 0 ? limits.upload * 1024 : 0 });
+    }
+    return true;
+  }
+
+  // 设置单个种子的标签
+  override async setTorrentLabel(id: string, label: string): Promise<boolean> {
+    await this.setTorrentProp(id, { s: "label", v: label });
+    return true;
   }
 }

--- a/src/packages/downloader/types.ts
+++ b/src/packages/downloader/types.ts
@@ -5,7 +5,11 @@ import { AxiosRequestConfig } from "axios";
 
 export type TorrentClientFeature =
   | "CustomPath" // 支持设置自定义目录作为下载目录
-  | "DefaultAutoStart"; // 支持发送种子时自动开始
+  | "DefaultAutoStart" // 支持发送种子时自动开始
+  | "Recheck" // 支持重新校验种子
+  | "Queue" // 支持调整种子在队列中的位置
+  | "SpeedLimit" // 支持设置单个种子的上传/下载速度限制
+  | "Label"; // 支持设置单个种子的标签/分类
 
 /**
  * 客户端配置信息
@@ -163,6 +167,15 @@ export interface CTorrentFilterRules {
   complete?: boolean;
 }
 
+// 种子队列调整方向
+export type TorrentQueueDirection = "top" | "up" | "down" | "bottom";
+
+// 单个种子的速度限制（单位 KiB/s，0 或 undefined 表示不限速）
+export interface TorrentSpeedLimit {
+  upload?: number;
+  download?: number;
+}
+
 // 添加种子
 export interface CAddTorrentOptions {
   /**
@@ -318,4 +331,24 @@ export abstract class AbstractBittorrentClient<T extends DownloaderBaseConfig = 
 
   // 获取种子的 Tracker 列表
   public abstract getTorrentTrackers(torrent: CTorrent): Promise<string[]>;
+
+  // 重新校验种子（Recheck/Verify），默认不支持，由各客户端 override
+  public async recheckTorrent(_id: any): Promise<boolean> {
+    return false;
+  }
+
+  // 调整种子在队列中的位置（top/up/down/bottom），默认不支持，由各客户端 override
+  public async moveTorrentInQueue(_id: any, _direction: TorrentQueueDirection): Promise<boolean> {
+    return false;
+  }
+
+  // 设置单个种子的速度限制（单位 KiB/s，0 或 undefined 表示不限速），默认不支持，由各客户端 override
+  public async setTorrentSpeedLimit(_id: any, _limits: TorrentSpeedLimit): Promise<boolean> {
+    return false;
+  }
+
+  // 设置单个种子的标签/分类，默认不支持，由各客户端 override
+  public async setTorrentLabel(_id: any, _label: string): Promise<boolean> {
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary by Sourcery

Expand torrent management with client-aware recheck, queue, speed-limit, labeling, and detailed inspection actions.

New Features:
- Add torrent rechecking, queue movement, per-torrent speed limits, and labels across supported downloader clients.
- Provide torrent detail views with tracker information, statistics, raw data, and magnet/hash copying.
- Allow navigating from downloader settings directly to a filtered torrent management view.

Bug Fixes:
- Correct Transmission torrent speed and transfer-total field names so current RPC responses and updates are handled correctly.

Enhancements:
- Add downloader capability metadata so unsupported torrent actions are hidden or disabled per client.
- Replace the raw torrent dialog with a structured detail dialog while retaining raw JSON access.