### PR TITLE
feat(pkg/site/ssd): 补充 Audio(有声) 分类与 1日/3日返还两档促销筛选

### DIFF
--- a/src/packages/site/definitions/springsunday.ts
+++ b/src/packages/site/definitions/springsunday.ts
@@ -41,6 +41,7 @@ export const siteMetadata: ISiteMetadata = {
         { value: 506, name: "Sports(体育)" },
         { value: 507, name: "MV(音乐视频)" },
         { value: 508, name: "Music(音乐)" },
+        { value: 510, name: "Audio(有声)" },
         { value: 509, name: "Others(其他)" },
       ],
       cross: { mode: "append" },
@@ -177,7 +178,10 @@ export const siteMetadata: ISiteMetadata = {
       },
     },
     CategoryIncldead,
-    CategorySpstate,
+    {
+      ...CategorySpstate,
+      options: [...CategorySpstate.options, { name: "1日返还", value: 9 }, { name: "3日返还", value: 8 }],
+    },
     {
       name: "显示推荐种子？",
       key: "pick",


### PR DESCRIPTION
## 背景

实站 torrents.php 搜索表单与当前 springsunday 定义有两处差异：

1. 实站类型区有 **cat510 Audio(有声)** 分类，定义缺失（实站无 504 Animations，按只加不删原则未动既有项）
2. 促销下拉实为 **10 档**，共享 `CategorySpstate` 仅 8 档，缺 SSD 特有的「1日返还=9」「3日返还=8」

## 改动

- cat 补充 `{ value: 510, name: "Audio(有声)" }`
- spstate 改为 `{ ...CategorySpstate, options: [...CategorySpstate.options, { name: "1日返还", value: 9 }, { name: "3日返还", value: 8 }] }`

## 验证（登录态导航）

- `?cat510=1` → 复选框自动勾选，结果全部为有声读物（MP3/M4A，CMCTA 有声组发布）✓
- `?spstate=9` → 下拉自动选中「1日返还」，返回 142 行专属结果集 ✓

`pnpm check` 无新增错误（仅既有 4 个 mediaServer 存量错误）。