### PR TITLE
feat(pkg/site/u2): 补充 Web 分类

### DIFF
--- a/src/packages/site/definitions/u2.ts
+++ b/src/packages/site/definitions/u2.ts
@@ -24,6 +24,7 @@ export const siteMetadata: ISiteMetadata = {
       options: [
         { value: 9, name: "U2-Rip" },
         { value: 411, name: "U2-RBD" },
+        { value: 413, name: "Web" },
         { value: 10, name: "R3TRAW" },
         { value: 11, name: "R2JRAW" },
         { value: 12, name: "BDRip" },


### PR DESCRIPTION
## 背景

实站 torrents.php 搜索表单在 U2-RBD 之后新增 `cat413 Web` 分类，当前 u2 定义缺失，扩展搜索中无法按 Web 来源过滤。

## 改动

补充 `{ value: 413, name: "Web" }`（按实站表单顺序置于 U2-RBD 之后）。

## 验证（登录态导航）

- `?cat413=1` → 复选框自动勾选，返回 105 行，标题均带 `[Web]` 来源标记 ✓

`pnpm check` 无新增错误（仅既有 4 个 mediaServer 存量错误）。

**备注**：定义中既有 `10 R3TRAW` `11 R2JRAW` `23 台译漫画` 在当前实站表单未出现，按只加不删原则未动（存量种子搜索可能仍有效）。