### PR TITLE
feat(pkg/site/cspt): 补充短剧分类

### DIFF
--- a/src/packages/site/definitions/cspt.ts
+++ b/src/packages/site/definitions/cspt.ts
@@ -27,6 +27,7 @@ export const siteMetadata: ISiteMetadata = {
       key: "cat",
       options: [
         { name: "儿童", value: 417 },
+        { name: "短剧", value: 418 },
         { name: "HQ音乐", value: 408 },
         { name: "其他", value: 409 },
         { name: "体育", value: 407 },


### PR DESCRIPTION
## 背景

实站 torrents.php 搜索表单新增 `cat418 短剧` 分类，当前 cspt 定义缺失，扩展搜索中无法按短剧过滤。

## 改动

补充 `{ name: "短剧", value: 418 }`。

## 验证（登录态导航）

- `?cat418=1` → 复选框自动勾选，101 行为短剧（`c_Playlet` 图标）✓
- 对照组 `?cat401=1` → 102 行电影（`c_movies`），过滤差异符合预期 ✓

`pnpm check` 无新增错误（仅既有 4 个 mediaServer 存量错误）。

**备注**：定义中既有 `417 儿童` 在当前实站表单未出现，按只加不删原则未动。