### PR TITLE
fix(mediaServer): 搜索失败时区分认证错误与其他错误，展示真实失败原因

### DIFF
--- a/src/entries/options/views/Overview/MediaServerEntity/utils.ts
+++ b/src/entries/options/views/Overview/MediaServerEntity/utils.ts
@@ -73,10 +73,14 @@ export async function doSearch(option: { searchKey?: string; loadMore?: boolean 
 
       if (searchResult.status !== EResultParseStatus.success) {
         const mediaServerDetail = metadataStore.mediaServers[mediaServerId];
-        runtimeStore.showSnakebar(
-          `媒体服务器 ${mediaServerDetail.name} [${mediaServerDetail.address}] 更新失败，请检查认证信息`,
-          { color: "error" },
-        );
+        // 只有认证类失败才提示检查认证信息，其余（超时/网络不可达/解析异常）展示真实原因（#1396）
+        const failReason =
+          searchResult.status === EResultParseStatus.needLogin
+            ? "请检查认证信息"
+            : (searchResult.errorMessage ?? "未知错误");
+        runtimeStore.showSnakebar(`媒体服务器 ${mediaServerDetail.name} [${mediaServerDetail.address}] 更新失败：${failReason}`, {
+          color: "error",
+        });
         return;
       }
 

--- a/src/packages/mediaServer/entity/emby.ts
+++ b/src/packages/mediaServer/entity/emby.ts
@@ -6,7 +6,7 @@ import {
   IMediaServerSearchOptions,
   IMediaServerSearchResult,
 } from "../types.ts";
-import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
+import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 import urlJoin from "url-join";
 import { toMerged } from "es-toolkit";
 import { EResultParseStatus } from "@ptd/site";
@@ -228,7 +228,14 @@ export default class Emby extends AbstractMediaServer<IEmbyConfig> {
         result.status = EResultParseStatus.needLogin;
       }
     } catch (e) {
-      result.status = EResultParseStatus.parseError;
+      // 401 是认证问题（needLogin），其余（超时、网络不可达、解析异常等）不是认证问题，
+      // 需要把真实错误带回去，避免 UI 统一提示「请检查认证信息」误导排障（#1396）
+      if (e instanceof AxiosError && e.response?.status === 401) {
+        result.status = EResultParseStatus.needLogin;
+      } else {
+        result.status = EResultParseStatus.parseError;
+      }
+      result.errorMessage = e instanceof Error ? `${e.name}: ${e.message}` : String(e);
     }
 
     return result;

--- a/src/packages/mediaServer/entity/jellyfin.ts
+++ b/src/packages/mediaServer/entity/jellyfin.ts
@@ -6,7 +6,7 @@ import {
   IMediaServerSearchOptions,
   IMediaServerSearchResult,
 } from "@ptd/mediaServer";
-import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
+import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 import {
   IEmbyQueryItem,
   IEmbyQueryResult,
@@ -174,7 +174,14 @@ export default class Jellyfin extends AbstractMediaServer<IJellyfinConfig> {
         result.status = EResultParseStatus.needLogin;
       }
     } catch (e) {
-      result.status = EResultParseStatus.parseError;
+      // 401 是认证问题（needLogin），其余（超时、网络不可达、解析异常等）不是认证问题，
+      // 需要把真实错误带回去，避免 UI 统一提示「请检查认证信息」误导排障（#1396）
+      if (e instanceof AxiosError && e.response?.status === 401) {
+        result.status = EResultParseStatus.needLogin;
+      } else {
+        result.status = EResultParseStatus.parseError;
+      }
+      result.errorMessage = e instanceof Error ? `${e.name}: ${e.message}` : String(e);
     }
 
     return result;

--- a/src/packages/mediaServer/types.ts
+++ b/src/packages/mediaServer/types.ts
@@ -84,6 +84,9 @@ export interface IMediaServerSearchResult<RAW = any> {
   // 搜索结果
   items: IMediaServerItem<RAW>[];
   options?: IMediaServerSearchOptions;
+
+  // 非 success 时附带的真实错误信息（如 timeout of 5000ms exceeded），用于 UI 展示失败原因
+  errorMessage?: string;
 }
 
 export abstract class AbstractMediaServer<T extends IMediaServerBaseConfig = IMediaServerBaseConfig> {


### PR DESCRIPTION
## 问题

refs #1396 ：Jellyfin 在配置页「测试连接」成功，但概览-媒体库搜索始终提示「更新失败，请检查认证信息」。

## 根因（错误处理层）

- `jellyfin.ts` / `emby.ts` 的 `getSearchResult` 将 catch 到的**一切异常**（请求超时、网络不可达、401、解析错误）统一置为 `parseError`；
- UI（`MediaServerEntity/utils.ts`）对所有非 `success` 结果一律提示「更新失败，请检查认证信息」。

两层叠加导致：连接超时这类与认证无关的故障也被归因为认证问题，严重误导排障（测试连接走 `/System/Info` 轻接口很容易成功，而 `/Items` 搜索在媒体库较大/网络较慢时容易超时，正是 issue 报告者的签名）。

注：PTD 构造的 jellyfin 查询参数本身没有问题——已对照官方 demo 服务器（10.11.11）逐项验证 `sortBy=Random`、`sortBy=IsFavoriteOrLiked,Random`、`fields` 列表及 `searchTerm` 查询均 200 且返回正常数据。

## 修复

- `IMediaServerSearchResult` 新增 `errorMessage` 字段，携带真实错误信息；
- `jellyfin.ts` / `emby.ts`：401 → `needLogin`（对齐 `plex.ts` 既有模式），其余保持 `parseError` 但附上 `${e.name}: ${e.message}`；
- `utils.ts`：snackbar 仅在 `needLogin` 时提示「请检查认证信息」，其余场景展示真实失败原因。

## E2E 验证（Chrome for Testing + CDP）

注入指向不可达地址的 jellyfin 服务器配置，触发概览媒体库自动搜索：

| 构建 | snackbar |
|---|---|
| master | `更新失败，请检查认证信息`（超时被误导为认证问题） |
| 本修复 | `更新失败：AxiosError: timeout of 4000ms exceeded` |

直连消息断言：`{status: 4, errorMessage: "AxiosError: timeout of 4000ms exceeded"}`，真实错误经 offscreen → 页面全链路贯通。

## 说明

401→needLogin 分支因本机验证环境限制（浏览器出站网络故障）未能实测真 401 响应，该分支为对齐 `plex.ts` 既有模式的直白实现；原 issue 报告者未回复版本信息，本 PR 修复「无论何种故障都被误导为认证问题」这一层，使其能看到真实失败原因以便进一步定位。