### PR TITLE
feat(pkg/site/chdbits): 补充断种/促销/收藏三个标准搜索筛选

### DIFF
--- a/src/packages/site/definitions/chdbits.ts
+++ b/src/packages/site/definitions/chdbits.ts
@@ -2,7 +2,7 @@
  * @JackettDefinitions https://github.com/Jackett/Jackett/blob/master/src/Jackett.Common/Definitions/chdbits.yml
  */
 import { ETorrentStatus, type ISiteMetadata } from "../types";
-import { SchemaMetadata } from "../schemas/NexusPHP";
+import { CategoryInclbookmarked, CategoryIncldead, CategorySpstate, SchemaMetadata } from "../schemas/NexusPHP";
 
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,
@@ -145,6 +145,9 @@ export const siteMetadata: ISiteMetadata = {
         { value: 25, name: "Destiny" },
       ],
     },
+    CategoryIncldead,
+    CategorySpstate,
+    CategoryInclbookmarked,
   ],
 
   officialGroupPattern: [/-(CHD|.*@CHDBits)|@CHDWEB/i],


### PR DESCRIPTION
## 背景

实站 torrents.php 搜索表单提供三组标准筛选下拉，值与共享定义完全一致，但 chdbits 定义未声明，扩展搜索中无法使用：

| 筛选 | 实站选项 | 对应共享定义 |
|------|---------|-------------|
| incldead | 包括断种=0 / 活种=1 / 断种=2 | `CategoryIncldead` |
| spstate | 全部=0 / 普通=1 / 免费=2 / 2X=3 / 2X免费=4 / 50%=5 / 2X 50%=6 / 30%=7 | `CategorySpstate` |
| inclbookmarked | 全部=0 / 仅收藏=1 / 仅未收藏=2 | `CategoryInclbookmarked` |

## 验证（登录态导航）

- `?spstate=2` → 下拉自动选中「免费」，返回 200/200 行均为 `pro_free` ✓

`pnpm check` 无新增错误（仅既有 4 个 mediaServer 存量错误）。

**备注**：定义中既有 `411 Study` 在当前实站表单未出现、`409` 实站标签为 Demo（定义为 Others），按只加不删原则本次未动。