### PR TITLE
fix(pkg/site/mteam): 迁移做种数据接口 myPeerStatistics → myPeerStatus

### DIFF
--- a/src/packages/site/definitions/mteam.ts
+++ b/src/packages/site/definitions/mteam.ts
@@ -386,11 +386,9 @@ export const siteMetadata: ISiteMetadata = {
         },
       },
       {
-        requestConfig: { url: "/api/tracker/myPeerStatistics", method: "POST", responseType: "json" },
+        requestConfig: { url: "/api/tracker/myPeerStatus", method: "POST", responseType: "json" },
         selectors: {
-          seeding: { selector: "data.seederCount", filters: [{ name: "parseNumber" }] },
-          seedingSize: { selector: "data.seederSize", filters: [{ name: "parseNumber" }] },
-          uploads: { selector: "data.uploadCount", filters: [{ name: "parseNumber" }] },
+          seeding: { selector: "data.seeder", filters: [{ name: "parseNumber" }] },
         },
       },
       {


### PR DESCRIPTION
Closes #1453

## 主要问题

M-Team 已将做种统计接口 `/api/tracker/myPeerStatistics` 更名为 `/api/tracker/myPeerStatus`，响应字段由 `seederCount`/`seederSize`/`uploadCount` 精简为 `seeder`/`leecher`。扩展仍请求旧接口，导致 MyData 做种数量、保种体积无法刷新。

## 解决方法

- 请求 URL 迁移至 `/api/tracker/myPeerStatus`
- `seeding` 选择器由 `data.seederCount` 改取 `data.seeder`
- 移除 `seedingSize`/`uploads` 选择器：新接口与 `/api/member/profile` 均无数据来源，展示为 `-`（同 keepfrds #1410 处理）

## 测试流程及结果

1. 登录态抓包站点网页前端：已全面调用新接口，实测响应为 `{"code":"0","message":"SUCCESS","data":{"seeder":"0","leecher":"0"}}`，与本次选择器一致；
2. `pnpm check` 通过，无新增类型错误。

**备注**：本机测试账号做种数为 0，未能验证非零数值形态；字段类型（字符串数字）与旧接口一致，解析路径未变。