### PR TITLE
fix(downloader): 修复推送种子到下载器失败的问题 (#1430, #1431)

### DIFF
--- a/src/entries/messages.ts
+++ b/src/entries/messages.ts
@@ -213,8 +213,11 @@ function createMessageWrapper<PM extends ProtocolMap>(original: {
     // @ts-expect-error
     const localHandler = messageMaps[type] as PM[K] | undefined;
 
-    if (__BROWSER__ == "firefox" && typeof data !== "undefined") {
-      data = JSON.parse(JSON.stringify(data)); // 为 firefox 深拷贝数据，避免传递 proxy 出现的 DataCloneError
+    // 深拷贝数据，避免 Vue 响应式 Proxy 或其他不可序列化对象进入消息链路引发 DataCloneError。
+    // 原实现仅对 firefox 生效，Chrome/Edge 下同样存在该问题（见 issue #1431），
+    // 故对所有浏览器统一执行深拷贝。
+    if (typeof data !== "undefined") {
+      data = JSON.parse(JSON.stringify(data));
     }
 
     if (localHandler) {

--- a/src/entries/offscreen/utils/download.ts
+++ b/src/entries/offscreen/utils/download.ts
@@ -305,7 +305,12 @@ async function downloadTorrent(downloadOption: IDownloadTorrentOption) {
     if (isDownloadToLocalFile) {
       // 本地下载
       downloadOption.localDownloadMethod ??= configStoreRaw?.download?.localDownloadMethod ?? "web";
-      downloadStatus = await downloadTorrentToLocalFile(downloadOption as TLocalDownloadOption, downloadRequestConfig);
+      const localResult = await downloadTorrentToLocalFile(
+        downloadOption as TLocalDownloadOption,
+        downloadRequestConfig,
+      );
+      downloadStatus = localResult.downloadStatus;
+      errorMessage = localResult.errorMessage;
     } else {
       // 远程推送
       addTorrentOptions.localDownload ??= true; // 默认开启本地中转选项（如果传递进来的没有 localDownload 值的话）
@@ -326,6 +331,12 @@ async function downloadTorrent(downloadOption: IDownloadTorrentOption) {
   }
 
   await setDownloadStatus(downloadId, downloadStatus);
+  if (errorMessage) {
+    // 将失败原因写入下载历史，方便在下载历史页面定位问题（见 issue #1430）
+    await patchDownloadHistory(downloadId, { errorMessage }).catch(() => {
+      logger({ msg: `Failed to persist errorMessage for download task #${downloadId}` });
+    });
+  }
   return { downloadId, downloadStatus, errorMessage } as IDownloadTorrentResult;
 }
 
@@ -334,9 +345,10 @@ onMessage("downloadTorrent", async ({ data: downloadOption }) => await downloadT
 async function downloadTorrentToLocalFile(
   downloadOption: TLocalDownloadOption,
   downloadRequestConfig: AxiosRequestConfig,
-): Promise<TTorrentDownloadStatus> {
+): Promise<Pick<IDownloadTorrentResult, "downloadStatus" | "errorMessage">> {
   let { torrent, localDownloadMethod = "web", downloadId } = downloadOption;
   let downloadStatus: TTorrentDownloadStatus = "downloading";
+  let errorMessage: string | undefined;
 
   const downloadUri = axios.getUri(downloadRequestConfig); // 组装 baseURL, url, params
   const {
@@ -350,7 +362,7 @@ async function downloadTorrentToLocalFile(
     if (downloadMethod.toUpperCase() === "GET" && isEmpty(downloadHeaders)) {
       logger({ msg: `Download torrent file with web method: ${downloadUri}` });
       window.open(downloadUri, "_blank");
-      return await setDownloadStatus(downloadId, "completed");
+      return { downloadStatus: await setDownloadStatus(downloadId, "completed"), errorMessage };
     } else {
       localDownloadMethod = "extension"; // 如果是不能直接使用 window.open 方法的情况，直接使用 extension 方法
     }
@@ -376,7 +388,7 @@ async function downloadTorrentToLocalFile(
 
       logger({ msg: `Download torrent file with browser method: ${downloadUri}`, data: downloadOptions });
       await sendMessage("downloadFile", downloadOptions);
-      return await setDownloadStatus(downloadId, "completed");
+      return { downloadStatus: await setDownloadStatus(downloadId, "completed"), errorMessage };
     } catch (e) {
       localDownloadMethod = "extension"; // 如果下载失败，直接使用 extension 方法（怎么可能？）
     }
@@ -402,10 +414,11 @@ async function downloadTorrentToLocalFile(
       URL.revokeObjectURL(torrentUrl);
     } catch (e) {
       downloadStatus = await setDownloadStatus(downloadId, "failed");
+      errorMessage = getErrorMessage(e);
     }
   }
 
-  return downloadStatus;
+  return { downloadStatus, errorMessage };
 }
 
 async function downloadTorrentToRemote(

--- a/src/entries/offscreen/utils/logger.ts
+++ b/src/entries/offscreen/utils/logger.ts
@@ -13,13 +13,18 @@ const MAX_LOGGER_LENGTH = 500;
 export const loggerStorage = useSessionStorage<ILoggerItem[]>("logger", []);
 
 export function logger(data: ILoggerItem) {
-  data.id ??= nanoid();
-  data.time ??= new Date().getTime();
-  data.msg = data.msg?.trim();
+  try {
+    data.id ??= nanoid();
+    data.time ??= new Date().getTime();
+    data.msg = data.msg?.trim();
 
-  loggerStorage.value.push(data);
-  if (loggerStorage.value.length > MAX_LOGGER_LENGTH) {
-    loggerStorage.value.shift();
+    loggerStorage.value.push(data);
+    if (loggerStorage.value.length > MAX_LOGGER_LENGTH) {
+      loggerStorage.value.shift();
+    }
+  } catch (e) {
+    // 日志记录失败不应影响主流程（如传入不可序列化数据、sessionStorage 写入异常等）
+    console.error("[PTD] logger failed:", e);
   }
 }
 

--- a/src/entries/options/views/Overview/DownloadHistory/Index.vue
+++ b/src/entries/options/views/Overview/DownloadHistory/Index.vue
@@ -233,6 +233,18 @@ onUnmounted(() => {
   <v-dialog v-model="showDownloadDetailDialog" width="800">
     <v-card>
       <v-card-text>
+        <v-alert
+          v-if="downloadDetail.errorMessage"
+          class="mb-3"
+          color="error"
+          icon="mdi-alert"
+          variant="tonal"
+        >
+          <div class="text-subtitle-2 font-weight-bold mb-1">
+            {{ t("DownloadHistory.detail.errorMessage") }}
+          </div>
+          <code class="text-body-2">{{ downloadDetail.errorMessage }}</code>
+        </v-alert>
         <pre> {{ JSON.stringify(downloadDetail, null, 2) }}</pre>
       </v-card-text>
     </v-card>

--- a/src/entries/shared/types/common/download.ts
+++ b/src/entries/shared/types/common/download.ts
@@ -47,6 +47,7 @@ export interface ITorrentDownloadMetadata extends Pick<ITorrent, "title" | "subT
 
   downloadRequestConfig?: AxiosRequestConfig;
   addTorrentResult?: CAddTorrentResult;
+  errorMessage?: string; // 失败时的错误信息（如推送失败原因），便于在下载历史中定位问题
 }
 
 export interface IDownloadTorrentResult {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -49,6 +49,9 @@
       "selectDownloader": "Select Downloader",
       "title": "Re-download {0} records"
     },
+    "detail": {
+      "errorMessage": "Error Message"
+    },
     "filterPlaceholder": "Filter download history",
     "reDownload": "Re-download",
     "refresh": "Refresh download history list",

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -49,6 +49,9 @@
       "selectDownloader": "选择下载服务器",
       "title": "重新下载 {0} 条记录"
     },
+    "detail": {
+      "errorMessage": "失败原因"
+    },
     "filterPlaceholder": "过滤下载记录",
     "reDownload": "重新下载",
     "refresh": "刷新下载记录列表",


### PR DESCRIPTION
修复两个「推送种子到下载器失败」的 issue：

- **#1430** 推送种子到下载器失败（downloadStatus: failed）：种子下载成功但推送失败，失败原因被静默吞掉、无任何错误输出
- **#1431** 传种子到下载器报 `DataCloneError: Failed to execute 'put' on 'IDBObjectStore': #<Object> could not be cloned.`

## 改动内容

### 1. messages：消息层对所有浏览器深拷贝数据（`src/entries/messages.ts`）
原实现仅对 firefox 执行 `JSON.parse(JSON.stringify(data))` 深拷贝以去除 Vue 响应式 Proxy（提交 4e5e507f 的注释即写明"避免传递 proxy 出现的 DataCloneError"），Chrome/Edge 下同样存在该问题——#1431 报错文案中的 `#<Object> could not be cloned` 正是 V8 结构化克隆遇到 Proxy 的报错。现对所有浏览器统一深拷贝，从源头杜绝 Proxy 进入消息链路。已审计全部 `sendMessage` 载荷均为 JSON 兼容结构（无函数/Blob/Date/Map/Set 跨消息层），且 Firefox 线上已按此运行多年，行为一致性有保证。

### 2. download：失败时将 errorMessage 写入下载历史（`src/entries/offscreen/utils/download.ts`）
- `ITorrentDownloadMetadata` 新增 `errorMessage?: string` 字段（IDB 无 schema，旧记录兼容）；
- `downloadTorrent` 收尾时若失败则 `patchDownloadHistory(downloadId, { errorMessage })`；
- `downloadTorrentToLocalFile` 返回值扩展为 `{ downloadStatus, errorMessage }`，本地下载（extension 方法）失败原因同样落库。

### 3. DownloadHistory：详情弹窗展示失败原因（`Index.vue` + 中英文 locale）
失败记录在详情弹窗中以错误样式高亮显示 `errorMessage`，方便用户直接看到此前被吞掉的真实底层错误。

### 4. logger：日志记录失败不再影响主流程（`src/entries/offscreen/utils/logger.ts`）
`logger()` 整体 try/catch，任何日志侧异常（不可序列化数据、sessionStorage 写入异常等）只输出 console.error，不再打断下载主流程。

## 验证
- `npx vue-tsc --noEmit`：无新增类型错误（仅 4 个 `src/packages/mediaServer/entity/*.ts` 既有错误，经 git stash 对照确认与本次改动无关，系 axios 1.19 类型升级引入）
- `pnpm build:dist` 构建通过，产物中已确认三处改动（消息层无条件深拷贝、errorMessage 持久化、logger try/catch）

## 说明
分析中提出的「修复 2（IDB 写入净化 + 不静默吞错）」与「修复 4（qBittorrent FormData content-type 覆盖）」未包含在本 PR 内，如需可另行处理。

## Summary by Sourcery

Make torrent delivery failures reliable and diagnosable by preventing message cloning errors and exposing persisted failure details to users.

Bug Fixes:
- Prevent download-message failures caused by Vue reactive or otherwise non-cloneable data across all supported browsers.
- Persist download failure messages and display them in download history details instead of silently hiding the underlying error.

Enhancements:
- Isolate logging failures so serialization or storage errors cannot interrupt the download workflow.