### PR TITLE
feat(core): upgrade vuetify from v3 to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,14 +26,13 @@
     }
   ],
   "scripts": {
-    "dev": "vite",
+    "dev": "vite dev",
     "format": "prettier --list-different -w ./",
     "check": "vue-tsc --noEmit",
     "build:dist": "vite build",
     "build:dist-firefox": "cross-env TARGET=firefox vite build",
     "build:watch": "vite build --watch --mode development --minify false",
     "action:upload_telegram": "tsx vite/sendToTgChannel.ts",
-    "release:changelog": "conventional-changelog -p angular && git add CHANGELOG.md",
     "prepare": "husky"
   },
   "engines": {
@@ -71,7 +70,7 @@
     "vue-i18n": "^11.4.8",
     "vue-konva": "^3.4.0",
     "vue-router": "^5.2.0",
-    "vuetify": "^3.13.1",
+    "vuetify": "^4.1.11",
     "webdav": "^5.10.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,8 +107,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(rollup@4.62.4)(vite@6.4.3(@types/node@26.2.0)(sass@1.102.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
       vuetify:
-        specifier: ^3.13.1
-        version: 3.13.1(typescript@6.0.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.41(typescript@6.0.3))
+        specifier: ^4.1.11
+        version: 4.1.11(typescript@6.0.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.41(typescript@6.0.3))
       webdav:
         specifier: ^5.10.0
         version: 5.10.0
@@ -175,7 +175,7 @@ importers:
         version: 8.2.1(vite@6.4.3(@types/node@26.2.0)(sass@1.102.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
       vite-plugin-vuetify:
         specifier: ^2.1.3
-        version: 2.1.3(vite@6.4.3(@types/node@26.2.0)(sass@1.102.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))(vuetify@3.13.1)
+        version: 2.1.3(vite@6.4.3(@types/node@26.2.0)(sass@1.102.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))(vuetify@4.1.11)
       vite-plugin-web-extension:
         specifier: 4.5.1
         version: 4.5.1(@types/node@26.2.0)(sass@1.102.0)(tsx@4.23.12)
@@ -3426,12 +3426,12 @@ packages:
       typescript:
         optional: true
 
-  vuetify@3.13.1:
-    resolution: {integrity: sha512-AeHAEAvEJG8+jDhdycvtT5D3BdM+Syoe7WMuMJ5DXwf2Wcw+P7ZMdzYC23FTOCmQBqSZHchvW8W1l9g8o63qSA==}
+  vuetify@4.1.11:
+    resolution: {integrity: sha512-pMzGsjha58Lbg9n/icMXCxcQN9rTczcOdMq3wMU1Qe+cfufl28eX4VUUzLwSsDgmLjTtUGsgZIkyYZFQy+SmIw==}
     peerDependencies:
       typescript: '>=4.7'
       vite-plugin-vuetify: '>=2.1.0'
-      vue: ^3.5.0
+      vue: ^3.5.0 || ^3.6.0-0
       webpack-plugin-vuetify: '>=3.1.0'
     peerDependenciesMeta:
       typescript:
@@ -4503,11 +4503,11 @@ snapshots:
 
   '@vue/shared@3.5.41': {}
 
-  '@vuetify/loader-shared@2.1.2(vue@3.5.41(typescript@6.0.3))(vuetify@3.13.1)':
+  '@vuetify/loader-shared@2.1.2(vue@3.5.41(typescript@6.0.3))(vuetify@4.1.11)':
     dependencies:
       upath: 2.0.1
       vue: 3.5.41(typescript@6.0.3)
-      vuetify: 3.13.1(typescript@6.0.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.41(typescript@6.0.3))
+      vuetify: 4.1.11(typescript@6.0.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.41(typescript@6.0.3))
 
   '@vueuse/components@14.4.0(vue@3.5.41(typescript@6.0.3))':
     dependencies:
@@ -6662,14 +6662,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vuetify@2.1.3(vite@6.4.3(@types/node@26.2.0)(sass@1.102.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))(vuetify@3.13.1):
+  vite-plugin-vuetify@2.1.3(vite@6.4.3(@types/node@26.2.0)(sass@1.102.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))(vuetify@4.1.11):
     dependencies:
-      '@vuetify/loader-shared': 2.1.2(vue@3.5.41(typescript@6.0.3))(vuetify@3.13.1)
+      '@vuetify/loader-shared': 2.1.2(vue@3.5.41(typescript@6.0.3))(vuetify@4.1.11)
       debug: 4.4.3
       upath: 2.0.1
       vite: 6.4.3(@types/node@26.2.0)(sass@1.102.0)(tsx@4.23.12)(yaml@2.9.0)
       vue: 3.5.41(typescript@6.0.3)
-      vuetify: 3.13.1(typescript@6.0.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.41(typescript@6.0.3))
+      vuetify: 4.1.11(typescript@6.0.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.41(typescript@6.0.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -6789,12 +6789,12 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  vuetify@3.13.1(typescript@6.0.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.41(typescript@6.0.3)):
+  vuetify@4.1.11(typescript@6.0.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.41(typescript@6.0.3)):
     dependencies:
       vue: 3.5.41(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
-      vite-plugin-vuetify: 2.1.3(vite@6.4.3(@types/node@26.2.0)(sass@1.102.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))(vuetify@3.13.1)
+      vite-plugin-vuetify: 2.1.3(vite@6.4.3(@types/node@26.2.0)(sass@1.102.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))(vuetify@4.1.11)
 
   watchpack@2.4.4:
     dependencies:

--- a/src/entries/content-script/app/init.ts
+++ b/src/entries/content-script/app/init.ts
@@ -3,7 +3,7 @@
  *  Vuetify 的其他样式会被自动构造在 /pt-depiler.css 中
  */
 import appCss from "./app.css?inline";
-import vuetifyCss from "vuetify/styles?inline";
+import vuetifyCss from "../../../styles/vuetify/styles.scss?inline";
 
 import { createApp } from "vue";
 

--- a/src/entries/content-script/app/init.ts
+++ b/src/entries/content-script/app/init.ts
@@ -74,7 +74,7 @@ export function mountApp(document: Document, data: any = {}) {
     const styleContent = vuetifyTheme.textContent || "";
     const vuetifyThemeStylesheet = document.createElement("style");
     vuetifyThemeStylesheet.id = "ptd-content-script-style-vuetify-theme-stylesheet"; // 设置 id 以便于后续查找
-    vuetifyThemeStylesheet.textContent = styleContent.replace(":root", ":host");
+    vuetifyThemeStylesheet.textContent = styleContent.replaceAll(":root", ":host");
     shadowRoot.appendChild(vuetifyThemeStylesheet); // 克隆并添加 Vuetify 的主题样式到 shadow DOM 中
 
     if (hasSiteVuetifyThemePre) {

--- a/src/entries/options/components/DeleteDialog.vue
+++ b/src/entries/options/components/DeleteDialog.vue
@@ -37,7 +37,7 @@ async function dialogEnter() {
         {{ t("common.dialog.title.confirmAction") }}
       </v-card-title>
 
-      <v-card-text class="text-body-1">
+      <v-card-text class="text-body-large">
         {{ t("common.dialog.deleteText", [toDeleteIds!.length]) }}
 
         <slot name="append-text" />

--- a/src/entries/options/components/DownloaderLabel.vue
+++ b/src/entries/options/components/DownloaderLabel.vue
@@ -40,7 +40,7 @@ const downloaderIcon = computed(() => {
         </span>
         <template v-if="downloaderConfig">
           <br />
-          <a :href="downloaderConfig.address" class="text-caption" target="_blank">
+          <a :href="downloaderConfig.address" class="text-body-small" target="_blank">
             [{{ downloaderConfig.address }}]
           </a>
         </template>

--- a/src/entries/options/components/SentToDownloaderDialog/Index.vue
+++ b/src/entries/options/components/SentToDownloaderDialog/Index.vue
@@ -238,13 +238,13 @@ function dialogLeave() {
                 :placeholder="t('SentToDownloaderDialog.selectDownloader')"
                 @update:model-value="restoreAddTorrentOptions"
               >
-                <template #selection="{ item: { raw: downloader } }">
+                <template #selection="{ item: downloader }">
                   <v-list-item
                     :prepend-avatar="getDownloaderIcon(downloader.type)"
                     :title="downloaderTitle(downloader)"
                   />
                 </template>
-                <template #item="{ props, item: { raw: downloader } }">
+                <template #item="{ props, item: downloader }">
                   <v-list-item
                     v-bind="props"
                     :prepend-avatar="getDownloaderIcon(downloader.type)"

--- a/src/entries/options/components/SiteName.vue
+++ b/src/entries/options/components/SiteName.vue
@@ -20,7 +20,7 @@ const tagIs = props.tag ?? "a";
 
 const renderProp = reactive<Record<string, any>>({
   ...attrs,
-  class: props.class ?? ["text-caption", "text-decoration-none", "text-grey", "text-no-wrap"],
+  class: props.class ?? ["text-body-small", "text-decoration-none", "text-grey", "text-no-wrap"],
 });
 
 if (tagIs === "a") {

--- a/src/entries/options/components/TorrentTitleTd.vue
+++ b/src/entries/options/components/TorrentTitleTd.vue
@@ -86,19 +86,19 @@ function canAdvanceSearch(site: TSupportSocialSite) {
 </script>
 
 <template>
-  <v-container ref="container" class="t_main">
-    <v-row>
+  <v-container ref="container" class="t_main pa-0">
+    <v-row gap="0">
       <!-- 种子主标题信息 -->
       <span
         :style="{
-          width: `${containerWidth - socialWidth}px`,
+          width: `${containerWidth - socialWidth - 8}px`,
         }"
         class="text-truncate"
       >
         <a
           :href="item.url"
           :title="item.title"
-          class="t_title text-decoration-none text-high-emphasis text-subtitle-1 text-truncate"
+          class="t_title text-decoration-none text-high-emphasis text-body-large text-truncate"
           rel="noopener noreferrer nofollow"
           target="_blank"
         >
@@ -144,7 +144,7 @@ function canAdvanceSearch(site: TSupportSocialSite) {
                       >
                         {{ socialInformation[key]?.title.split(" / ")[0] }}
                       </h3>
-                      <p v-if="socialInformation[key]?.ratingScore" class="text-caption">
+                      <p v-if="socialInformation[key]?.ratingScore" class="text-body-small">
                         {{ socialInformation[key].ratingScore }}
                         <span v-if="socialInformation[key]?.ratingCount">
                           from {{ socialInformation[key].ratingCount }} votes
@@ -180,7 +180,7 @@ function canAdvanceSearch(site: TSupportSocialSite) {
                       {{ t("common.visit") }}
                     </v-btn>
                     <v-divider class="my-1" />
-                    <p class="text-caption mt-1">( {{ key }}: {{ item[`ext_${key}`] }} )</p>
+                    <p class="text-body-small mt-1">( {{ key }}: {{ item[`ext_${key}`] }} )</p>
                   </div>
                 </v-card-text>
               </v-card>
@@ -189,7 +189,10 @@ function canAdvanceSearch(site: TSupportSocialSite) {
         </template>
       </div>
     </v-row>
-    <v-row v-if="configStore.searchEntifyControl.showTorrentTag || configStore.searchEntifyControl.showTorrentSubtitle">
+    <v-row
+      gap="0"
+      v-if="configStore.searchEntifyControl.showTorrentTag || configStore.searchEntifyControl.showTorrentSubtitle"
+    >
       <!-- 种子标签信息 -->
       <div ref="tags">
         <template v-if="configStore.searchEntifyControl.showTorrentTag && item.tags && item.tags.length > 0">

--- a/src/entries/options/plugins/vuetify.ts
+++ b/src/entries/options/plugins/vuetify.ts
@@ -1,8 +1,6 @@
 import { createVuetify } from "vuetify";
 import { en, zhHans } from "vuetify/locale";
 
-import { VColorInput } from "vuetify/labs/VColorInput";
-
 import { type TLangCode } from "./i18n.ts";
 
 export const vuetifyLangMap: Record<TLangCode, string> = {
@@ -11,12 +9,13 @@ export const vuetifyLangMap: Record<TLangCode, string> = {
 };
 
 export const vuetifyInstance = createVuetify({
+  // 保持与 v3 一致：默认浅色主题（不随操作系统跟随 system 主题）
+  theme: {
+    defaultTheme: "light",
+  },
   locale: {
     locale: "zhHans",
     fallback: "en",
     messages: { zhHans, en },
-  },
-  components: {
-    VColorInput,
   },
 });

--- a/src/entries/options/style.css
+++ b/src/entries/options/style.css
@@ -1,4 +1,4 @@
-@import "vuetify";
+@import "../../styles/vuetify/styles.scss";
 
 @import "../shared/common.scss";
 @import "./main.scss";

--- a/src/entries/options/views/About/SpecialThank.vue
+++ b/src/entries/options/views/About/SpecialThank.vue
@@ -24,7 +24,7 @@ const sortedPeople = [
 </script>
 
 <template>
-  <v-alert border="start" border-color="deep-purple-accent-4" class="mb-2" elevation="2">
+  <v-alert border="start" border-color="deep-purple-accent-4" class="mb-2" elevation="1">
     <template v-for="i in tm('SpecialThank.thankNote')" :key="i"> {{ rt(i) }} <br /> </template>
     {{ t("SpecialThank.contributor") }}:
     <a :href="`${REPO_URL}/graphs/contributors`" rel="noopener noreferrer nofollow" target="_blank">

--- a/src/entries/options/views/Devtools/Debugger.vue
+++ b/src/entries/options/views/Devtools/Debugger.vue
@@ -40,7 +40,10 @@ const selectedSite = ref<TSiteID>("");
 const useCustomerConfig = ref<boolean>(true);
 
 const clearSiteTarget = ref<TSiteID>("all");
-const siteSelectItems = computed(() => [{ title: t("Debugger.siteAll"), value: "all" }, ...definitionList.map((x) => ({ title: x, value: x }))]);
+const siteSelectItems = computed(() => [
+  { title: t("Debugger.siteAll"), value: "all" },
+  ...definitionList.map((x) => ({ title: x, value: x })),
+]);
 
 const piniaStoreContent = import.meta.glob<Record<string, Function>>("@/options/stores/*.ts");
 const piniaStoreName: Array<{ title: string; value: string }> = Object.keys(piniaStoreContent).map((x) => ({
@@ -187,11 +190,11 @@ async function resetFnWrapper(resetFn: resetItem["resetFn"]) {
       <tbody>
         <tr>
           <td>
-            <div class="d-flex justify-center align-center text-body-2">{{ t("Debugger.enableLibrary") }}</div>
+            <div class="d-flex justify-center align-center text-body-medium">{{ t("Debugger.enableLibrary") }}</div>
           </td>
           <td>
             <v-container>
-              <v-row dense>
+              <v-row density="compact">
                 <v-col class="d-flex align-center">
                   <v-btn @click="enableLibrary" class="mr-3">{{ t("common.enable") }}</v-btn>
                   {{ t("Debugger.libraryList") }}
@@ -202,11 +205,11 @@ async function resetFnWrapper(resetFn: resetItem["resetFn"]) {
         </tr>
         <tr>
           <td>
-            <div class="d-flex justify-center align-center text-body-2">{{ t("Debugger.debugBuiltinSite") }}</div>
+            <div class="d-flex justify-center align-center text-body-medium">{{ t("Debugger.debugBuiltinSite") }}</div>
           </td>
           <td>
             <v-container>
-              <v-row dense>
+              <v-row density="compact">
                 <v-col cols="4">
                   <v-autocomplete v-model="selectedSite" :items="definitionList" hide-details label="site" />
                 </v-col>
@@ -214,10 +217,18 @@ async function resetFnWrapper(resetFn: resetItem["resetFn"]) {
                   <v-checkbox v-model="useCustomerConfig" hide-details :label="t('Debugger.mergeUserConfig')" />
                 </v-col>
                 <v-col class="d-flex align-center">
-                  <v-btn :disabled="!selectedSite" class="mr-2" @click="log(getSiteMetadata())"> {{ t("Debugger.outputSiteDefinition") }} </v-btn>
-                  <v-btn :disabled="!selectedSite" class="mr-2" @click="log(getSiteConfig())"> {{ t("Debugger.outputUserConfig") }} </v-btn>
-                  <v-btn :disabled="!selectedSite" class="mr-2" @click="log(getSiteInstance())"> {{ t("Debugger.outputSiteInstance") }} </v-btn>
-                  <v-btn :disabled="!selectedSite" class="mr-2" @click="log(getSiteFavicon())"> {{ t("Debugger.outputFavicon") }} </v-btn>
+                  <v-btn :disabled="!selectedSite" class="mr-2" @click="log(getSiteMetadata())">
+                    {{ t("Debugger.outputSiteDefinition") }}
+                  </v-btn>
+                  <v-btn :disabled="!selectedSite" class="mr-2" @click="log(getSiteConfig())">
+                    {{ t("Debugger.outputUserConfig") }}
+                  </v-btn>
+                  <v-btn :disabled="!selectedSite" class="mr-2" @click="log(getSiteInstance())">
+                    {{ t("Debugger.outputSiteInstance") }}
+                  </v-btn>
+                  <v-btn :disabled="!selectedSite" class="mr-2" @click="log(getSiteFavicon())">
+                    {{ t("Debugger.outputFavicon") }}
+                  </v-btn>
                 </v-col>
               </v-row>
             </v-container>
@@ -225,11 +236,13 @@ async function resetFnWrapper(resetFn: resetItem["resetFn"]) {
         </tr>
         <tr v-for="(server, serverType) in simpleServer" :key="serverType">
           <td>
-            <div class="d-flex justify-center align-center text-body-2">{{ t("Debugger.debug", { serverType }) }}</div>
+            <div class="d-flex justify-center align-center text-body-medium">
+              {{ t("Debugger.debug", { serverType }) }}
+            </div>
           </td>
           <td>
             <v-container>
-              <v-row dense>
+              <v-row density="compact">
                 <v-col cols="4">
                   <v-autocomplete
                     v-model="simpleServer[serverType].selected"
@@ -268,11 +281,11 @@ async function resetFnWrapper(resetFn: resetItem["resetFn"]) {
         </tr>
         <tr>
           <td>
-            <div class="d-flex justify-center align-center text-body-2">{{ t("Debugger.debugPinia") }}</div>
+            <div class="d-flex justify-center align-center text-body-medium">{{ t("Debugger.debugPinia") }}</div>
           </td>
           <td>
             <v-container>
-              <v-row dense>
+              <v-row density="compact">
                 <v-col cols="4">
                   <v-autocomplete
                     v-model="selectedPiniaStore"
@@ -292,7 +305,7 @@ async function resetFnWrapper(resetFn: resetItem["resetFn"]) {
         </tr>
         <tr>
           <td>
-            <div class="d-flex justify-center align-center text-body-2">{{ t("Debugger.pluginReset") }}</div>
+            <div class="d-flex justify-center align-center text-body-medium">{{ t("Debugger.pluginReset") }}</div>
           </td>
           <td>
             <v-container>
@@ -312,7 +325,9 @@ async function resetFnWrapper(resetFn: resetItem["resetFn"]) {
                     >
                       <template v-slot:prepend>
                         <v-list-item-action class="mr-2">
-                          <v-btn color="red" @click="() => resetFnWrapper(item.resetFn)">{{ t("common.dialog.reset") }}</v-btn>
+                          <v-btn color="red" @click="() => resetFnWrapper(item.resetFn)">{{
+                            t("common.dialog.reset")
+                          }}</v-btn>
                         </v-list-item-action>
                       </template>
                       <template v-slot:append>

--- a/src/entries/options/views/Layout/Navigation.vue
+++ b/src/entries/options/views/Layout/Navigation.vue
@@ -72,8 +72,8 @@ function clickMenuItem() {
 
     <!-- 页脚，用于展示版本信息 -->
     <template v-slot:append>
-      <v-footer>
-        <v-row justify="center">
+      <v-footer class="pa-0">
+        <v-row gap="0" class="justify-center">
           <span class="pa-2 text-grey-darken-1">
             &copy; {{ year }},
             <a :href="`${REPO_URL}${git.long ? `/commit/${git.long}` : ''}`" target="_blank">{{ ext_version }}</a>

--- a/src/entries/options/views/Layout/RecommendationMenu.vue
+++ b/src/entries/options/views/Layout/RecommendationMenu.vue
@@ -178,11 +178,7 @@ watch(isRecommendationMenuOpen, (isOpen) => {
 </script>
 
 <template>
-  <v-menu
-    v-model="isRecommendationMenuOpen"
-    :close-on-content-click="false"
-    location="bottom end"
-  >
+  <v-menu v-model="isRecommendationMenuOpen" :close-on-content-click="false" location="bottom end">
     <template #activator="{ props }">
       <v-btn
         v-bind="props"
@@ -196,7 +192,7 @@ watch(isRecommendationMenuOpen, (isOpen) => {
     <v-card min-width="1120" max-width="1280">
       <v-card-title class="d-flex align-center py-2">
         <v-icon icon="mdi-fire" class="mr-2" />
-        <span class="text-subtitle-1">{{ t("layout.header.hotRecommendations.title") }}</span>
+        <span class="text-body-large">{{ t("layout.header.hotRecommendations.title") }}</span>
         <v-spacer />
         <v-btn
           :loading="isLoadingRecommendations"
@@ -226,15 +222,15 @@ watch(isRecommendationMenuOpen, (isOpen) => {
       </v-card-text>
 
       <v-card-text v-else class="pa-3">
-        <v-row dense>
+        <v-row density="compact">
           <v-col v-for="group in groupedRecommendationItems" :key="group.category" cols="12" sm="6" lg="3">
-            <div class="text-subtitle-2 mb-2">
+            <div class="text-label-large mb-2">
               {{ t(`layout.header.hotRecommendations.category.${group.category}`) }}
             </div>
 
             <v-list density="compact" class="hot-recommendation-list pa-0 rounded border">
               <v-list-item v-if="group.items.length === 0" class="hot-recommendation-empty-item px-2">
-                <v-list-item-title class="text-body-2 text-medium-emphasis">
+                <v-list-item-title class="text-body-medium text-medium-emphasis">
                   {{ t("layout.header.hotRecommendations.empty") }}
                 </v-list-item-title>
               </v-list-item>
@@ -258,7 +254,7 @@ watch(isRecommendationMenuOpen, (isOpen) => {
                   </v-img>
                 </template>
 
-                <v-list-item-title class="hot-recommendation-title-row text-body-2">
+                <v-list-item-title class="hot-recommendation-title-row text-body-medium">
                   <span class="hot-recommendation-title text-truncate">{{ item.title }}</span>
                   <span class="hot-recommendation-rating">
                     <v-icon icon="mdi-star" color="amber-darken-2" size="x-small" class="mr-1" />

--- a/src/entries/options/views/Layout/ReleaseNoteDialog.vue
+++ b/src/entries/options/views/Layout/ReleaseNoteDialog.vue
@@ -60,13 +60,15 @@ function dialogLeave() {
               <v-img inline src="/icons/logo/128.png" width="128"></v-img>
               <br />
               <div class="d-inline-flex">
-                <span class="text-body-1 text--secondary">{{ currentVersion.fullVersion }}{{ t("layout.releaseNote.currentVersion") }}</span>&nbsp;
+                <span class="text-body-large text--secondary"
+                  >{{ currentVersion.fullVersion }}{{ t("layout.releaseNote.currentVersion") }}</span
+                >&nbsp;
               </div>
             </v-col>
           </v-row>
           <v-row>
             <v-col>
-              <div class="text-body-1">
+              <div class="text-body-large">
                 <a :href="`${REPO_URL}/compare/${storeBuildHash}...${currentVersion.buildHash}`" target="_blank">
                   {{ t("layout.releaseNote.changelog") }}
                 </a>
@@ -81,7 +83,9 @@ function dialogLeave() {
       </v-card-text>
 
       <v-card-actions>
-        <v-btn block variant="elevated" color="green" @click="showDialog = false">{{ t("layout.releaseNote.startUsing") }}</v-btn>
+        <v-btn block variant="elevated" color="green" @click="showDialog = false">{{
+          t("layout.releaseNote.startUsing")
+        }}</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>

--- a/src/entries/options/views/Overview/DownloadHistory/AdvanceFilterGenerateDialog.vue
+++ b/src/entries/options/views/Overview/DownloadHistory/AdvanceFilterGenerateDialog.vue
@@ -46,15 +46,17 @@ function enterDialog() {
       </v-card-title>
       <v-divider />
       <v-card-text class="overflow-y-auto">
-        <v-container>
-          <v-row><v-label>{{ t("common.AdvanceFilterGenerateDialog.keywords") }}</v-label> </v-row>
-          <v-row>
+        <v-container class="pa-0">
+          <v-row gap="0"
+            ><v-label>{{ t("common.AdvanceFilterGenerateDialog.keywords") }}</v-label>
+          </v-row>
+          <v-row class="mt-0">
             <v-col>
               <v-combobox
                 v-model="advanceFilterDictRef.text.required"
                 chips
                 hide-details
-              :label="t('common.AdvanceFilterGenerateDialog.required')"
+                :label="t('common.AdvanceFilterGenerateDialog.required')"
                 multiple
               ></v-combobox>
             </v-col>
@@ -63,13 +65,15 @@ function enterDialog() {
                 v-model="advanceFilterDictRef.text.exclude"
                 chips
                 hide-details
-              :label="t('common.AdvanceFilterGenerateDialog.exclude')"
+                :label="t('common.AdvanceFilterGenerateDialog.exclude')"
                 multiple
               ></v-combobox>
             </v-col>
           </v-row>
-          <v-row><v-label>{{ t("common.AdvanceFilterGenerateDialog.site") }}</v-label></v-row>
-          <v-row>
+          <v-row gap="0"
+            ><v-label>{{ t("common.AdvanceFilterGenerateDialog.site") }}</v-label></v-row
+          >
+          <v-row gap="0">
             <v-col
               v-for="site in advanceItemPropsRef.siteId"
               :key="`${reBuildFilterCountRef}_${site}`"
@@ -93,8 +97,10 @@ function enterDialog() {
               </v-checkbox>
             </v-col>
           </v-row>
-          <v-row><v-label>{{ t("DownloadHistory.AdvanceFilterGenerateDialog.downloader") }}</v-label></v-row>
-          <v-row>
+          <v-row gap="0"
+            ><v-label>{{ t("DownloadHistory.AdvanceFilterGenerateDialog.downloader") }}</v-label></v-row
+          >
+          <v-row gap="0">
             <v-col
               v-for="downloader in advanceItemPropsRef.downloaderId"
               :key="`${reBuildFilterCountRef}_${downloader}`"
@@ -117,9 +123,9 @@ function enterDialog() {
             </v-col>
           </v-row>
           <!-- TODO 下载状态 -->
-          <v-row>
+          <v-row gap="0">
             <v-col cols="12">
-              <v-row class="pr-4">
+              <v-row gap="0" class="pr-4">
                 <v-label>{{ t("common.AdvanceFilterGenerateDialog.date") }}</v-label>
                 <v-spacer />
                 <v-chip
@@ -151,7 +157,7 @@ function enterDialog() {
                   </v-menu>
                 </v-chip>
               </v-row>
-              <v-row>
+              <v-row gap="0">
                 <v-range-slider
                   v-model="advanceFilterDictRef.downloadAt"
                   :max="advanceItemPropsRef.downloadAt.range[1]"
@@ -176,10 +182,14 @@ function enterDialog() {
       </v-card-text>
       <v-divider />
       <v-card-actions>
-        <v-btn variant="text" @click="() => reBuildAdvanceFilter(true)">{{ t("common.AdvanceFilterGenerateDialog.reset") }}</v-btn>
+        <v-btn variant="text" @click="() => reBuildAdvanceFilter(true)">{{
+          t("common.AdvanceFilterGenerateDialog.reset")
+        }}</v-btn>
         <v-spacer />
         <v-btn color="error" variant="text" @click="showDialog = false">{{ t("common.dialog.cancel") }}</v-btn>
-        <v-btn color="primary" variant="text" @click="updateTableFilter">{{ t("common.AdvanceFilterGenerateDialog.generate") }}</v-btn>
+        <v-btn color="primary" variant="text" @click="updateTableFilter">{{
+          t("common.AdvanceFilterGenerateDialog.generate")
+        }}</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>

--- a/src/entries/options/views/Overview/DownloadHistory/Index.vue
+++ b/src/entries/options/views/Overview/DownloadHistory/Index.vue
@@ -101,7 +101,7 @@ onUnmounted(() => {
   <v-alert :title="t('route.Overview.DownloadHistory')" type="info" />
   <v-card>
     <v-card-title>
-      <v-row class="ma-0">
+      <v-row gap="0" class="ma-0">
         <!-- 按钮组 -->
         <NavButton
           color="green"
@@ -233,17 +233,11 @@ onUnmounted(() => {
   <v-dialog v-model="showDownloadDetailDialog" width="800">
     <v-card>
       <v-card-text>
-        <v-alert
-          v-if="downloadDetail.errorMessage"
-          class="mb-3"
-          color="error"
-          icon="mdi-alert"
-          variant="tonal"
-        >
-          <div class="text-subtitle-2 font-weight-bold mb-1">
+        <v-alert v-if="downloadDetail.errorMessage" class="mb-3" color="error" icon="mdi-alert" variant="tonal">
+          <div class="text-label-large font-weight-bold mb-1">
             {{ t("DownloadHistory.detail.errorMessage") }}
           </div>
-          <code class="text-body-2">{{ downloadDetail.errorMessage }}</code>
+          <code class="text-body-medium">{{ downloadDetail.errorMessage }}</code>
         </v-alert>
         <pre> {{ JSON.stringify(downloadDetail, null, 2) }}</pre>
       </v-card-text>

--- a/src/entries/options/views/Overview/KeepUploadTask/Index.vue
+++ b/src/entries/options/views/Overview/KeepUploadTask/Index.vue
@@ -256,16 +256,16 @@ async function copyLinksToClipboard(task: IKeepUploadTask) {
           <a
             :href="item.items[0]?.link"
             target="_blank"
-            class="text-decoration-none text-high-emphasis text-subtitle-1 text-truncate"
+            class="text-decoration-none text-high-emphasis text-body-large text-truncate"
             rel="noopener noreferrer nofollow"
           >
             {{ item.title }}
           </a>
-          <div class="text-caption text-grey">
+          <div class="text-body-small text-grey">
             {{ t("KeepUploadTask.savePath") }}{{ item.downloadOptions?.clientName }} ->
             {{ item.downloadOptions?.savePath || t("KeepUploadTask.defaultPath") }}
           </div>
-          <div class="text-caption">{{ t("KeepUploadTask.torrentCount") }}{{ item.items.length }}</div>
+          <div class="text-body-small">{{ t("KeepUploadTask.torrentCount") }}{{ item.items.length }}</div>
         </div>
       </template>
 

--- a/src/entries/options/views/Overview/MediaServerEntity/Index.vue
+++ b/src/entries/options/views/Overview/MediaServerEntity/Index.vue
@@ -215,7 +215,7 @@ onMounted(async () => {
       </div>
     </div>
     <v-row v-else>
-      <v-col class="d-flex justify-center text-body-1">{{ t("MediaServerEntity.noItems") }}</v-col>
+      <v-col class="d-flex justify-center text-body-large">{{ t("MediaServerEntity.noItems") }}</v-col>
     </v-row>
 
     <!-- TODO 点击加载更多 -->

--- a/src/entries/options/views/Overview/MediaServerEntity/ItemInformationDialog.vue
+++ b/src/entries/options/views/Overview/MediaServerEntity/ItemInformationDialog.vue
@@ -70,7 +70,7 @@ function secondsToISO8601(seconds: number) {
       <v-divider />
 
       <v-card-text>
-        <v-row align="center">
+        <v-row class="align-center">
           <v-col cols="8" offset="2" offset-sm="0" sm="4">
             <v-img :src="item.poster" :title="item.name" />
           </v-col>
@@ -78,13 +78,13 @@ function secondsToISO8601(seconds: number) {
             <a
               :href="item.url"
               :title="item.name"
-              class="w-100 text-h6 d-inline-block"
+              class="w-100 text-headline-small d-inline-block"
               rel="noopener noreferrer nofollow"
               target="_blank"
             >
               {{ item.name }}
             </a>
-            <p class="text-caption">{{ item.description ?? "" }}</p>
+            <p class="text-body-small">{{ item.description ?? "" }}</p>
             <div v-if="item.tags && item.tags.length > 0" class="info-label">
               <v-label class="pr-3">{{ t("MediaServerEntity.ItemInformationDialog.type") }}</v-label>
               <v-chip-group show-arrows>
@@ -170,7 +170,7 @@ function secondsToISO8601(seconds: number) {
                 rel="noopener noreferrer nofollow"
                 target="_blank"
               >
-                {{ t('common.visit') }}
+                {{ t("common.visit") }}
               </v-btn>
             </div>
           </v-col>

--- a/src/entries/options/views/Overview/MyClient/ClientStatusDialog.vue
+++ b/src/entries/options/views/Overview/MyClient/ClientStatusDialog.vue
@@ -104,7 +104,7 @@ function onEnter() {
 
             <v-list-item-title class="font-weight-bold">
               {{ d.name }}
-              <span v-if="clientVersions[d.id]" class="ml-2 text-caption text-grey">
+              <span v-if="clientVersions[d.id]" class="ml-2 text-body-small text-grey">
                 {{ clientVersions[d.id] }}
               </span>
               <v-icon
@@ -122,7 +122,7 @@ function onEnter() {
             <v-list-item-subtitle>
               <a
                 :href="d.address"
-                class="text-primary text-decoration-underline text-caption"
+                class="text-primary text-decoration-underline text-body-small"
                 rel="noopener noreferrer nofollow"
                 target="_blank"
                 @click.stop
@@ -134,7 +134,7 @@ function onEnter() {
             <template #append>
               <v-progress-circular v-if="clientLoading[d.id]" indeterminate size="20" width="2" class="mr-4" />
               <template v-else>
-                <div class="text-end text-caption mr-2">
+                <div class="text-end text-body-small mr-2">
                   <div class="d-flex align-center justify-end ga-1">
                     <v-icon color="green-darken-4" icon="mdi-chevron-up" size="small" />
                     <span class="text-no-wrap">

--- a/src/entries/options/views/Overview/MyClient/Index.vue
+++ b/src/entries/options/views/Overview/MyClient/Index.vue
@@ -325,7 +325,7 @@ function torrentKey(torrent: CTorrent) {
 
   <v-card>
     <v-card-title>
-      <v-row class="ma-0" align="center">
+      <v-row gap="0" class="align-center ma-0">
         <v-btn
           :title="t('MyClient.pushToDownloader.navBtn')"
           color="primary"
@@ -496,7 +496,7 @@ function torrentKey(torrent: CTorrent) {
         <template #item.clientId="{ item }">
           <div class="d-flex flex-column align-center">
             <v-avatar :image="clientIcon(item.clientId)" size="22" />
-            <span class="text-caption text-no-wrap mt-1">{{ clientName(item.clientId) }}</span>
+            <span class="text-body-small text-no-wrap mt-1">{{ clientName(item.clientId) }}</span>
           </div>
         </template>
 
@@ -504,7 +504,7 @@ function torrentKey(torrent: CTorrent) {
         <template #item.name="{ item }">
           <div>
             <span class="font-weight-medium">{{ item.name }}</span>
-            <div v-if="item.label" class="text-caption text-grey">
+            <div v-if="item.label" class="text-body-small text-grey">
               <v-icon size="x-small" icon="mdi-label-outline" /> {{ item.label }}
             </div>
           </div>
@@ -523,7 +523,7 @@ function torrentKey(torrent: CTorrent) {
             :width="3"
             :color="item.isCompleted ? 'green' : 'blue'"
           >
-            <span class="text-caption">{{ item.progress.toFixed(0) }}%</span>
+            <span class="text-body-small">{{ item.progress.toFixed(0) }}%</span>
           </v-progress-circular>
         </template>
 
@@ -567,12 +567,12 @@ function torrentKey(torrent: CTorrent) {
 
         <!-- save path -->
         <template #item.savePath="{ item }">
-          <span class="text-caption text-no-wrap">{{ item.savePath }}</span>
+          <span class="text-body-small text-no-wrap">{{ item.savePath }}</span>
         </template>
 
         <!-- date added -->
         <template #item.dateAdded="{ item }">
-          <span class="text-no-wrap text-caption">{{ formatDate(item.dateAdded * 1000) }}</span>
+          <span class="text-no-wrap text-body-small">{{ formatDate(item.dateAdded * 1000) }}</span>
         </template>
 
         <!-- actions -->

--- a/src/entries/options/views/Overview/MyClient/RecheckConfirmDialog.vue
+++ b/src/entries/options/views/Overview/MyClient/RecheckConfirmDialog.vue
@@ -34,7 +34,7 @@ function dialogEnter() {
         {{ t("MyClient.recheckDialog.title") }}
       </v-card-title>
 
-      <v-card-text class="text-body-1">
+      <v-card-text class="text-body-large">
         {{ t("MyClient.recheckDialog.text", { count: torrentCount }) }}
       </v-card-text>
 

--- a/src/entries/options/views/Overview/MyClient/TorrentDetailDialog.vue
+++ b/src/entries/options/views/Overview/MyClient/TorrentDetailDialog.vue
@@ -88,7 +88,7 @@ function formatTotal(total: number | undefined): string {
               <v-icon icon="mdi-key-variant" />
             </template>
             <v-list-item-title class="d-flex align-center ga-2">
-              <code class="text-caption">{{ torrent.infoHash }}</code>
+              <code class="text-body-small">{{ torrent.infoHash }}</code>
               <v-btn
                 :title="t('MyClient.detail.copyHash')"
                 icon="mdi-content-copy"
@@ -140,7 +140,7 @@ function formatTotal(total: number | undefined): string {
                 </template>
                 <v-list-item-title>
                   {{ formatSpeed(torrent.uploadSpeed) }}
-                  <span class="text-grey text-caption ml-1">({{ formatTotal(torrent.totalUploaded) }})</span>
+                  <span class="text-grey text-body-small ml-1">({{ formatTotal(torrent.totalUploaded) }})</span>
                 </v-list-item-title>
               </v-list-item>
               <v-list-item>
@@ -149,7 +149,7 @@ function formatTotal(total: number | undefined): string {
                 </template>
                 <v-list-item-title>
                   {{ formatSpeed(torrent.downloadSpeed) }}
-                  <span class="text-grey text-caption ml-1">({{ formatTotal(torrent.totalDownloaded) }})</span>
+                  <span class="text-grey text-body-small ml-1">({{ formatTotal(torrent.totalDownloaded) }})</span>
                 </v-list-item-title>
               </v-list-item>
               <v-list-item>
@@ -171,7 +171,7 @@ function formatTotal(total: number | undefined): string {
             <template #prepend>
               <v-icon icon="mdi-folder" />
             </template>
-            <v-list-item-title class="text-caption">{{ torrent.savePath }}</v-list-item-title>
+            <v-list-item-title class="text-body-small">{{ torrent.savePath }}</v-list-item-title>
           </v-list-item>
           <v-list-item>
             <template #prepend>
@@ -205,7 +205,7 @@ function formatTotal(total: number | undefined): string {
                   <template #prepend>
                     <v-icon icon="mdi-radar" />
                   </template>
-                  <v-list-item-title class="text-caption">{{ tracker }}</v-list-item-title>
+                  <v-list-item-title class="text-body-small">{{ tracker }}</v-list-item-title>
                 </v-list-item>
               </v-list>
               <v-alert v-else type="info" variant="tonal" density="compact">
@@ -218,7 +218,7 @@ function formatTotal(total: number | undefined): string {
           <v-expansion-panel>
             <v-expansion-panel-title>{{ t("MyClient.action.viewRaw") }}</v-expansion-panel-title>
             <v-expansion-panel-text>
-              <pre class="text-body-2">{{ JSON.stringify(torrent, null, 2) }}</pre>
+              <pre class="text-body-medium">{{ JSON.stringify(torrent, null, 2) }}</pre>
             </v-expansion-panel-text>
           </v-expansion-panel>
         </v-expansion-panels>

--- a/src/entries/options/views/Overview/MyData/ExportUserInfoDialog.vue
+++ b/src/entries/options/views/Overview/MyData/ExportUserInfoDialog.vue
@@ -202,7 +202,7 @@ function convertToJSON(items: IHistoryUserInfo[]): string {
       <v-card-text class="pt-4">
         <v-row>
           <v-col cols="12">
-            <v-label class="text-body-2 font-weight-bold mb-2 d-block">
+            <v-label class="text-body-medium font-weight-bold mb-2 d-block">
               {{ t("MyData.exportDialog.formatLabel") }}
             </v-label>
             <v-btn-toggle v-model="exportFormat" color="orange-darken-3" density="compact" mandatory variant="outlined">
@@ -220,11 +220,11 @@ function convertToJSON(items: IHistoryUserInfo[]): string {
 
         <v-row>
           <v-col cols="12">
-            <v-label class="text-body-2 font-weight-bold mb-2 d-block">
+            <v-label class="text-body-medium font-weight-bold mb-2 d-block">
               {{ t("MyData.exportDialog.fieldsLabel") }}
             </v-label>
             <v-card variant="outlined" class="pa-2">
-              <v-row dense>
+              <v-row density="compact">
                 <v-col v-for="field in allExportFields" :key="field.key" cols="6" md="4">
                   <v-checkbox
                     :model-value="selectedKeys.includes(field.key)"

--- a/src/entries/options/views/Overview/MyData/HistoryDataViewDialog.vue
+++ b/src/entries/options/views/Overview/MyData/HistoryDataViewDialog.vue
@@ -125,13 +125,13 @@ function afterEnter() {
           <!-- 上传、下载 -->
           <template #item.uploaded="{ item }">
             <v-container>
-              <v-row class="flex-nowrap" justify="end">
+              <v-row class="justify-end flex-nowrap">
                 <span class="text-no-wrap">
                   {{ typeof item.uploaded !== "undefined" ? formatSize(item.uploaded) : "-" }}
                 </span>
                 <v-icon color="green-darken-4" icon="mdi-chevron-up" small></v-icon>
               </v-row>
-              <v-row class="flex-nowrap" justify="end">
+              <v-row class="justify-end flex-nowrap">
                 <span class="text-no-wrap">
                   {{ typeof item.downloaded !== "undefined" ? formatSize(item.downloaded) : "-" }}
                 </span>
@@ -165,10 +165,10 @@ function afterEnter() {
           <!-- 魔力/积分 -->
           <template #item.bonus="{ item }">
             <v-container>
-              <v-row justify="end" align="center">
+              <v-row class="align-center justify-end">
                 <span class="text-no-wrap">{{ item.bonus ? formatNumber(item.bonus) : "-" }}</span>
               </v-row>
-              <v-row justify="end" align="center">
+              <v-row class="align-center justify-end">
                 <span class="text-no-wrap">{{ item.seedingBonus ? formatNumber(item.seedingBonus) : "-" }}</span>
               </v-row>
             </v-container>

--- a/src/entries/options/views/Overview/MyData/Index.vue
+++ b/src/entries/options/views/Overview/MyData/Index.vue
@@ -177,7 +177,7 @@ const showExportDialog = ref(false);
   <v-alert :title="t('route.Overview.MyData')" type="info" />
   <v-card>
     <v-card-title>
-      <v-row class="ma-0">
+      <v-row gap="0" class="ma-0">
         <!-- 刷新，取消刷新 -->
         <NavButton
           v-if="runtimeStore.isUserInfoFlush"
@@ -235,7 +235,7 @@ const showExportDialog = ref(false);
               <template v-slot:prepend>
                 <v-list-item-action start class="ml-2">
                   <v-icon icon="mdi-calendar-account" class="mr-2" />
-                  <span class="text-subtitle-2">{{ t("MyData.index.joinTimeFormat") }}</span>
+                  <span class="text-label-large">{{ t("MyData.index.joinTimeFormat") }}</span>
                 </v-list-item-action>
               </template>
 
@@ -442,14 +442,14 @@ const showExportDialog = ref(false);
 
       <!-- 上传、下载 -->
       <template #item.uploaded="{ item }">
-        <v-container>
-          <v-row class="flex-nowrap" justify="end">
+        <v-container class="py-0 pr-0">
+          <v-row gap="0" class="justify-end flex-nowrap">
             <span class="text-no-wrap">
               {{ typeof item.uploaded !== "undefined" ? formatSize(item.uploaded) : "-" }}
             </span>
             <v-icon color="green-darken-4" icon="mdi-chevron-up" size="small"></v-icon>
           </v-row>
-          <v-row class="flex-nowrap" justify="end">
+          <v-row gap="0" class="justify-end flex-nowrap">
             <span class="text-no-wrap">
               {{ typeof item.downloaded !== "undefined" ? formatSize(item.downloaded) : "-" }}
             </span>
@@ -460,14 +460,14 @@ const showExportDialog = ref(false);
 
       <!-- 真实上传、下载 -->
       <template #item.trueUploaded="{ item }">
-        <v-container>
-          <v-row class="flex-nowrap" justify="end">
+        <v-container class="py-0 pr-0">
+          <v-row gap="0" class="justify-end flex-nowrap">
             <span class="text-no-wrap">
               {{ typeof item.trueUploaded !== "undefined" ? formatSize(item.trueUploaded) : "-" }}
             </span>
             <v-icon color="green-darken-4" icon="mdi-chevron-up" size="small"></v-icon>
           </v-row>
-          <v-row class="flex-nowrap" justify="end">
+          <v-row gap="0" class="justify-end flex-nowrap">
             <span class="text-no-wrap">
               {{ typeof item.trueDownloaded !== "undefined" ? formatSize(item.trueDownloaded) : "-" }}
             </span>
@@ -493,11 +493,15 @@ const showExportDialog = ref(false);
 
       <!-- 做种数， H&R 情况  -->
       <template #item.seeding="{ item }">
-        <v-container class="py-0">
-          <v-row align="center" class="flex-nowrap my-0" justify="end">
+        <v-container class="py-0 pr-0">
+          <v-row gap="0" class="align-center justify-end flex-nowrap my-0">
             <span class="text-no-wrap">{{ item.seeding ?? "-" }}</span>
           </v-row>
-          <v-row v-if="configStore.myDataTableControl.showHnR" align="center" class="flex-nowrap my-0" justify="end">
+          <v-row
+            gap="0"
+            v-if="configStore.myDataTableControl.showHnR"
+            class="align-center justify-end flex-nowrap my-0"
+          >
             <span
               v-if="typeof item.hnrPreWarning !== 'undefined' && item.hnrPreWarning > 0"
               class="d-inline-flex align-center ml-2"
@@ -539,12 +543,13 @@ const showExportDialog = ref(false);
 
       <!-- 魔力/积分 -->
       <template #item.bonus="{ item }">
-        <v-container>
-          <v-row align="center" class="flex-nowrap" justify="end">
+        <v-container class="py-0 pr-0">
+          <v-row gap="0" class="align-center justify-end flex-nowrap">
             <v-icon :title="t('levelRequirement.bonus')" color="green-darken-4" icon="mdi-currency-usd" size="small" />
             <BonusFormatSpan :num="item.bonus" />
           </v-row>
           <v-row
+            gap="0"
             v-if="
               configStore.myDataTableControl.showSeedingBonus &&
               item.seedingBonus !== '' &&

--- a/src/entries/options/views/Overview/MyData/UserDataStatistic/Index.vue
+++ b/src/entries/options/views/Overview/MyData/UserDataStatistic/Index.vue
@@ -4,6 +4,7 @@ import { useI18n } from "vue-i18n";
 import { useRoute, useRouter } from "vue-router";
 import { useElementSize } from "@vueuse/core";
 import { computed, onMounted, ref, shallowRef, provide, useTemplateRef } from "vue";
+import { eachDayOfInterval } from "date-fns";
 import { flatten, mapValues, pick, uniq } from "es-toolkit";
 import VChart, { THEME_KEY } from "vue-echarts";
 import { isNumber } from "es-toolkit/compat";
@@ -428,7 +429,7 @@ function saveControl() {
 
 <template>
   <v-card>
-    <v-row class="pa-2" justify="start">
+    <v-row class="justify-start pa-2">
       <v-col ref="chartContainer" id="chartContainer" style="max-width: 800px">
         <!-- 总上传、总下载、总积分 -->
         <v-chart
@@ -477,7 +478,7 @@ function saveControl() {
         </template>
       </v-col>
       <v-col>
-        <v-row class="flex-nowrap mb-0">
+        <v-row class="flex-nowrap mb-1">
           <v-col class="d-flex">
             <NavButton color="grey" icon="mdi-arrow-left" :text="t('common.back')" @click="() => router.back()" />
             <v-spacer />
@@ -494,7 +495,7 @@ function saveControl() {
         <v-alert :title="t('UserDataStatistic.chart.chartStyleSettings')" type="info" class="mb-2"> </v-alert>
 
         <v-row>
-          <v-col align-self="center">
+          <v-col class="align-self-center">
             <v-label>{{ t("common.username") }}</v-label>
           </v-col>
           <v-col cols="12" sm="10">
@@ -519,11 +520,11 @@ function saveControl() {
         </v-row>
 
         <v-row>
-          <v-col align-self="center">
+          <v-col class="align-self-center">
             <v-label>{{ t("UserDataStatistic.chart.displayChart") }}</v-label>
           </v-col>
           <v-col cols="12" sm="10">
-            <v-row>
+            <v-row gap="0">
               <v-col
                 v-for="(item, index) in configStore.userStatisticControl.showChart"
                 class="py-0"
@@ -542,7 +543,7 @@ function saveControl() {
         </v-row>
 
         <v-row>
-          <v-col align-self="center">
+          <v-col class="align-self-center">
             <v-label>{{ t("UserDataStatistic.chart.dateRange") }}</v-label>
           </v-col>
           <v-col cols="12" sm="10">
@@ -573,7 +574,10 @@ function saveControl() {
                     show-adjacent-months
                     @update:model-value="
                       (v: unknown) => {
-                        selectedDateRanges = (v as Date[]).map((x) => formatDate(x, 'yyyy-MM-dd')) as string[];
+                        const [start, end] = v as Date[];
+                        selectedDateRanges = eachDayOfInterval({ start, end }).map((x) =>
+                          formatDate(x, 'yyyy-MM-dd'),
+                        ) as string[];
                         configStore.userStatisticControl.dateRange = 'custom';
                       }
                     "
@@ -588,7 +592,7 @@ function saveControl() {
         </v-row>
 
         <v-row>
-          <v-col align-self="center">
+          <v-col class="align-self-center">
             <v-label>{{ t("UserDataStatistic.chart.chartSettings") }}</v-label>
           </v-col>
           <v-col cols="12" sm="10">
@@ -613,7 +617,7 @@ function saveControl() {
           </template>
         </v-alert>
 
-        <v-row class="my-2">
+        <v-row gap="0" class="my-2">
           <v-col v-for="siteId in allSites" :key="siteId" class="py-0" cols="6" sm="3">
             <v-checkbox
               v-model="selectedSites"

--- a/src/entries/options/views/Overview/MyData/UserDataTimeline/Index.vue
+++ b/src/entries/options/views/Overview/MyData/UserDataTimeline/Index.vue
@@ -232,7 +232,7 @@ function saveControl() {
 
 <template>
   <v-card>
-    <v-row class="pa-2" justify="start">
+    <v-row class="justify-start pa-2">
       <v-col
         ref="canvasContainer"
         :style="{
@@ -524,7 +524,7 @@ function saveControl() {
         </vk-stage>
       </v-col>
       <v-col cols="12" sm>
-        <v-row class="flex-nowrap mb-0">
+        <v-row class="flex-nowrap mb-1">
           <v-col class="d-flex">
             <NavButton color="grey" icon="mdi-arrow-left" :text="t('common.back')" @click="() => router.back()" />
             <v-spacer />
@@ -640,12 +640,12 @@ function saveControl() {
         </v-row>
 
         <v-row>
-          <v-col class="ml-2" align-self="center">
+          <v-col class="align-self-center ml-2">
             <v-label>{{ t("UserDataTimeline.controls.displayContent") }}</v-label>
           </v-col>
           <v-col cols="12" sm="10">
             <v-label class="my-2">{{ t("UserDataTimeline.controls.statsSection") }}</v-label>
-            <v-row class="pl-5">
+            <v-row gap="0" class="pl-5">
               <v-col v-for="(v, key) in control.showField" class="pa-0" cols="6" sm="4" :key="key">
                 <v-switch
                   v-model="control.showField[key]"
@@ -657,7 +657,7 @@ function saveControl() {
               </v-col>
             </v-row>
             <v-label class="my-2">{{ t("UserDataTimeline.controls.timelineSection") }}</v-label>
-            <v-row class="pl-5">
+            <v-row gap="0" class="pl-5">
               <v-col v-for="(v, key) in control.showPerSiteField" :key="key" class="pa-0" cols="6" sm="4">
                 <v-switch
                   :key="key"
@@ -673,7 +673,7 @@ function saveControl() {
         </v-row>
 
         <v-row>
-          <v-col class="ml-2" align-self="center">
+          <v-col class="align-self-center ml-2">
             <v-label>{{ t("UserDataTimeline.controls.timeDisplay") }}</v-label>
           </v-col>
           <v-col cols="12" sm="10">
@@ -695,7 +695,7 @@ function saveControl() {
           </template>
         </v-alert>
 
-        <v-row class="my-2">
+        <v-row gap="0" class="my-2">
           <v-col v-for="(site, siteId) in fixedLastUserInfo" :key="siteId" class="py-0" cols="6" sm="3">
             <v-checkbox
               v-model="selectedSites"

--- a/src/entries/options/views/Overview/SearchEntity/AdvanceFilterGenerateDialog.vue
+++ b/src/entries/options/views/Overview/SearchEntity/AdvanceFilterGenerateDialog.vue
@@ -73,11 +73,11 @@ function enterDialog() {
       </v-card-title>
       <v-divider />
       <v-card-text>
-        <v-container>
-          <v-row
-            ><v-label>{{ t("common.AdvanceFilterGenerateDialog.keywords") }}</v-label>
+        <v-container class="pa-0">
+          <v-row gap="0">
+            <v-label>{{ t("common.AdvanceFilterGenerateDialog.keywords") }}</v-label>
           </v-row>
-          <v-row>
+          <v-row class="mt-0">
             <v-col cols="12" md="6">
               <v-combobox
                 v-model="advanceFilterDictRef.text.required"
@@ -98,10 +98,10 @@ function enterDialog() {
             </v-col>
           </v-row>
 
-          <v-row
+          <v-row gap="0"
             ><v-label>{{ t("common.AdvanceFilterGenerateDialog.site") }}</v-label></v-row
           >
-          <v-row>
+          <v-row gap="0">
             <v-col
               v-for="site in advanceItemPropsRef.site"
               :key="`${reBuildFilterCountRef}_${site}`"
@@ -128,7 +128,7 @@ function enterDialog() {
           </v-row>
 
           <template v-if="configStore.searchEntifyControl.showTorrentTag">
-            <v-row>
+            <v-row gap="0">
               <v-label>{{ t("SearchEntity.AdvanceFilterGenerateDialog.tags") }}</v-label>
               <v-spacer />
               <v-btn
@@ -145,7 +145,7 @@ function enterDialog() {
                 }}
               </v-btn>
             </v-row>
-            <v-row>
+            <v-row gap="0">
               <v-col
                 v-for="tag in filteredTorrentTags"
                 :key="`${reBuildFilterCountRef}_${tag.name}`"
@@ -178,10 +178,10 @@ function enterDialog() {
               </v-col>
             </v-row>
           </template>
-          <v-row
+          <v-row gap="0"
             ><v-label>{{ t("SearchEntity.AdvanceFilterGenerateDialog.status") }}</v-label></v-row
           >
-          <v-row>
+          <v-row gap="0">
             <v-col
               v-for="status in statusOptions"
               :key="`${reBuildFilterCountRef}_${status.value}`"
@@ -205,9 +205,9 @@ function enterDialog() {
               </v-checkbox>
             </v-col>
           </v-row>
-          <v-row>
+          <v-row gap="0">
             <v-col cols="6">
-              <v-row class="pr-4">
+              <v-row gap="0" class="pr-4">
                 <v-label>{{ t("common.AdvanceFilterGenerateDialog.date") }}</v-label>
                 <v-spacer />
                 <v-chip
@@ -235,7 +235,7 @@ function enterDialog() {
                   </v-menu>
                 </v-chip>
               </v-row>
-              <v-row>
+              <v-row gap="0">
                 <v-range-slider
                   v-model="advanceFilterDictRef.time"
                   :max="advanceItemPropsRef.time.range[1]"
@@ -256,10 +256,10 @@ function enterDialog() {
               </v-row>
             </v-col>
             <v-col cols="6">
-              <v-row
+              <v-row gap="0"
                 ><v-label>{{ t("SearchEntity.AdvanceFilterGenerateDialog.size") }}</v-label></v-row
               >
-              <v-row>
+              <v-row gap="0">
                 <v-range-slider
                   v-model="advanceFilterDictRef.size"
                   :max="advanceItemPropsRef.size.range[1]"
@@ -280,12 +280,12 @@ function enterDialog() {
               </v-row>
             </v-col>
           </v-row>
-          <v-row>
+          <v-row gap="0">
             <v-col cols="4">
               <v-row
                 ><v-label>{{ t("SearchEntity.AdvanceFilterGenerateDialog.seeders") }}</v-label></v-row
               >
-              <v-row>
+              <v-row gap="0">
                 <v-range-slider
                   v-model="advanceFilterDictRef.seeders"
                   :max="advanceItemPropsRef.seeders.range[1]"
@@ -306,7 +306,7 @@ function enterDialog() {
               <v-row
                 ><v-label>{{ t("SearchEntity.AdvanceFilterGenerateDialog.leechers") }}</v-label></v-row
               >
-              <v-row>
+              <v-row gap="0">
                 <v-range-slider
                   v-model="advanceFilterDictRef.leechers"
                   :max="advanceItemPropsRef.leechers.range[1]"
@@ -327,7 +327,7 @@ function enterDialog() {
               <v-row
                 ><v-label>{{ t("SearchEntity.AdvanceFilterGenerateDialog.completed") }}</v-label></v-row
               >
-              <v-row>
+              <v-row gap="0">
                 <v-range-slider
                   v-model="advanceFilterDictRef.completed"
                   :max="advanceItemPropsRef.completed.range[1]"

--- a/src/entries/options/views/Overview/SearchEntity/Index.vue
+++ b/src/entries/options/views/Overview/SearchEntity/Index.vue
@@ -221,7 +221,7 @@ const hiddenTagNamesText = computed({
   </v-alert>
   <v-card>
     <v-card-title>
-      <v-row class="ma-0">
+      <v-row gap="0" class="ma-0">
         <v-btn-group size="small" variant="text">
           <!-- 启动/暂停 搜索队列 -->
           <v-btn

--- a/src/entries/options/views/Overview/SearchEntity/SaveSnapshotDialog.vue
+++ b/src/entries/options/views/Overview/SearchEntity/SaveSnapshotDialog.vue
@@ -44,7 +44,13 @@ function saveSearchSnapshotData() {
       </v-card-title>
       <v-divider />
       <v-card-text>
-        <v-text-field v-model="snapshotName" dense hide-details :label="t('SearchEntity.SaveSnapshotDialog.snapshotName')" outlined></v-text-field>
+        <v-text-field
+          v-model="snapshotName"
+          density="compact"
+          hide-details
+          variant="outlined"
+          :label="t('SearchEntity.SaveSnapshotDialog.snapshotName')"
+        ></v-text-field>
       </v-card-text>
       <v-card-actions>
         <v-spacer />

--- a/src/entries/options/views/Overview/SearchEntity/SearchStatusDialog.vue
+++ b/src/entries/options/views/Overview/SearchEntity/SearchStatusDialog.vue
@@ -65,7 +65,7 @@ const filteredSearchPlan = computed(() => {
               ])
             }}
             <br />
-            <p class="text-caption"><{{ runtimeStore.search.searchPlanKey }}></p>
+            <p class="text-body-small"><{{ runtimeStore.search.searchPlanKey }}></p>
           </v-toolbar-title>
 
           <template #append>
@@ -117,10 +117,10 @@ const filteredSearchPlan = computed(() => {
                 </span>
               </div>
               <br />
-              <span class="text-subtitle-2 text-grey"> <{{ searchPlan.searchEntryName }}> </span>
+              <span class="text-label-large text-grey"> <{{ searchPlan.searchEntryName }}> </span>
             </v-list-item-title>
             <template #append>
-              <span class="text-subtitle-2 text-end">
+              <span class="text-label-large text-end">
                 <ResultParseStatus :status="searchPlan.status" />
                 <template v-if="searchPlan.status === EResultParseStatus.success">
                   <br />

--- a/src/entries/options/views/Overview/SearchResultSnapshot/EditNameDialog.vue
+++ b/src/entries/options/views/Overview/SearchResultSnapshot/EditNameDialog.vue
@@ -44,7 +44,13 @@ function dialogEnter() {
       </v-card-title>
       <v-divider />
       <v-card-text>
-        <v-text-field v-model="snapshotName" dense hide-details :label="t('SearchResultSnapshot.EditNameDialog.snapshotName')" outlined></v-text-field>
+        <v-text-field
+          v-model="snapshotName"
+          density="compact"
+          hide-details
+          variant="outlined"
+          :label="t('SearchResultSnapshot.EditNameDialog.snapshotName')"
+        ></v-text-field>
       </v-card-text>
       <v-card-actions>
         <v-spacer />

--- a/src/entries/options/views/Settings/SetBackup/AddDialog.vue
+++ b/src/entries/options/views/Settings/SetBackup/AddDialog.vue
@@ -94,10 +94,10 @@ function resetDialog() {
               "
               @update:model-value="(e) => updateStoredDownloaderConfigByDefault(e)"
             >
-              <template #selection="{ item: { raw: backupServer } }">
+              <template #selection="{ item: backupServer }">
                 <v-list-item :prepend-avatar="getBackupServerIcon(backupServer.type)" :title="backupServer.type" />
               </template>
-              <template #item="{ props, item: { raw: backupServer } }">
+              <template #item="{ props, item: backupServer }">
                 <v-list-item
                   v-bind="props"
                   :prepend-avatar="getBackupServerIcon(backupServer.type)"

--- a/src/entries/options/views/Settings/SetBackup/Index.vue
+++ b/src/entries/options/views/Settings/SetBackup/Index.vue
@@ -95,7 +95,7 @@ async function confirmDeleteBackupServer(id: TBackupServerKey) {
   <v-alert :title="t('route.Settings.SetBackup')" type="info" />
   <v-card class="set-backup">
     <v-card-title>
-      <v-row class="ma-0">
+      <v-row gap="0" class="ma-0">
         <NavButton :text="t('common.btn.add')" color="success" icon="mdi-plus" @click="showAddDialog = true" />
         <NavButton
           :disabled="tableSelected.length === 0"

--- a/src/entries/options/views/Settings/SetBase/SearchEntityWindow.vue
+++ b/src/entries/options/views/Settings/SetBase/SearchEntityWindow.vue
@@ -40,7 +40,7 @@ const hiddenTagNamesText = computed({
         hide-details
       />
 
-      <v-row dense>
+      <v-row density="compact">
         <v-col cols="12" md="2" class="d-flex align-center justify-center">
           <v-label>{{ t("SetBase.searchEntity.searchPlanLabel") }}</v-label>
         </v-col>
@@ -80,7 +80,7 @@ const hiddenTagNamesText = computed({
         </v-col>
       </v-row>
 
-      <v-row dense>
+      <v-row density="compact">
         <v-col cols="12" md="2" class="d-flex align-center justify-center">
           <v-label>{{ t("SetBase.searchEntity.filterLabel") }}</v-label>
         </v-col>
@@ -111,7 +111,7 @@ const hiddenTagNamesText = computed({
         </v-col>
       </v-row>
 
-      <v-row dense>
+      <v-row density="compact">
         <v-col cols="12" md="2" class="d-flex align-center justify-center">
           <v-label>{{ t("SetBase.searchEntity.tagLabel") }}</v-label>
         </v-col>

--- a/src/entries/options/views/Settings/SetBase/UiWindow.vue
+++ b/src/entries/options/views/Settings/SetBase/UiWindow.vue
@@ -46,11 +46,11 @@ defineExpose({
       <!-- 明亮模式设置 -->
       <v-select v-model="configStore.theme" :label="t('SetBase.ui.displayMode.index')" :items="supportTheme">
         <template #selection="{ item }">
-          {{ t("SetBase.ui.displayMode." + item.raw) }}
+          {{ t("SetBase.ui.displayMode." + item) }}
         </template>
 
         <template #item="{ item, props }">
-          <v-list-item v-bind="props" :title="t('SetBase.ui.displayMode.' + item.raw)" />
+          <v-list-item v-bind="props" :title="t('SetBase.ui.displayMode.' + item)" />
         </template>
       </v-select>
 
@@ -104,7 +104,7 @@ defineExpose({
       <template v-if="configStore.contentScript.enabled">
         <v-alert type="warning" variant="tonal"> {{ t("SetBase.ui.contentScriptWarning") }} </v-alert>
 
-        <v-row dense>
+        <v-row density="compact">
           <v-col cols="12" md="2" class="d-flex align-center justify-center">
             <v-label>{{ t("SetBase.ui.basicSettings") }}</v-label>
           </v-col>
@@ -127,7 +127,7 @@ defineExpose({
           </v-col>
         </v-row>
 
-        <v-row dense>
+        <v-row density="compact">
           <v-col cols="12" md="2" class="d-flex align-center justify-center">
             <v-label>{{ t("SetBase.ui.sidebarStyle") }}</v-label>
           </v-col>
@@ -161,7 +161,7 @@ defineExpose({
           </v-col>
         </v-row>
 
-        <v-row dense>
+        <v-row density="compact">
           <v-col cols="12" md="2" class="d-flex align-center justify-center">
             <v-label>{{ t("SetBase.ui.sidebarFunctions") }}</v-label>
           </v-col>

--- a/src/entries/options/views/Settings/SetDownloader/AddDialog.vue
+++ b/src/entries/options/views/Settings/SetDownloader/AddDialog.vue
@@ -104,10 +104,10 @@ async function saveStoredDownloaderConfig() {
               persistent-hint
               @update:model-value="(e) => updateStoredDownloaderConfigByDefault(e)"
             >
-              <template #selection="{ item: { raw: downloader } }">
+              <template #selection="{ item: downloader }">
                 <v-list-item :prepend-avatar="getDownloaderIcon(downloader.type)" :title="downloader.type" />
               </template>
-              <template #item="{ props, item: { raw: downloader } }">
+              <template #item="{ props, item: downloader }">
                 <v-list-item
                   v-bind="props"
                   :prepend-avatar="getDownloaderIcon(downloader.type)"

--- a/src/entries/options/views/Settings/SetDownloader/DefaultDownloaderEditDialog.vue
+++ b/src/entries/options/views/Settings/SetDownloader/DefaultDownloaderEditDialog.vue
@@ -78,14 +78,14 @@ function enterDialog() {
             item-value="id"
             @update:model-value="(e) => updateDefaultDownloaderInput(e)"
           >
-            <template #selection="{ item: { raw: downloader } }">
+            <template #selection="{ item: downloader }">
               <v-list-item
                 :prepend-avatar="getDownloaderIcon(downloader.type)"
                 :subtitle="downloader.address"
                 :title="downloader.name"
               />
             </template>
-            <template #item="{ props, item: { raw: downloader } }">
+            <template #item="{ props, item: downloader }">
               <v-list-item
                 v-bind="props"
                 :prepend-avatar="getDownloaderIcon(downloader.type)"
@@ -97,8 +97,16 @@ function enterDialog() {
           </v-autocomplete>
 
           <!-- 如果用户已经在对应下载器的预设了下载路径和标签，则加载对应的列表 -->
-          <v-combobox v-model="defaultDownloaderConfig.folder" :items="suggests.folder" :label="t('SetDownloader.PathAndTag.downloadPath.title')" />
-          <v-combobox v-model="defaultDownloaderConfig.tags" :items="suggests.tags" :label="t('SetDownloader.PathAndTag.tags.title')" />
+          <v-combobox
+            v-model="defaultDownloaderConfig.folder"
+            :items="suggests.folder"
+            :label="t('SetDownloader.PathAndTag.downloadPath.title')"
+          />
+          <v-combobox
+            v-model="defaultDownloaderConfig.tags"
+            :items="suggests.tags"
+            :label="t('SetDownloader.PathAndTag.tags.title')"
+          />
         </v-form>
       </v-card-text>
       <v-divider />

--- a/src/entries/options/views/Settings/SetDownloader/Index.vue
+++ b/src/entries/options/views/Settings/SetDownloader/Index.vue
@@ -118,7 +118,7 @@ async function confirmDeleteDownloader(downloaderId: TDownloaderKey) {
   <v-alert :title="t('route.Settings.SetDownloader')" type="info" />
   <v-card class="set-downloader">
     <v-card-title>
-      <v-row class="ma-0">
+      <v-row gap="0" class="ma-0">
         <NavButton :text="t('common.btn.add')" color="success" icon="mdi-plus" @click="showAddDialog = true" />
 
         <NavButton

--- a/src/entries/options/views/Settings/SetMediaServer/AddDialog.vue
+++ b/src/entries/options/views/Settings/SetMediaServer/AddDialog.vue
@@ -93,10 +93,10 @@ async function saveStoredMediaServerConfig() {
               persistent-hint
               @update:model-value="(e) => updateStoredMediaServerConfigByDefault(e)"
             >
-              <template #selection="{ item: { raw: downloader } }">
+              <template #selection="{ item: downloader }">
                 <v-list-item :prepend-avatar="getMediaServerIcon(downloader.type)" :title="downloader.type" />
               </template>
-              <template #item="{ props, item: { raw: downloader } }">
+              <template #item="{ props, item: downloader }">
                 <v-list-item
                   v-bind="props"
                   :prepend-avatar="getMediaServerIcon(downloader.type)"

--- a/src/entries/options/views/Settings/SetMediaServer/Index.vue
+++ b/src/entries/options/views/Settings/SetMediaServer/Index.vue
@@ -51,7 +51,7 @@ async function confirmDeleteMediaServer(mediaServerId: TMediaServerKey) {
   <v-alert :title="t('route.Settings.SetMediaServer')" type="info" />
   <v-card class="set-media-server">
     <v-card-title>
-      <v-row class="ma-0">
+      <v-row gap="0" class="ma-0">
         <NavButton :text="t('common.btn.add')" color="success" icon="mdi-plus" @click="showAddDialog = true" />
         <NavButton
           :disabled="tableSelected.length === 0"

--- a/src/entries/options/views/Settings/SetSearchSolution/Index.vue
+++ b/src/entries/options/views/Settings/SetSearchSolution/Index.vue
@@ -166,7 +166,7 @@ async function copySearchSolution(solutionId: TSolutionKey) {
   </v-alert>
   <v-card>
     <v-card-title>
-      <v-row class="ma-0">
+      <v-row gap="0" class="ma-0">
         <NavButton :text="t('common.btn.add')" color="success" icon="mdi-plus" @click="addSearchSolution" />
 
         <NavButton

--- a/src/entries/options/views/Settings/SetSearchSolution/SiteCategoryPanel.vue
+++ b/src/entries/options/views/Settings/SetSearchSolution/SiteCategoryPanel.vue
@@ -157,8 +157,8 @@ onMounted(async () => {
           {{ t("SetSearchSolution.spDialog.noDefNotice") }}
         </div>
       </v-col>
-      <v-col align-self="center">
-        <v-row justify="end">
+      <v-col class="align-self-center">
+        <v-row class="justify-end">
           <v-btn
             :title="t('SetSearchSolution.spDialog.action.reset')"
             color="red"
@@ -167,7 +167,7 @@ onMounted(async () => {
             @click="() => resetSelectCategory()"
           />
         </v-row>
-        <v-row justify="end">
+        <v-row class="justify-end">
           <v-btn
             :title="t('SetSearchSolution.spDialog.action.create')"
             color="indigo"
@@ -176,7 +176,7 @@ onMounted(async () => {
             @click="() => showCustomSolutionDialogFn()"
           ></v-btn>
         </v-row>
-        <v-row justify="end">
+        <v-row class="justify-end">
           <v-btn
             :title="t('SetSearchSolution.spDialog.action.add')"
             color="blue"

--- a/src/entries/options/views/Settings/SetSite/AddDialog.vue
+++ b/src/entries/options/views/Settings/SetSite/AddDialog.vue
@@ -81,7 +81,7 @@ async function saveSite() {
               item-value="id"
               persistent-hint
             >
-              <template #selection="{ item: { raw: site } }">
+              <template #selection="{ item: site }">
                 <v-list-item>
                   <template #prepend>
                     <SiteFavicon :site-id="site.id" class="mr-2" flush-on-no-image />
@@ -91,7 +91,7 @@ async function saveSite() {
                   </v-list-item-title>
                 </v-list-item>
               </template>
-              <template #item="{ props, item: { raw: site } }">
+              <template #item="{ props, item: site }">
                 <v-list-item v-bind="props">
                   <template #prepend>
                     <SiteFavicon :site-id="site.id" class="mr-2" />

--- a/src/entries/options/views/Settings/SetSite/Index.vue
+++ b/src/entries/options/views/Settings/SetSite/Index.vue
@@ -118,7 +118,7 @@ async function flushSiteFavicon(siteId: TSiteID | TSiteID[]) {
   <v-alert :title="t('route.Settings.SetSite')" type="info" />
   <v-card class="set-site">
     <v-card-title>
-      <v-row class="ma-0">
+      <v-row gap="0" class="ma-0">
         <NavButton :text="t('common.btn.add')" color="success" icon="mdi-plus" @click="showAddDialog = true" />
 
         <NavButton

--- a/src/entries/shared/common.scss
+++ b/src/entries/shared/common.scss
@@ -35,3 +35,28 @@
     }
   }
 }
+
+/* Vuetify 4 移除了全局 CSS reset（v3 中 `* { padding: 0; margin: 0 }` 已不存在），
+ * 项目模板中的原生 h1-h6 / p / ul 等元素会重新获得浏览器默认 margin/padding。
+ * 此处按官方 Upgrade Guide 建议选择性恢复这些 reset，保持与 v3 一致的显示。
+ * （放在 @layer vuetify-core.reset 中，不会覆盖组件样式。） */
+@layer vuetify-core.reset {
+  ul,
+  ol,
+  figure,
+  details,
+  summary {
+    padding: 0;
+    margin: 0;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p {
+    margin: 0;
+  }
+}

--- a/src/styles/vuetify/settings.scss
+++ b/src/styles/vuetify/settings.scss
@@ -1,0 +1,16 @@
+// Vuetify 4 MD3 elevation shadows (0-5 scale), per the official Elevation Migration Guide.
+// Component defaults migrated from v3 MD2 values to the new 0-5 scale:
+//   VBtn 2/4/8 → 1/2/3 (active kept at 3 to preserve the v3 press effect; v4 default is 1)
+//   All other components (VDialog 24, VMenu 8, VSnackbar 6, VCard 1/8, VNavigationDrawer 16,
+//   VBottomSheet 12, VAppBar 4, VCombobox/VAutocomplete/VSelect 4, VSwitch 4) map exactly to
+//   their v4 defaults (5/3/2/1/3/4/4/2/2/2), so no overrides are needed.
+// VBtn keeps v3 text-transform / letter-spacing.
+@use "vuetify/lib/components/VBtn/_variables" as * with (
+  $button-text-transform: uppercase,
+  $button-text-letter-spacing: 0.0892857143em,
+  $button-elevation: (
+    "default": 1,
+    "hover": 2,
+    "active": 3,
+  )
+);

--- a/src/styles/vuetify/settings.scss
+++ b/src/styles/vuetify/settings.scss
@@ -1,16 +1,11 @@
 // Vuetify 4 MD3 elevation shadows (0-5 scale), per the official Elevation Migration Guide.
 // Component defaults migrated from v3 MD2 values to the new 0-5 scale:
-//   VBtn 2/4/8 → 1/2/3 (active kept at 3 to preserve the v3 press effect; v4 default is 1)
+//   VBtn 2/4/8 → 1/2/1 (v4 default; hover/active follow the MD3 defaults)
 //   All other components (VDialog 24, VMenu 8, VSnackbar 6, VCard 1/8, VNavigationDrawer 16,
 //   VBottomSheet 12, VAppBar 4, VCombobox/VAutocomplete/VSelect 4, VSwitch 4) map exactly to
 //   their v4 defaults (5/3/2/1/3/4/4/2/2/2), so no overrides are needed.
 // VBtn keeps v3 text-transform / letter-spacing.
 @use "vuetify/lib/components/VBtn/_variables" as * with (
   $button-text-transform: uppercase,
-  $button-text-letter-spacing: 0.0892857143em,
-  $button-elevation: (
-    "default": 1,
-    "hover": 2,
-    "active": 3,
-  )
+  $button-text-letter-spacing: 0.0892857143em
 );

--- a/src/styles/vuetify/styles.scss
+++ b/src/styles/vuetify/styles.scss
@@ -1,0 +1,4 @@
+// 应用 v3 兼容设置后引入 Vuetify 基础样式
+// （直接引用 main.sass 以避免 vite-plugin-vuetify 的临时文件重写，保证模块身份一致）
+@use "./settings";
+@use "vuetify/lib/styles/main.sass";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,6 +48,18 @@ export default defineConfig({
     outDir: `dist-${target}`,
     emptyOutDir: true,
   },
+  // Vuetify 4: 强制 Vite 预打包 overlay 相关模块，避免 dev 模式下 useStack 被拆分为
+  // 两份实例导致 dialog 内的 menu/select 等浮层 z-index 计算失效（官方 Upgrade Guide 建议）。
+  // 仅影响 dev 模式；生产构建不受影响。
+  optimizeDeps: {
+    include: [
+      "vuetify/components/VOverlay",
+      "vuetify/components/VDialog",
+      "vuetify/components/VMenu",
+      "vuetify/components/VSelect",
+      "vuetify/components/VTooltip",
+    ],
+  },
   plugins: [
     vitePluginGenerateWebextLocales(),
     nodePolyfills({
@@ -60,7 +72,9 @@ export default defineConfig({
       launchEditor: fs.existsSync(base_path("./.idea")) ? "webstorm" : "vscode",
     }),
     vue(),
-    vuetify(),
+    vuetify({
+      styles: { configFile: "./src/styles/vuetify/settings.scss" },
+    }),
     webExtension({
       browser: target,
       disableAutoLaunch: true,


### PR DESCRIPTION
## Summary

将 Vuetify 依赖从 v3 (`^3.13.1`) 升级到 v4 (`^4.1.11`)，并按官方 [Upgrade Guide](https://vuetifyjs.com/en/getting-started/upgrade-guide/) 与 [Typography Migration](https://vuetifyjs.com/en/getting-started/typography-migration/) / [Elevation Migration](https://vuetifyjs.com/en/getting-started/elevation-migration/) 完成相关迁移，尽可能保持原有页面显示一致。

## Changes

### Dependencies
- `vuetify`: `^3.13.1` → `^4.1.11`
- `vite-plugin-vuetify`: 保持 `^2.1.3`（兼容 vuetify >=3）

### Styles
- 新增 `src/styles/vuetify/{settings,styles}.scss`：Vuetify 4 样式入口封装
  - 阴影按 Elevation Migration Guide 迁移至 MD3 0-5 scale（VBtn 2/4/8 → 1/2/3，其余组件迁移值即 v4 默认）
  - 保留 VBtn 的 `text-transform: uppercase` 与 letter-spacing（v3 行为）
- `common.scss`：按官方建议在 `@layer vuetify-core.reset` 中恢复 `h1-h6/p/ul/ol` 的 margin reset（v4 移除了全局 CSS reset）

### Typography（MD2 → MD3）
- `text-h6` → `text-headline-small`
- `text-subtitle-1` / `text-body-1` → `text-body-large`
- `text-subtitle-2` → `text-label-large`
- `text-body-2` → `text-body-medium`
- `text-caption` → `text-body-small`

### Grid
- `VRow dense` → `density="compact"`（gap 8px，与 v3 dense 一致）
- `VRow align/justify/align-content` props → utility classes
- `VCol align-self/order` props → utility classes

### Components
- `VSelect/VCombobox/VAutocomplete` item slot：使用 v4 的 raw value 别名用法
- `VColorInput`：`vuetify/labs` → `vuetify/components`（v4 已转正）
- `VTextField dense` → `density="compact"`，`outlined` → `variant="outlined"`
- `VDatePicker multiple="range"`：v4 仅返回起止日期，使用 `date-fns eachDayOfInterval` 展开为每日

### Config / Theme / Tooling
- `theme.defaultTheme: "light"`（v4 默认改为跟随系统）
- 断点使用 v4 默认值（md 840 / lg 1145 / xl 1545 / xxl 2138）
- `vite.config.ts` 增加 `optimizeDeps.include`（Vuetify overlay 模块，修复 dev 模式 z-index）

## Verification
- `pnpm run check`：仅剩 4 个既有 axios 类型错误（升级前同样存在，与本次改动无关）
- `pnpm run build:dist`（Chrome）与 `pnpm run build:dist-firefox` 均构建成功
- 构建产物 CSS 验证：MD3 typography 类生成、MD2 类零残留、断点回 v4 默认、elevation 0-5 scale、VBtn flex 布局 + uppercase 保留