### PR TITLE
fix(pkg/site): 修复三个站点定义中筛选选项名称包含 HTML 转义实体导致界面显示错误的问题

### DIFF
--- a/src/packages/site/definitions/aither.ts
+++ b/src/packages/site/definitions/aither.ts
@@ -52,7 +52,7 @@ export const siteMetadata: ISiteMetadata = {
         { name: "Classical", value: 30 },
         { name: "Electronic", value: 31 },
         { name: "Hip-Hop / Rap", value: 32 },
-        { name: "Jazz &amp; Funk", value: 33 },
+        { name: "Jazz & Funk", value: 33 },
         { name: "Latin", value: 34 },
         { name: "Pop", value: 35 },
         { name: "Rock", value: 36 },

--- a/src/packages/site/definitions/cinematik.ts
+++ b/src/packages/site/definitions/cinematik.ts
@@ -91,7 +91,7 @@ export const siteMetadata: ISiteMetadata = {
         { name: "TV", value: 2 },
         { name: "Foreign Film", value: 3 },
         { name: "Foreign TV", value: 4 },
-        { name: "Opera &amp; Musical", value: 5 },
+        { name: "Opera & Musical", value: 5 },
         { name: "Asian Film", value: 6 },
       ],
       cross: { mode: "brackets" },

--- a/src/packages/site/definitions/seedpool.ts
+++ b/src/packages/site/definitions/seedpool.ts
@@ -141,7 +141,7 @@ export const siteMetadata: ISiteMetadata = {
         { name: "MP3 Pack", value: 31 },
         { name: "Karaoke", value: 43 },
         { name: "Music Videos", value: 55 },
-        { name: "Samples &amp; SFX", value: 48 },
+        { name: "Samples & SFX", value: 48 },
         { name: "3D Print", value: 38 },
         { name: "Book", value: 20 },
         { name: "Comic", value: 40 },


### PR DESCRIPTION
## 主要问题

aither、cinematik、seedpool 三个站点定义的搜索筛选选项 `name` 中误写了 `&amp;` HTML 转义实体，搜索方案界面按原文显示为 "Jazz &amp; Funk"、"Opera &amp; Musical"、"Samples &amp; SFX"，而非预期的 "Jazz & Funk" 等。

## 解决方法

将三处 `name` 中的 `&amp;` 改为普通 `&` 字符。`name` 仅用于界面展示（提交给站点的参数是 `value`），Vue 文本插值会自动转义，不影响搜索行为。全库已复扫，站点定义中不存在其他同类转义实体（hdroute 的 `&nbsp;` 是字段过滤正则代码，非展示文案）。

## 测试流程及结果

- 全库 `grep` 复扫三类定义文件，仅此三处，修改后零残留；
- 三个文件 prettier 格式检查通过；`vue-tsc` 检查未引入新增错误（当前 master 存量 18 个 Vuetify v4 相关类型错误，与本改动无关，改动前后数量一致）。