### PR TITLE
feat(pkg/site/xingyunge): 补充搜索分类与筛选配置

### DIFF
--- a/src/packages/site/definitions/xingyunge.ts
+++ b/src/packages/site/definitions/xingyunge.ts
@@ -1,5 +1,5 @@
 import type { ISiteMetadata } from "../types";
-import { SchemaMetadata } from "../schemas/NexusPHP";
+import { CategoryInclbookmarked, CategoryIncldead, CategorySpstate, SchemaMetadata } from "../schemas/NexusPHP";
 
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,
@@ -15,6 +15,40 @@ export const siteMetadata: ISiteMetadata = {
 
   urls: ["uggcf://cg.kvatlhatrcg.bet/", "uggcf://cg.kvatlhatrcg.pa/"],
   legacyUrls: ["https://xingyunge.top/"],
+
+  category: [
+    {
+      name: "类型",
+      key: "cat",
+      options: [
+        { name: "电影", value: 401 },
+        { name: "电视剧", value: 402 },
+        { name: "综艺", value: 403 },
+        { name: "纪录片", value: 404 },
+        { name: "动漫", value: 405 },
+        { name: "MV", value: 406 },
+        { name: "体育", value: 407 },
+        { name: "音频", value: 408 },
+        { name: "其他", value: 409 },
+        { name: "短剧", value: 410 },
+      ],
+      cross: { mode: "append" },
+    },
+    CategoryIncldead,
+    CategorySpstate,
+    CategoryInclbookmarked,
+    {
+      name: "审核状态：",
+      key: "approval_status",
+      options: [
+        { value: "", name: "全部" },
+        { value: 0, name: "未审" },
+        { value: 1, name: "通过" },
+        { value: 2, name: "拒绝" },
+      ],
+      cross: false,
+    },
+  ],
 
   levelRequirements: [
     {


### PR DESCRIPTION
## 背景

当前 xingyunge 定义未声明任何 `category`，扩展搜索无法按分类、促销状态等过滤。实站 torrents.php 搜索表单实际提供完整的筛选能力。

## 改动

按实站表单补齐：

**分类（cat，append 模式，10 个）**：401 电影 / 402 电视剧 / 403 综艺 / 404 纪录片 / 405 动漫 / 406 MV / 407 体育 / 408 音频 / 409 其他 / 410 短剧

**标准筛选**（值与共享定义完全一致）：`CategoryIncldead`、`CategorySpstate`、`CategoryInclbookmarked`

**审核状态**：`approval_status`（全部/未审=0/通过=1/拒绝=2），写法对齐 hdkylin 既有惯例

## 验证（登录态导航）

- `?cat410=1` → 复选框自动勾选，55 行中 50 行为短剧分类、其余为置顶跨分类行，行数较未过滤明显缩减 ✓

`pnpm check` 无新增错误（仅既有 4 个 mediaServer 存量错误）。