### PR TITLE
chore(vite): 加固 Telegram 推送脚本的输入校验

### DIFF
--- a/vite/plugin/generateWebextLocales.ts
+++ b/vite/plugin/generateWebextLocales.ts
@@ -11,17 +11,9 @@ export function vitePluginGenerateWebextLocales() {
       const localeFiles = fs.readdirSync(localesDir).filter((file) => file.endsWith(".json"));
 
       localeFiles.forEach((file) => {
-        // 防御：目录项经 basename 归一后必须匹配白名单（语言代码.json），否则跳过，
-        // 确保进入后续 path.join / 文件读写的片段不含路径分隔符或父级引用
-        const safeFile = path.basename(file);
-        if (!/^[A-Za-z0-9_-]+\.json$/.test(safeFile)) {
-          console.warn(`Skip suspicious locale file name: ${file}`);
-          return;
-        }
-        const localeName = path.basename(safeFile, ".json");
-        // 路径基底为字面量，动态片段（safeFile / localeName）均已 basename 归一并通过白名单校验
-        const localeFilePath = `${localesDir}/${safeFile}`;
-        const localeOutputDir = `${publicLocalesDir}/${localeName}`;
+        const localeName = path.basename(file, ".json");
+        const localeFilePath = path.join(localesDir, file);
+        const localeOutputDir = path.join(publicLocalesDir, localeName);
 
         try {
           // 读取 json 文件内容
@@ -49,7 +41,7 @@ export function vitePluginGenerateWebextLocales() {
           }
 
           // 写入 messages.json 文件
-          const outputFilePath = `${localeOutputDir}/messages.json`;
+          const outputFilePath = path.join(localeOutputDir, "messages.json");
           fs.writeFileSync(outputFilePath, JSON.stringify(messages, null, 2));
           console.log(`Generated ${outputFilePath}`);
         } catch (error) {

--- a/vite/plugin/generateWebextLocales.ts
+++ b/vite/plugin/generateWebextLocales.ts
@@ -11,9 +11,17 @@ export function vitePluginGenerateWebextLocales() {
       const localeFiles = fs.readdirSync(localesDir).filter((file) => file.endsWith(".json"));
 
       localeFiles.forEach((file) => {
-        const localeName = path.basename(file, ".json");
-        const localeFilePath = path.join(localesDir, file);
-        const localeOutputDir = path.join(publicLocalesDir, localeName);
+        // 防御：目录项经 basename 归一后必须匹配白名单（语言代码.json），否则跳过，
+        // 确保进入后续 path.join / 文件读写的片段不含路径分隔符或父级引用
+        const safeFile = path.basename(file);
+        if (!/^[A-Za-z0-9_-]+\.json$/.test(safeFile)) {
+          console.warn(`Skip suspicious locale file name: ${file}`);
+          return;
+        }
+        const localeName = path.basename(safeFile, ".json");
+        // 路径基底为字面量，动态片段（safeFile / localeName）均已 basename 归一并通过白名单校验
+        const localeFilePath = `${localesDir}/${safeFile}`;
+        const localeOutputDir = `${publicLocalesDir}/${localeName}`;
 
         try {
           // 读取 json 文件内容
@@ -41,7 +49,7 @@ export function vitePluginGenerateWebextLocales() {
           }
 
           // 写入 messages.json 文件
-          const outputFilePath = path.join(localeOutputDir, "messages.json");
+          const outputFilePath = `${localeOutputDir}/messages.json`;
           fs.writeFileSync(outputFilePath, JSON.stringify(messages, null, 2));
           console.log(`Generated ${outputFilePath}`);
         } catch (error) {

--- a/vite/sendToTgChannel.ts
+++ b/vite/sendToTgChannel.ts
@@ -11,13 +11,8 @@ const FILES_DIR = "build";
 
 // Telegram Bot API 域名固定；token 形态校验后拼接，避免任意值直接进入请求 URL
 const TELEGRAM_API_BASE = "https://api.telegram.org";
-const BOT_TOKEN_PATTERN = /^\d+:[A-Za-z0-9_-]{30,}$/;
-
-function telegramEndpoint(method: string): string {
-  if (!BOT_TOKEN || !BOT_TOKEN_PATTERN.test(BOT_TOKEN)) {
-    throw new Error("TELEGRAM_BOT_TOKEN 缺失或形态非法");
-  }
-  return `${TELEGRAM_API_BASE}/bot${BOT_TOKEN}/${method}`;
+if (!BOT_TOKEN || !/^\d+:[A-Za-z0-9_-]{30,}$/.test(BOT_TOKEN)) {
+  throw new Error("TELEGRAM_BOT_TOKEN 缺失或形态非法");
 }
 
 function getCommitInfo() {
@@ -45,8 +40,8 @@ function escapeLegacyMarkdown(text: string): string {
 }
 
 async function main() {
-  if (!BOT_TOKEN || !CHAT_ID) {
-    console.error("缺少 TELEGRAM_BOT_TOKEN 或 TELEGRAM_CHAT_ID 环境变量");
+  if (!CHAT_ID) {
+    console.error("缺少 TELEGRAM_CHAT_ID 环境变量");
     process.exit(1);
   }
 
@@ -123,7 +118,7 @@ ${escapeLegacyMarkdown(commitInfo.moreMessage)}`
     );
   });
 
-  const response = await axios.post(telegramEndpoint("sendMediaGroup"), formData);
+  const response = await axios.post(`${TELEGRAM_API_BASE}/bot${BOT_TOKEN}/sendMediaGroup`, formData);
 
   if (!response.data.ok) {
     throw new Error(`Telegram API 错误: ${response.status}`);

--- a/vite/sendToTgChannel.ts
+++ b/vite/sendToTgChannel.ts
@@ -9,6 +9,17 @@ const BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
 const CHAT_ID = process.env.TELEGRAM_CHAT_ID;
 const FILES_DIR = "build";
 
+// Telegram Bot API 域名固定；token 形态校验后拼接，避免任意值直接进入请求 URL
+const TELEGRAM_API_BASE = "https://api.telegram.org";
+const BOT_TOKEN_PATTERN = /^\d+:[A-Za-z0-9_-]{30,}$/;
+
+function telegramEndpoint(method: string): string {
+  if (!BOT_TOKEN || !BOT_TOKEN_PATTERN.test(BOT_TOKEN)) {
+    throw new Error("TELEGRAM_BOT_TOKEN 缺失或形态非法");
+  }
+  return `${TELEGRAM_API_BASE}/bot${BOT_TOKEN}/${method}`;
+}
+
 function getCommitInfo() {
   try {
     const commitHash = execSync("git rev-parse --short HEAD").toString().trim();
@@ -112,7 +123,7 @@ ${escapeLegacyMarkdown(commitInfo.moreMessage)}`
     );
   });
 
-  const response = await axios.post(`https://api.telegram.org/bot${BOT_TOKEN}/sendMediaGroup`, formData);
+  const response = await axios.post(telegramEndpoint("sendMediaGroup"), formData);
 
   if (!response.data.ok) {
     throw new Error(`Telegram API 错误: ${response.status}`);


### PR DESCRIPTION
## 主要问题

两处构建/发布辅助脚本对输入缺少校验，属防御性加固：

1. `generateWebextLocales` 插件将目录项直接拼入文件读写路径，未校验文件名形态；
2. `sendToTgChannel` 将环境变量 `TELEGRAM_BOT_TOKEN` 原样拼进请求 URL，任意值都会直接发起网络请求。

## 解决方法

- 插件侧：目录项经 `basename` 归一后须匹配语言代码白名单 `^[A-Za-z0-9_-]+\.json$` 才处理，异常文件名跳过并输出告警；
- 推送侧：Telegram API 域名固定为常量，Bot Token 先做形态校验 `^\d+:[A-Za-z0-9_-]{30,}$` 再拼接端点 URL，非法值在发起网络请求前抛出明确错误。

## 测试流程及结果

- A/B 构建对比：带/不带加固各构建一次，`_locales` 产物（en、zh_CN 的 messages.json）MD5 逐字节一致，合法输入行为不变；现有及常见语言文件名（含下划线、连字符）均通过白名单；
- 推送脚本：坏形态 token（`../../etc/passwd`）在网络请求发出前被拦截报错；合形态假 token 可正常到达 Telegram API 返回 401（认证拒绝而非 404），URL 拼装与原先等价；
- `vue-tsc` 对两文件零类型错误。