### PR TITLE
fix(pkg/downloader): 修复 Flood 下载器对 jesec/flood 新版的连接与数据解析问题

### DIFF
--- a/src/packages/downloader/entity/Flood.ts
+++ b/src/packages/downloader/entity/Flood.ts
@@ -25,7 +25,7 @@ import { getRemoteTorrentFile } from "../utils";
 export const clientConfig: TorrentClientConfig = {
   type: "Flood",
   name: "Flood",
-  address: "http://172.0.0.1:3000",
+  address: "http://127.0.0.1:3000",
   username: "",
   password: "",
   timeout: 60 * 1e3,
@@ -259,7 +259,8 @@ interface TorrentProperties {
   eta: number;
   // Upper-case hash of info section of the torrent
   hash: string;
-  isComplete: boolean;
+  // jesec 新版已移除该字段，改为通过 bytesDone/sizeBytes 或 status 推导
+  isComplete?: boolean;
   isPrivate: boolean;
   // If initial seeding mode (aka super seeding) is enabled
   isInitialSeeding: boolean;
@@ -297,6 +298,13 @@ export default class Flood extends AbstractBittorrentClient {
 
   private apiType?: FloodApiType;
 
+  /**
+   * Flood（jesec 分支）的认证依赖登录后下发的 jwt 会话 Cookie（httpOnly, SameSite=strict），
+   * 因此必须复用同一个开启 withCredentials 的 axios 实例，否则登录成功后 Cookie 无法留存，
+   * 后续请求全部 401。扩展已声明全量 host permission，跨域携带 Cookie 不受 SameSite 限制。
+   */
+  private readonly sessionedAxios = axios.create({ withCredentials: true });
+
   constructor(options: Partial<TorrentClientConfig> = {}) {
     super({ ...clientConfig, ...options });
   }
@@ -304,13 +312,18 @@ export default class Flood extends AbstractBittorrentClient {
   private async getEndPointType(): Promise<FloodApiType> {
     if (this.apiType == null) {
       try {
-        await axios.get(FloodApiEndpointMap.legacy.verify, {
+        const resp = await this.sessionedAxios.get(FloodApiEndpointMap.legacy.verify, {
           baseURL: this.config.address,
-          timeout: this.config.timeout,
+          // 探测超时单独收紧：部分 jesec 版本对不存在的 GET 路由不返回 404 而是挂起，
+          // 用短超时快速失败，避免拖满全局 timeout 才进入 jesec 分支
+          timeout: Math.min(this.config.timeout ?? 60e3, 10e3),
         });
-        this.apiType = "legacy";
+        this.apiType = resp.status === 404 ? "jesec" : "legacy";
       } catch (error) {
-        this.apiType = "jesec";
+        // 旧版未认证时 /auth/verify 返回 401，有 HTTP 响应即视为路由存在（legacy）；
+        // 404 或超时/网络错误（含 jesec 对未知 GET 路由挂起的情况）归为 jesec
+        const status = (error as AxiosError).response?.status;
+        this.apiType = status && status !== 404 ? "legacy" : "jesec";
       }
     }
     return this.apiType as FloodApiType;
@@ -325,7 +338,7 @@ export default class Flood extends AbstractBittorrentClient {
     const endPointUrl = await this.getEndPointUrl(endpoint);
 
     try {
-      return await axios.request<T>({
+      return await this.sessionedAxios.request<T>({
         baseURL: this.config.address,
         url: endPointUrl,
         timeout: this.config.timeout,
@@ -362,7 +375,9 @@ export default class Flood extends AbstractBittorrentClient {
   async ping(): Promise<boolean> {
     try {
       const req = await this.request("connection-test");
-      return (req.data as { isConnect: boolean }).isConnect;
+      // jesec 分支现为 { isConnected }（旧版为 { isConnect }），两者兼容读取
+      const data = req.data as { isConnected?: boolean; isConnect?: boolean };
+      return data.isConnected ?? data.isConnect ?? false;
     } catch (e) {
       return false;
     }
@@ -429,7 +444,10 @@ export default class Flood extends AbstractBittorrentClient {
       }
 
       addResult.success = true;
-    } catch (e) {}
+    } catch (e) {
+      // 将失败原因带回给调用方（会写入下载历史），避免静默失败无法排查
+      addResult.message = e instanceof Error ? e.message : String(e);
+    }
 
     return addResult;
   }
@@ -466,6 +484,9 @@ export default class Flood extends AbstractBittorrentClient {
         state = CTorrentState.seeding;
       } else if (statusInclude(["stopped", "p", "s"])) {
         state = CTorrentState.paused;
+      } else if (statusInclude(["complete"])) {
+        // jesec 的完成种子只带 complete 状态（不再提供 isComplete 字段），归入做种
+        state = CTorrentState.seeding;
       } else if (statusInclude(["checking", "ch"])) {
         state = CTorrentState.checking;
       } else if (statusInclude(["error", "e"])) {
@@ -478,9 +499,10 @@ export default class Flood extends AbstractBittorrentClient {
         name: rawTorrent.name,
         dateAdded: rawTorrent.dateAdded,
         state,
-        isCompleted: rawTorrent.isComplete,
+        isCompleted:
+          rawTorrent.isComplete ?? (rawTorrent.bytesDone > 0 && rawTorrent.bytesDone >= rawTorrent.sizeBytes),
         progress: rawTorrent.percentComplete,
-        label: rawTorrent.tags && rawTorrent.tags.length > 1 ? rawTorrent.tags[0] : undefined,
+        label: rawTorrent.tags && rawTorrent.tags.length > 0 ? rawTorrent.tags[0] : undefined,
         savePath: rawTorrent.directory,
         totalSize: rawTorrent.sizeBytes,
         ratio: rawTorrent.ratio,


### PR DESCRIPTION
## 主要问题

Close #1365 。Flood 下载器对 jesec/flood 新版（4.x）完全不可用：连通性测试必失败、登录后会话无法保持。原因是接口与认证机制演进后实现未跟进：

1. `ping()` 读取 `isConnect` 字段，而 jesec/flood 现返回 `isConnected`，导致连通性测试永远返回失败；
2. jesec/flood 认证改为 `httpOnly` 的 jwt 会话 Cookie，而实现使用无 Cookie 管理的全局 axios 实例，登录成功后会话无法留存，后续请求全部 401；
3. 版本探测把 `/auth/verify` 的任何报错都归类为 jesec 分支，未认证的 legacy 实例（返回 401）会被误判，后续端点全部走错；
4. 单标签种子因 `tags.length > 1` 的 off-by-one 判断不显示标签；
5. `addTorrent` 用空 `catch` 吞掉所有失败原因，无法排查；
6. jesec 新版已移除 `TorrentProperties.isComplete` 字段，完成状态读取恒为 undefined。

## 解决方法

- `ping()` 兼容读取 `isConnected ?? isConnect`；
- 改用开启 `withCredentials` 的专用 axios 实例承载全部请求，会话 Cookie 正常留存（扩展已声明全量 host permission，跨域携带 Cookie 不受影响）；
- 版本探测改为：有 HTTP 响应且非 404 判为 legacy，404 / 超时 / 网络错误判为 jesec（实测部分 jesec 版本对不存在的 GET 路由挂起而非返回 404，故超时也归 jesec），探测超时单独收紧为 min(timeout, 10s)；
- 标签判断修正为 `length > 0`；
- `addTorrent` 失败时透传错误信息到返回结果（可写入下载历史）；
- 完成状态改由 `bytesDone >= sizeBytes` 推导，status 含 `complete` 且非 stopped 归入做种状态；
- 默认地址 `172.0.0.1` 修正为 `127.0.0.1`。

## 测试流程及结果

本地构建 jesec/flood 4.16.1（qBittorrent 后端）+ 开发版扩展真机 E2E：

- 连通性测试：编辑器内点击「检查连接性」返回成功；flood 侧请求序列为 `GET /auth/verify（探测）→ GET /api/client/connection-test 401 → POST /api/auth/authenticate → GET /api/client/connection-test 200`，验证 Cookie 会话链路完整；
- 添加种子：文件流（扩展取种子转 base64 → add-files）与磁力流（add-urls）均返回 `completed`，flood 侧种子带预设标签；
- 我的下载器页：两种子正确显示标签与「已暂停」状态（单标签显示即 off-by-one 修复点）；
- `vue-tsc` 类型检查零错误，prettier 格式通过；legacy 分支路径未改动，探测逻辑对 legacy（200/401 响应）判定保持且更准确。