### PR TITLE
fix(userInfo): 升级达标日期随数据刷新漂移，改用绝对达标时间渲染

### DIFF
--- a/src/entries/options/views/Overview/MyData/UserLevelShowSpan.vue
+++ b/src/entries/options/views/Overview/MyData/UserLevelShowSpan.vue
@@ -24,7 +24,6 @@ const {
 
 const { t } = useI18n();
 const configStore = useConfigStore();
-const currentTime = +new Date();
 
 // Toggle function for double-click
 function toggleIntervalDisplay() {
@@ -66,8 +65,17 @@ function formatDuration(duration: number | isoDuration) {
 
 function formatIntervalDate(duration: number | isoDuration): string {
   try {
-    // 展示剩余时间时，基于 current 计算；展现等级要求时，基于 joinTime 计算
-    const refTime = useJoinTimeAsRef ? (userInfo.joinTime ?? currentTime) : currentTime;
+    // #1140 unmet 结果带有绝对达标时间时优先使用，避免「挂载时刻 + 重算差值」的时钟错位导致日期漂移
+    if (levelRequirement.passTime) {
+      const passTimeDate = formatDate(new Date(levelRequirement.passTime), "yyyy-MM-dd");
+      if (typeof passTimeDate === "string") {
+        return passTimeDate;
+      }
+    }
+
+    // 展示剩余时间时，基于当前时刻计算；展现等级要求时，基于 joinTime 计算
+    // 注意每次渲染时重新取值，不能缓存到 setup 顶层（浏览器长期不关闭时缓存值会持续陈旧）
+    const refTime = useJoinTimeAsRef ? (userInfo.joinTime ?? Date.now()) : Date.now();
     if (typeof duration === "number") {
       // 如果是数字（秒）
       const targetDate = new Date(refTime + duration * 1000);

--- a/src/packages/site/types/userinfo.ts
+++ b/src/packages/site/types/userinfo.ts
@@ -49,6 +49,13 @@ export interface IImplicitUserInfo {
   // bonusNeededInterval?: `${number}H`;
   // seedingBonusNeededInterval?: `${number}H`;
 
+  /**
+   * passTime 是一个由 levelRequirementUnMet 计算得到的结果（unix 毫秒时间戳），
+   * 表示满足 interval 需求的绝对达标时间；前端渲染日期时优先使用该值，避免相对差值与渲染时刻的时钟错位（#1140）
+   * ！！请不要在 levelRequirements 中定义该值！！
+   */
+  passTime?: number;
+
   uploads?: number; // 发布数需求
   leeching?: number; // 下载数量需求
   snatches?: number; // 完成种子数需求

--- a/src/packages/site/utils/level.ts
+++ b/src/packages/site/utils/level.ts
@@ -91,6 +91,7 @@ export function levelRequirementUnMet(
       if (leftDuration.months) interval += `${leftDuration.months}M`;
       if (leftDuration.days) interval += `${leftDuration.days}D`;
       unmetRequirement.interval = interval; // 只保留日期部分
+      unmetRequirement.passTime = +passTime; // 附带绝对达标时间，供前端渲染日期时直接使用（#1140）
     }
   }
 


### PR DESCRIPTION
## 问题

Closes #1140

浏览器长期不关闭时，「我的数据」表格中下一等级的达标日期会越漂越远，重启浏览器后日期跳正（如 issue 中 5-20 → 5-22）。

## 根因

两处时钟错位叠加：

1. `UserLevelShowSpan.vue` 在 setup 顶层缓存了 `const currentTime = +new Date()`，组件挂载后永不更新——页面开几天就陈旧几天；
2. `levelRequirementUnMet` 内部明明算出了绝对达标时间 `passTime`，却只把相对差值（`PxxMxxD`，且天数向下取整）下发给前端，前端再用陈旧的 `currentTime` 往回加。

刷新数据触发重算时：陈旧挂载时刻 + 新鲜差值 = 日期倒退。感谢 @hui-shao 在 issue 中的分析。

## 修复

- `level.ts`：`levelRequirementUnMet` 在下发相对差值的同时，附带绝对达标时间戳 `passTime`（沿用 `bonusNeededInterval` 同款「计算结果专用键」惯例，已在类型中注明不得在 levelRequirements 中定义）；
- `UserLevelShowSpan.vue`：移除 setup 顶层缓存的 `currentTime`；渲染日期时优先使用 `passTime`；兜底路径改用渲染时刻的 `Date.now()`。

等级要求列表（`useJoinTimeAsRef` 场景）传入的是原始 requirement、不含 `passTime`，继续走 `joinTime + interval` 的既有稳定路径，行为不变。

## E2E 验证（Chrome for Testing + CDP）

注入 tjupt 用户数据（`joinTime = now-3w`，下一级要求 `P4W`），页面挂载后将页面时钟前移 5 天，再刷新 lastUserInfo 触发重算：

| 构建 | T0 初始渲染 | T1（时钟+5d 并重算） |
|---|---|---|
| master | 08-28（title 6D） | **08-23（title 1D）❌ 日期倒退 5 天** |
| 本修复 | 08-29（title 6D） | **08-29（title 1D）✅ 日期不动** |

- 剩余时长 title 由 6D → 1D，证明重算确实发生，而达标日期不再漂移；
- 附带收益：master 的初始渲染比真实达标日（`joinTime+4w` = 08-29）早 1 天，系旧实现「差值取整到天再往回加」的精度丢失，本修复直接使用绝对时间后一并消除。

## Summary by Sourcery

Fix achievement-date rendering so refreshed level requirements remain anchored to their absolute completion time.

Bug Fixes:
- Prevent next-level achievement dates from drifting or moving backward when user data is refreshed after the browser has been open for a long time.
- Preserve accurate achievement dates by eliminating the previous loss of day-level precision from rounded relative intervals.

Enhancements:
- Render unmet level requirements using their absolute achievement timestamps while retaining the existing join-time calculation path for applicable level requirement lists.

Tests:
- Add end-to-end verification that recalculating user data updates the remaining duration without changing the displayed achievement date.