### PR TITLE
feat(pkg/site/ubits): 补充有声书分类

### DIFF
--- a/src/packages/site/definitions/ubits.ts
+++ b/src/packages/site/definitions/ubits.ts
@@ -1,7 +1,13 @@
 import { set } from "es-toolkit/compat";
 import type { IAdvancedSearchRequestConfig, ISiteMetadata, TSelectSearchCategoryValue } from "../types";
 import { GB, TB } from "../utils";
-import { CategoryIncldead, CategorySpstate, CategoryInclbookmarked, SchemaMetadata, createUserBonusSelectorFn } from "../schemas/NexusPHP";
+import {
+  CategoryIncldead,
+  CategorySpstate,
+  CategoryInclbookmarked,
+  SchemaMetadata,
+  createUserBonusSelectorFn,
+} from "../schemas/NexusPHP";
 
 export const siteMetadata: ISiteMetadata = {
   ...SchemaMetadata,
@@ -32,6 +38,7 @@ export const siteMetadata: ISiteMetadata = {
         { value: 406, name: "Music(音乐)" },
         { value: 407, name: "Sports(体育)" },
         { value: 409, name: "MV(音乐视频)" },
+        { value: 415, name: "有声书" },
         { value: 408, name: "Others(其他)" },
       ],
       cross: { mode: "append" },


### PR DESCRIPTION
## 背景

实站 torrents.php 搜索表单新增 `cat415 有声书` 分类，当前 ubits 定义缺失，扩展搜索中无法按有声书过滤。

## 改动

补充 `{ value: 415, name: "有声书" }`（另含 pre-commit prettier 对超长 import 行的自动换行）。

## 验证（登录态导航）

- `?cat415=1` → 复选框自动勾选，31/31 行均为「有声书」分类 ✓

`pnpm check` 无新增错误（仅既有 4 个 mediaServer 存量错误）。