### PR TITLE
fix(pkg/site/piggo): 搜索入口改用 search.php 绕过雷池WAF拦截

### DIFF
--- a/src/packages/site/definitions/piggo.ts
+++ b/src/packages/site/definitions/piggo.ts
@@ -16,103 +16,19 @@ export const siteMetadata: ISiteMetadata = {
 
   urls: ["uggcf://cvttb.zr/"],
 
-  category: [
-    {
-      name: "类别",
-      key: "cat",
-      options: [
-        { value: 912, name: "有声-大众" },
-        { value: 408, name: "音乐-大众" },
-        { value: 409, name: "其他-大众" },
-        { value: 407, name: "体育-大众" },
-        { value: 406, name: "MV-大众" },
-        { value: 403, name: "综艺-大众" },
-        { value: 402, name: "电视剧-大众" },
-        { value: 405, name: "动漫-大众" },
-        { value: 404, name: "纪录片-大众" },
-        { value: 401, name: "电影-大众" },
-        { value: 907, name: "纪录片-儿童" },
-        { value: 910, name: "读书绘本-儿童" },
-        { value: 911, name: "音乐-儿童" },
-        { value: 905, name: "有声读物-儿童" },
-        { value: 909, name: "儿童电影-儿童" },
-        { value: 908, name: "儿童剧集-儿童" },
-      ],
-      cross: { mode: "append" },
+  /**
+   * 站点已部署雷池（SafeLine）WAF：torrents.php 对浏览器 JS 环境以外的客户端
+   * （如插件后台的 fetch）一律返回 468 质询页，导致扩展搜索无结果（refs #1394）。
+   * search.php 为站方提供的全站搜索入口（覆盖大众区与儿童区），不受该 WAF 规则限制，
+   * 但仅支持关键字与 search_area 参数，不支持分类等过滤参数，故不再声明 category。
+   */
+  search: {
+    ...SchemaMetadata.search!,
+    requestConfig: {
+      ...SchemaMetadata.search!.requestConfig!,
+      url: "/search.php",
     },
-    {
-      name: "媒介",
-      key: "medium",
-      options: [
-        { value: 11, name: "Untouched" },
-        { value: 3, name: "Remux" },
-        { value: 7, name: "Encode" },
-        { value: 5, name: "DIY" },
-        { value: 8, name: "Other" },
-      ],
-      cross: { mode: "append" },
-    },
-    {
-      name: "编码",
-      key: "codec",
-      options: [
-        { value: 1, name: "H.264/X.264" },
-        { value: 6, name: "H.265/X.265" },
-        { value: 5, name: "Other" },
-      ],
-      cross: { mode: "append" },
-    },
-    {
-      name: "音频编码",
-      key: "audiocodec",
-      options: [
-        { value: 1, name: "FLAC" },
-        { value: 2, name: "APE" },
-        { value: 3, name: "DTS" },
-        { value: 4, name: "MP3" },
-        { value: 6, name: "AAC" },
-        { value: 7, name: "Other" },
-        { value: 8, name: "AC-3" },
-        { value: 9, name: "DTS-HD MA" },
-        { value: 10, name: "TrueHD" },
-        { value: 11, name: "LPCM" },
-      ],
-      cross: { mode: "append" },
-    },
-    {
-      name: "分辨率",
-      key: "standard",
-      options: [
-        { value: 3, name: "720p" },
-        { value: 1, name: "1080p/i" },
-        { value: 5, name: "4K" },
-        { value: 6, name: "other" },
-      ],
-      cross: { mode: "append" },
-    },
-    {
-      name: "制作组",
-      key: "team",
-      options: [
-        { value: 8, name: "PigoWeb" },
-        { value: 7, name: "PigoHD" },
-        { value: 9, name: "PigoNF" },
-        { value: 10, name: "PigoAD" },
-        { value: 5, name: "Other" },
-      ],
-    },
-    {
-      name: "画质",
-      key: "processing",
-      options: [
-        { value: 4, name: "DV（杜比视界)" },
-        { value: 3, name: "HDR10+" },
-        { value: 2, name: "HDR10" },
-        { value: 1, name: "SDR" },
-      ],
-      cross: { mode: "brackets" },
-    },
-  ],
+  },
 
   officialGroupPattern: [/PigoHD|PigoWeb|PiGoNF/i],
 


### PR DESCRIPTION
refs #1394（Piggo 部分）

## 问题

Piggo 站内搜索在扩展中无结果 / 解析错误（#1394）。

## 根因（实测）

站点已部署雷池（SafeLine）WAF，`torrents.php` 对浏览器 JS 环境以外的客户端（扩展后台 fetch 无法执行质询 JS）一律返回 **HTTP 468 质询页**；而站方提供的全站搜索入口 `search.php` 不受该规则限制。

实测矩阵（登录态浏览器内）：

| 请求 | 状态 | 解析行数 |
|---|---|---|
| `torrents.php`（无参 / 带搜索 / 带分类） | **468** WAF 质询 | 0 |
| `search.php?search=...` | **200** | 100-200 |

从 PT-depiler 扩展页面上下文（chrome-extension 源 + credentials，与后台搜索同环境）复测结论一致。

## 修复

- 搜索地址由 `/torrents.php` 改为 `/search.php`（站方全站搜索，**覆盖大众区与儿童区**，儿童区内容 cat 905-912 与大众区 401-409 均在结果中）
- 移除全部分类过滤组声明：实测 `cat401=1`、`cat=401`、`spstate`、`incldead` 在 search.php 上均被服务端忽略，保留会造成 UI 过滤器失效误导
- IMDb 高级搜索（search_area=4）search.php 原生支持，schema 默认配置无需改动

## 验证

- ✅ NexusPHP schema 行解析选择器在 search.php 真实 DOM 上 30/30 命中（download 链接 / 标题 / 分类图）
- ✅ 实搜「喜羊羊」：186 行结果，其中官种 PigoWeb 128 行，`officialGroupPattern` 大小写不敏感全部可识别
- ✅ vue-tsc 无新增错误；构建产物已确认指向 search.php

## 说明

- 站点用户正常浏览 torrents.php 不受影响（浏览器执行质询 JS 自动通过），仅扩展等程序化客户端被拦 —— 若站方后续调整 WAF 规则，可还原本 PR 的地址改动并恢复分类过滤（git revert 即可）

## Summary by Sourcery

Use Piggo’s search.php endpoint for reliable extension searches and remove filters that the endpoint does not support.

Bug Fixes:
- Route Piggo extension searches through the WAF-compatible site-wide search endpoint so programmatic clients can retrieve and parse results successfully.

Enhancements:
- Remove unsupported category and advanced filtering declarations from the Piggo site definition while retaining native search support, including IMDb search.