### PR TITLE
fix(mediaServer): 修复 axios 1.19 升级后 request 泛型导致的类型报错

### DIFF
--- a/src/packages/mediaServer/entity/emby.ts
+++ b/src/packages/mediaServer/entity/emby.ts
@@ -113,10 +113,10 @@ export default class Emby extends AbstractMediaServer<IEmbyConfig> {
     return urlJoin(serverAddress, "/web/index.html");
   }
 
-  protected async request<T = any, R = AxiosResponse<T>, D = any>(
+  protected async request<T = any, D = any>(
     url: string,
     config: AxiosRequestConfig<D> = {},
-  ): Promise<R> {
+  ): Promise<AxiosResponse<T, D>> {
     config.baseURL = this.apiBaseUrl;
     config.timeout ??= this.config.timeout; // 未额外传入 timeout 时，使用默认的 timeout
 
@@ -129,7 +129,7 @@ export default class Emby extends AbstractMediaServer<IEmbyConfig> {
     // 处理请求url
     config.url = url;
 
-    return axios.request(config);
+    return axios.request<T>(config);
   }
 
   public override async ping(): Promise<boolean> {

--- a/src/packages/mediaServer/entity/fnos.ts
+++ b/src/packages/mediaServer/entity/fnos.ts
@@ -244,11 +244,11 @@ export default class FnOS extends AbstractMediaServer<IFnOSConfig> {
     return session;
   }
 
-  protected async request<T = any, R = AxiosResponse<T>, D = any>(
+  protected async request<T = any, D = any>(
     url: string,
     config: AxiosRequestConfig<D> = {},
     retried = false,
-  ): Promise<R> {
+  ): Promise<AxiosResponse<T, D>> {
     const session = await this.login();
 
     config.baseURL = this.apiBaseUrl;
@@ -262,7 +262,7 @@ export default class FnOS extends AbstractMediaServer<IFnOSConfig> {
     };
 
     try {
-      return await axios.request(config);
+      return await axios.request<T>(config);
     } catch (e) {
       if (!retried && e instanceof AxiosError && e.response?.status === 401) {
         await this.login(true);

--- a/src/packages/mediaServer/entity/jellyfin.ts
+++ b/src/packages/mediaServer/entity/jellyfin.ts
@@ -61,10 +61,10 @@ export default class Jellyfin extends AbstractMediaServer<IJellyfinConfig> {
     return serverAddress;
   }
 
-  protected async request<T = any, R = AxiosResponse<T>, D = any>(
+  protected async request<T = any, D = any>(
     url: string,
     config: AxiosRequestConfig<D> = {},
-  ): Promise<R> {
+  ): Promise<AxiosResponse<T, D>> {
     config.baseURL = this.baseUrl;
     config.timeout ??= this.config.timeout; // 未额外传入 timeout 时，使用默认的 timeout
 
@@ -80,7 +80,7 @@ export default class Jellyfin extends AbstractMediaServer<IJellyfinConfig> {
     // 处理请求url
     config.url = url;
 
-    return axios.request(config);
+    return axios.request<T>(config);
   }
 
   public async ping(): Promise<boolean> {

--- a/src/packages/mediaServer/entity/plex.ts
+++ b/src/packages/mediaServer/entity/plex.ts
@@ -129,10 +129,10 @@ export default class Plex extends AbstractMediaServer<IPlexConfig> {
     return serverAddress.replace(/\/$/, "") + "/web/index.html";
   }
 
-  protected async request<T = any, R = AxiosResponse<T>, D = any>(
+  protected async request<T = any, D = any>(
     url: string,
     config: AxiosRequestConfig<D> = {},
-  ): Promise<R> {
+  ): Promise<AxiosResponse<T, D>> {
     config.baseURL = this.apiBaseUrl;
     config.url = url;
     config.timeout ??= this.config.timeout; // 未额外传入 timeout 时，使用默认的 timeout
@@ -143,7 +143,7 @@ export default class Plex extends AbstractMediaServer<IPlexConfig> {
     config.params["X-Plex-Token"] = this.config.auth.apikey;
 
     config.responseType = "json";
-    return axios.request(config);
+    return axios.request<T>(config);
   }
 
   private async getServerIdentity(): Promise<string | undefined> {


### PR DESCRIPTION
## 问题

axios 升级到 1.19 后，`src/packages/mediaServer/entity/` 下 4 个媒体服务器实体构建报错：

```
build: src/packages/mediaServer/entity/plex.ts#L146
Type 'AxiosResponseResult<any, R, D, any>' is not assignable to type 'R'.
build: src/packages/mediaServer/entity/jellyfin.ts#L83
Type 'AxiosResponseResult<any, R, D, any>' is not assignable to type 'R'.
build: src/packages/mediaServer/entity/fnos.ts#L265
Type 'AxiosResponseResult<any, R, D, any>' is not assignable to type 'R'.
build: src/packages/mediaServer/entity/emby.ts#L132
Type 'AxiosResponseResult<any, R, D, any>' is not assignable to type 'R'.
```

## 原因

axios 1.19 的类型定义中 `request<T, R, D, P>` 返回 `AxiosResponseResult` 条件类型（`R extends AxiosResponseDefault ? AxiosResponse<T, D> : R`）。当外层 `request` 方法以 `R = AxiosResponse<T>` 作为泛型参数时，TypeScript 无法将 `AxiosResponseResult<any, R, D, any>` 归约为 `R`。

## 修复

移除 `request` 方法中多余的 `R` 泛型参数，直接返回 `Promise<AxiosResponse<T, D>>`，并显式调用 `axios.request<T>(config)`，与项目中其他 axios 封装（如 `AbstractBittorrentSite`、`qBittorrent`）保持一致。

涉及文件：
- `src/packages/mediaServer/entity/plex.ts`
- `src/packages/mediaServer/entity/jellyfin.ts`
- `src/packages/mediaServer/entity/fnos.ts`
- `src/packages/mediaServer/entity/emby.ts`

已通过 `pnpm check`（vue-tsc --noEmit）验证。