### PR TITLE
feat(pkg/site): 补齐织梦(zmpt)站点搜索分类与制作组配置

### DIFF
--- a/src/packages/site/definitions/zmpt.ts
+++ b/src/packages/site/definitions/zmpt.ts
@@ -33,6 +33,7 @@ export const siteMetadata: ISiteMetadata = {
         { name: "音乐 / Music", value: 423 },
         { name: "有声书 / Audiobook", value: 424 },
         { name: "软件 / Software", value: 425 },
+        { name: "游戏 / Games", value: 426 },
       ],
       cross: { mode: "append" },
     },
@@ -91,8 +92,10 @@ export const siteMetadata: ISiteMetadata = {
         { name: "ZmWeb", value: 7 },
         { name: "ZmPT", value: 6 },
         { name: "ZmMusic", value: 8 },
+        { name: "ZmAudio", value: 11 },
         { name: "DYZ-Movie", value: 9 },
         { name: "GodDramas", value: 10 },
+        { name: "RL/RL4B", value: 12 },
       ],
       cross: { mode: "append" },
     },
@@ -101,7 +104,7 @@ export const siteMetadata: ISiteMetadata = {
     CategoryInclbookmarked,
   ],
 
-  officialGroupPattern: ["ZmWeb", "ZmPT"],
+  officialGroupPattern: ["ZmWeb", "ZmPT", "ZmMusic", "ZmAudio"],
 
   userInfo: {
     ...SchemaMetadata.userInfo!,


### PR DESCRIPTION
## 变更说明

对照 zmpt.cc 站点当前实际表单，补齐 `zmpt.ts` 中缺失的搜索配置：

1. **分类**新增 `游戏 / Games (cat=426)` —— 站点侧栏与高级搜索表单均已提供该分类，但扩展中无法筛选
2. **制作组**新增 `ZmAudio (11)`、`RL/RL4B (12)` —— 站点表单实际有 8 个制作组，原配置仅 6 个
3. `officialGroupPattern` 补充 `ZmMusic`、`ZmAudio`，用于从标题识别官组并添加标签

## 真机验证（Chrome for Testing 加载 dist + 真实站点登录态）

**站点侧（登录态实测 zmpt.cc）**：
- `torrents.php?cat=426` 过滤生效：101 行中 100 行为游戏分类图标（另 1 行为跨分类置顶）
- 关键字搜索（`search`）100 行、IMDb 号搜索（`search_area=4`，tt0944947）56 行，默认 title/link/time/subTitle/促销标签选择器 100% 命中（本次顺带体检，核心搜索无需改动）
- 表单 checkbox 实际值：team11=ZmAudio、team12=RL/RL4B

**扩展侧（fail-first → fixed）**：
- master 构建：搜索方案弹窗中织梦分类无「游戏」、制作组无 ZmAudio/RL4B（截图存档）
- 本 PR 构建：三项选项全部出现；勾选「游戏」生成方案后 `chrome.storage.local` 中 `metadata.solutions` 落盘 `requestConfig.params.cat426=1`，与站点自身表单编码（input name=`cat426`）一致

## 备注

- 站点列表页的 IMDb/豆瓣徽标为纯 `img+span`（无 href / data-id / onmouseover），DOM 不暴露 ID，`ext_imdb`/`ext_douban` 无法通过选择器获取，属站点侧限制，本次不处理。