### PR TITLE
fix(pkg/site/hdhome): 移除不存在的分类 471（与 426 TVShow IPad 重复）

### DIFF
--- a/src/packages/site/definitions/hdhome.ts
+++ b/src/packages/site/definitions/hdhome.ts
@@ -138,7 +138,6 @@ export const siteMetadata: ISiteMetadata = {
         { value: 424, name: "TVMusic 1080i" },
         { value: 425, name: "TVShow SD" },
         { value: 426, name: "TVShow IPad" },
-        { value: 471, name: "TVShow IPad" },
         { value: 427, name: "TVShow 720p" },
         { value: 428, name: "TVShow 1080i" },
         { value: 429, name: "TVShow 1080p" },


### PR DESCRIPTION
## 问题
`cat_torrent` 中 value 471 与 426 同名「TVShow IPad」。实站搜索表单 61 个分类中不存在 471（自项目重建时误入的复制行），UI 中出现两个无法区分的同名分类，勾选 471 得不到任何结果。

## 解决方法
删除 471 一行；426 为实站真实分类，保持不变。

## 测试流程及结果
实测（hdhome.org，2026-08-25）：
- 全量提取实站分类复选框：无 cat471；
- `torrents.php?cat=471` → 0 行；`?cat=426` → 2 行，行首分类图标均为 TVShow IPad；
- `pnpm check` 无错误。