### PR TITLE
refactor(messages): 深拷贝优先 structuredClone，失败回退 JSON；errorMessage 落盘截断

### DIFF
--- a/src/entries/messages.ts
+++ b/src/entries/messages.ts
@@ -216,8 +216,14 @@ function createMessageWrapper<PM extends ProtocolMap>(original: {
     // 深拷贝数据，避免 Vue 响应式 Proxy 或其他不可序列化对象进入消息链路引发 DataCloneError。
     // 原实现仅对 firefox 生效，Chrome/Edge 下同样存在该问题（见 issue #1431），
     // 故对所有浏览器统一执行深拷贝。
-    if (typeof data !== "undefined") {
-      data = JSON.parse(JSON.stringify(data));
+    // 优先 structuredClone：保留 Date/Map/Set 等结构、支持循环引用，且性能优于 JSON 往返；
+    // 遇到函数/DOM 节点等无法结构化克隆的载荷时回退 JSON 深拷贝。
+    if (typeof data === "object" && data !== null) {
+      try {
+        data = structuredClone(data);
+      } catch {
+        data = JSON.parse(JSON.stringify(data));
+      }
     }
 
     if (localHandler) {

--- a/src/entries/offscreen/utils/download.ts
+++ b/src/entries/offscreen/utils/download.ts
@@ -332,8 +332,9 @@ async function downloadTorrent(downloadOption: IDownloadTorrentOption) {
 
   await setDownloadStatus(downloadId, downloadStatus);
   if (errorMessage) {
-    // 将失败原因写入下载历史，方便在下载历史页面定位问题（见 issue #1430）
-    await patchDownloadHistory(downloadId, { errorMessage }).catch(() => {
+    // 将失败原因写入下载历史，方便在下载历史页面定位问题（见 issue #1430）。
+    // 截断落盘以避免超长错误信息（如带堆栈的 Error）撑大 IndexedDB 记录；返回给调用方的仍为完整信息。
+    await patchDownloadHistory(downloadId, { errorMessage: errorMessage.slice(0, 2000) }).catch(() => {
       logger({ msg: `Failed to persist errorMessage for download task #${downloadId}` });
     });
   }


### PR DESCRIPTION
## 变更说明

#1436 的后续无损优化（曾以叠加 PR 形式提出：Rhilip/PT-depiler#3，因 #1436 先行合并而转独立 PR），不改变其修复语义：

### 1. sendMessage 深拷贝优先 `structuredClone`（src/entries/messages.ts）

#1436 对所有消息 `JSON.parse(JSON.stringify(data))`，有两处可无损改进：

- **循环引用直接 TypeError**：JSON 往返遇循环结构抛 `Converting circular structure to JSON`，等于把 DataCloneError 换了个新报错；structuredClone 原生支持循环引用
- **类型损毁**：Date→字符串、Map/Set→空对象、TypedArray→普通对象；structuredClone 全部保留，性能也更好

实现：`typeof data === "object" && data !== null` 才克隆（原始值跳过）；`structuredClone` 抛错（函数、DOM 节点、**Proxy**——实测 V8 的 structuredClone 同样不接受 Proxy，会抛 DataCloneError）时回退原有 JSON 深拷贝。即 #1436 的修复目标场景（Vue 响应式 Proxy 进消息链路/IndexedDB）仍走 JSON 回退，行为与已合并代码完全一致；其余载荷获得更好保真。

### 2. errorMessage 落盘截断（src/entries/offscreen/utils/download.ts）

失败原因写入下载历史前 `slice(0, 2000)`，防止超长错误信息（带堆栈的 Error）撑大 IndexedDB 记录；返回给调用方（snackbar 展示）的仍为完整信息。

## 验证

- Node 语义对照：同一载荷下 JSON 往返 vs 本实现——Date/Map 保留、循环引用存活（JSON 版抛 TypeError）、Proxy 走回退、函数载荷回退后字段丢弃与原行为一致、原始值跳过，断言全部通过
- `pnpm check`：无新增错误（mediaServer 4 个为存量）
- 构建产物确认 offscreen（vendor 共享块）/background/options 三处消息链路均带上新代码
- CFT 实机冒烟：options 页正常渲染（启动过程数百次跨上下文消息走新克隆路径）、chrome.storage 往返正常
- 本分支基于合并后的 master，目标文件与验证时内容逐字节一致（`git diff dd32a8ff upstream/master` 为零）

## 边界

原始 DataCloneError 需特定 Proxy 进入 IDB 的路径才能端到端复现，以语义对照 + 冒烟替代，如实声明。