### PR TITLE
feat(pkg/site/agsvpt): 补充断种/促销/收藏三个标准搜索筛选

### DIFF
--- a/src/packages/site/definitions/agsvpt.ts
+++ b/src/packages/site/definitions/agsvpt.ts
@@ -3,7 +3,7 @@
  * @JackettIssue https://github.com/Jackett/Jackett/issues/14946
  */
 import { type ISiteMetadata } from "../types";
-import { SchemaMetadata } from "../schemas/NexusPHP";
+import { CategoryInclbookmarked, CategoryIncldead, CategorySpstate, SchemaMetadata } from "../schemas/NexusPHP";
 import { extractContent } from "../utils";
 
 export const siteMetadata: ISiteMetadata = {
@@ -44,6 +44,9 @@ export const siteMetadata: ISiteMetadata = {
       ],
       cross: { mode: "append" },
     },
+    CategoryIncldead,
+    CategorySpstate,
+    CategoryInclbookmarked,
   ],
 
   search: {


### PR DESCRIPTION
## 背景

实站 torrents.php 搜索表单提供三组标准筛选下拉，值与共享定义完全一致，但 agsvpt 定义未声明，扩展搜索中无法使用：

| 筛选 | 实站选项 | 对应共享定义 |
|------|---------|-------------|
| incldead | 包括断种=0 / 活种=1 / 断种=2 | `CategoryIncldead` |
| spstate | 全部=0 / 普通=1 / 免费=2 / 2X=3 / 2X免费=4 / 50%=5 / 2X 50%=6 / 30%=7 | `CategorySpstate` |
| inclbookmarked | 全部=0 / 仅收藏=1 / 仅未收藏=2 | `CategoryInclbookmarked` |

## 改动

在 category 数组补充三个共享定义（与 43+ 个站点的既有惯例一致）。

## 验证（登录态导航）

- `?spstate=2` → 下拉自动选中「免费」，返回 100/100 行均为 `pro_free` ✓

`pnpm check` 无新增错误（仅既有 4 个 mediaServer 存量错误）。