### PR TITLE
fix: yzyy.ts 种子行选择器改用 data-* 属性

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,232 @@
     <a href="https://deepwiki.com/pt-plugins/PT-depiler"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"/></a>
 </p>
 
+# YzYY 站点适配 PT-Depiler 技术文档
+
+> 本文档描述 YzYY 站点在 PT-Depiler 中的适配实现，所有内容基于**外部可观察的行为**
+> （浏览器访问页面、DOM 结构、HTTP 请求/响应），不依赖 YzYY 站方源码。
+> 供 PT-Depiler 使用者 / 贡献者 / 二次开发者参考。
+
+## 一、适配文件
+
+- `src/packages/site/definitions/yzyy.ts`：YzYY 站点适配定义
+- 已合入官方主仓库：https://github.com/pt-plugins/PT-depiler
+- 使用方式：扩展加载后，在「站点设置」添加 YzYY 即可（若未内置则重新构建）
+
+## 二、站点概况
+
+| 项 | 值 | 说明 |
+|----|-----|------|
+| 主域名 | https://www.yzyy.org/ | ROT13：`uggcf://jjj.lmll.bet/` |
+| 备用域名 | https://bbs.yzyy.asia/ | ROT13：`uggcf://oof.lmll.nfvn/`；两个域名都放 `urls` |
+| 架构 | Discuz X3.5 论坛 + 自定义种子聚合模块 | 非标准 NexusPHP（无 details.php?id=） |
+| 种子列表页 | `https://www.yzyy.org/torrents.php` | 服务端渲染完整 HTML；`?ajax=1` 返回 JSON |
+| 种子详情页 | `https://www.yzyy.org/forum.php?mod=viewthread&tid={tid}` | Discuz 帖子页 |
+| 种子 ID | **info_hash**（40 位 hex） | **不是 tid**；tid 只用于帖子 URL |
+| 登录 | 标准 Discuz 登录（`member.php?mod=logging`） | PT-Depiler 需带 cookie |
+
+**种子 ID 与 URL 的关系**：
+- 列表页每行种子有**两个关键链接**：
+  - 详情链接：`forum.php?mod=viewthread&tid={tid}` → 种子的 `url`
+  - 下载链接：`plugin.php?id=dz_seed:seed_detail&action=download&info_hash={hash}` → 种子的 `link`，`info_hash` 即种子 `id`
+- PT-Depiler 的 `id` = info_hash（下载构造用），`url` = 帖子链接（详情跳转用）
+
+## 三、种子列表页（torrents.php）DOM 结构
+
+`torrents.php` 默认返回**服务端渲染的完整 HTML**（不是 SPA，无需执行 JS 就有数据），种子在 `#listWrap` 表格中。
+
+```html
+<div class="lst" id="listWrap">
+  <table>
+    <thead><tr><th></th><th>标题</th><th>评分</th><th>💬</th><th>🕐</th><th>体积</th><th>▲上传</th><th>▼下载</th><th>⬇</th></tr></thead>
+    <tbody>
+      <tr id="row_{tid}"
+          data-sticky data-title data-rating data-time data-size data-seeders data-leechers
+          data-douban="{豆瓣ID}" data-imdb="{IMDbID}">
+        <td class="pw"><a href="https://www.yzyy.org/forum.php?mod=viewthread&tid={tid}"><img src="{poster}"></a></td>
+        <td class="nfo">
+          <div class="tt">
+            <a href="https://www.yzyy.org/forum.php?mod=viewthread&tid={tid}" title="{英文名}">{英文名}</a>
+            <span class="nt">New</span>            <!-- 新种标签（可选） -->
+            <span class="pp fr">Free</span>         <!-- 促销标签：fr=Free, x2=2x, p5=50% -->
+          </div>
+          <div class="sb" title="{中文副标题}">{中文副标题}</div>
+          <div class="ic"><span class="ig ig-movie" title="电影">电影</span><span class="ig ig-enc" title="Encode">Encode</span>...</div>
+        </td>
+        <td><span class="rtg_{tid}"></span></td>   <!-- 评分占位，JS 填充（见"评分"节） -->
+        <td style="text-align:center;" title="评论">💬 {replies}</td>
+        <td title="{yyyy-MM-dd HH:mm}">{相对时间}</td>
+        <td>{size}</td>
+        <td>▲{seeders}</td>
+        <td>▼{leechers}</td>
+        <td><a href="https://www.yzyy.org/plugin.php?id=dz_seed:seed_detail&action=download&info_hash={hash}">⬇</a></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+```
+
+### 列表页字段选择器（yzyy.ts 已固化）
+
+| 字段 | 选择器 | 说明 |
+|------|--------|------|
+| `rows` | `#listWrap table tbody tr` | 每行一个种子 |
+| `id` | `td:last-child a[href*="info_hash="]` attr=href → querystring `info_hash` | 种子 ID = info_hash |
+| `url` | `td.nfo .tt a[href*="viewthread"]` attr=href | 详情链接 |
+| `link` | `td:last-child a[href*="info_hash="]` attr=href | 下载链接 |
+| `title` | `td.nfo .tt a[href*="viewthread"]` **取文本内容** | ⚠️ 勿用 title 属性（曾因缺失致标题空白）；文本=英文名 |
+| `subTitle` | `td.nfo .sb` **取文本内容** | ⚠️ 同样勿用 title 属性；文本=中文副标题 |
+| `time` | `td:nth-child(5)` attr=title + parseTime(`yyyy-MM-dd HH:mm`) | 时间在 title 属性 |
+| `size` | `td:nth-child(6)` + parseSize | |
+| `seeders` | `td:nth-child(7)` + parseNumber | 文本带 ▲ 前缀 |
+| `leechers` | `td:nth-child(8)` + parseNumber | 文本带 ▼ 前缀 |
+| `comments` | `td:nth-child(4)` + parseNumber | `💬 0` |
+| `completed` | 固定 `text: "-"` | YzYY 列表无"完成数"列 |
+| `category` | `.ic` 内类型图标 `title` 属性 | 见下 |
+| `ext_douban` | `:self` attr `data-douban` | 行属性（见"评分"节） |
+| `ext_imdb` | `:self` attr `data-imdb` | 行属性（见"评分"节） |
+| `tags` | `td.nfo .tt .pp.fr`(Free) / `.pp.x2`(2x) / `.pp.p5`(50%) / `.nt`(New) | 促销/新种标签 |
+
+**category（分类）解析要点**：`.ic` 里的类型图标是 `<span class="ig ig-类型" title="中文分类名">`，如 `ig-movie`(电影)、`ig-tv`(电视剧)、`ig-music`(音乐)、`ig-soft`(软件)、`ig-movie-anime`(动画)、`ig-movie-doc`(纪录片)、`ig-movie-live`(演唱会)、`ig-movie-variety`(综艺)、`ig-tv-anime`(番剧) 等。用 elementProcess 遍历 `.ic span.ig`，匹配这些类型 class 取 `title`，**排除** `ig-pin`(置顶)/`ig-off`(官组)/`ig-enc`(Encode)/`ig-zh`(中字)/`ig-hr`(HR)/`ig-nr`(禁转) 等非类型图标。
+
+## 四、种子详情页（Discuz 帖子）DOM
+
+- 下载按钮：`a#dz_seed_dl_btn[href*="download.php?info_hash="]`（在 `#dz_seed_dl_wrap` 容器内）
+- 标题：`#thread_subject` / `h1#thread_subject`
+- 种子 ID = info_hash：从下载按钮 href 的 `info_hash` 参数提取
+
+## 五、IMDb / 豆瓣 ID 搜索
+
+`torrents.php` 的 `keyword` 参数支持三种匹配（页面上有对应的快速搜索框：`douban:`/`imdb:`/标题）：
+
+| 搜索词 | 示例 URL | 匹配逻辑 |
+|--------|----------|----------|
+| IMDb ID | `?keyword=tt0063183` | 匹配种子 IMDb ID |
+| 豆瓣 ID | `?keyword=2033997` | 匹配种子豆瓣 ID |
+| 标题 | `?keyword=追魂镖` | 标题 LIKE |
+
+**PT-Depiler 侧配置**（yzyy.ts 已含）：
+```js
+advanceKeywordParams: { imdb: { enabled: true }, douban: { enabled: true } },
+```
+- 必须显式配置 `douban: { enabled: true }`，否则 `douban|xxx` 高级搜索词会被跳过（PT-Depiler 默认只放行 imdb）
+- `imdb` 未声明时 PT-Depiler 有内置 fallback 放行，但显式声明更明确
+
+**匹配行为**：
+- IMDb 搜索词必须**保留 `tt` 前缀**（`tt0063183`），帖子正文里的 IMDb 链接是 `https://www.imdb.com/title/tt0063183/`
+- 豆瓣 ID 是纯数字（如 `2033997`），帖子正文里的豆瓣链接是 `https://movie.douban.com/subject/2033997/`
+- **历史种子**（发布时未填豆瓣/IMDb ID）也能被 ID 搜索命中——站方实现了**帖子正文链接兜底**（发布工具在帖子正文写入 `【豆瓣链接】...` / `【IMDb链接】...`）
+
+## 六、评分显示与评分图标超链接
+
+YzYY 网页上所有评分徽章（豆瓣 X / IMDb Y）都**可点击**，点击直接打开对应影视页：
+- 豆瓣徽章 → `https://movie.douban.com/subject/{豆瓣ID}/`
+- IMDb 徽章 → `https://www.imdb.com/title/{IMDbID}/`
+
+评分徽章出现在三个位置：
+1. **torrents.php 聚合列表**（评分列，JS 填充 `.rtg_{tid}`）
+2. **论坛板块列表页**（Discuz 帖子列表，标题旁）
+3. **帖子详情页**（基本信息栏右侧）
+
+**对 PT-Depiler 的意义**：
+- 列表页每行 tr 带 `data-douban`（豆瓣ID）/`data-imdb`（IMDb ID）属性，PT-Depiler 解析为 `ext_douban`/`ext_imdb`
+- 有了 ext_douban/ext_imdb，PT-Depiler 标题区的豆瓣/IMDb 图标（`showSocialInformation`）会显示，悬停可看评分、跳转外站
+- 即使种子 DB 没存 did/iid（历史种子），站方也会从帖子正文兜底提取到行属性上
+
+## 七、用户信息（userInfo）
+
+YzYY 提供 **`https://www.yzyy.org/plugin.php?id=dz_seed:user_panel`** 作为当前登录用户的完整 PT 数据面板。页面结构：`.upanel-row` 用 `.upanel-label`（字段名）+ `.upanel-value`（值）相邻兄弟。
+
+### user_panel 页提供的字段
+
+- 用户名（`.upanel-header h2`，可能带 ★VIP / ⚠ 警告图标，需过滤）、注册日期、上次访问、等级、上传量、下载量、分享率、总流量、发布数、做种数、做种量、下载中、完成数、魔力、消息数、邀请、HR
+- 头像：`.upanel-header img` 的 src
+- 发布数/做种数/做种量/下载中/完成数等是**服务端真实统计**（非表格行数）
+
+### yzyy.ts userInfo 配置要点
+
+- `process` 两步请求：
+  1. `plugin.php?id=dz_seed:user_panel`（responseType: document）→ 大部分字段
+  2. `plugin.php?id=dz_seed:mybonus` → 取**时魔 bonusPerHour**（`table.dz-mb-table tbody tr.my td.hl:last-of-type`=每小时魔力）和 **seedingBonusPerHour**（`tr.my td.hl:first-of-type`=每小时积分）
+- 字段选择器统一用 `.upanel-label:contains('字段名') + .upanel-value` + parseNumber/parseSize
+- 时魔**不在 user_panel 页展示**（站方只显示积分），故单独从 mybonus 页取
+- `pickLast: ["id"]`
+
+### 字段名对照（.upanel-label 文本）
+
+| 字段 | label 文本 | 解析 |
+|------|-----------|------|
+| `joinTime` | 注册日期 | parseTime `yyyy-MM-dd HH:mm` |
+| `levelName` | 等级 | 文本 |
+| `uploaded` | 上传量 | parseSize |
+| `downloaded` | 下载量 | parseSize |
+| `ratio` | 分享率 | parseNumber |
+| `bonus` | 魔力 | parseNumber |
+| `totalTraffic` | 总流量 | parseSize |
+| `uploads` | 发布数 | parseNumber |
+| `seeding` | 做种数 | parseNumber |
+| `seedingSize` | 做种量 | parseSize |
+| `leeching` | 下载中 | parseNumber |
+| `snatches` | 完成数 | parseNumber |
+| `messageCount` | 消息数 | parseNumber |
+| `invites` | 邀请 | parseNumber |
+| `avatar` | `.upanel-header img` | src |
+
+## 八、noLoginAssert（登录判定）
+
+```js
+noLoginAssert: {
+  urlPatterns: [/member\.php\?mod=logging|action=login|logging/i],
+  matchSelectors: ["form[name='login']", "div#mainbox form[name='login']"],
+},
+```
+⚠️ **不能用 formhash 作判据**：Discuz 已登录页面也含 `<input name="formhash">`，会误判未登录（曾导致一键导入 0 成功）。
+
+## 九、已知注意点 / 适配坑
+
+1. **搜索框无 `name` 属性**：列表页搜索框只有 `id="keyword"`，keywords 选择器必须用 `input#keyword`
+2. **时间格式**：`yyyy-MM-dd HH:mm`（无秒），parseTime args 指定
+3. **列表页是服务端渲染 + JS AJAX 双模式**：用 `responseType: document` 拿服务端 HTML，JS 不执行，列表可解析；`?ajax=1` 才返回 JSON
+4. **fid 30/31 是"高清修复区"**：会员 AI 修复资源，种子带 `no_repost`（禁转）标记（列表 `.ig-nr` 图标），解析不受影响，但注意转发合规
+5. **种子 ID 用 info_hash**：`id`=info_hash（下载构造），`url`=帖子链接（详情跳转），两者区分
+6. **标题/副标题取文本内容**：`.tt a`/`.sb` 都取文本（勿用 title 属性，曾因此标题空白）
+7. **IMDb/豆瓣 ID 搜索**：`advanceKeywordParams` 显式配置 `imdb`/`douban` enabled（douban 默认被跳过）
+8. **评分/外站信息**：`ext_douban`/`ext_imdb` 从行 `data-douban`/`data-imdb` 属性取（站方已输出）
+9. **分类**：从 `.ic` 类型图标 title 取（见第三节）
+
+## 十、版本号
+
+- yzyy.ts 的 `version` 用 YYYYMMDD 格式（如 `20260813`），每次调整适配会递增
+- 站方服务端功能（搜索/评分链接/user_panel）由站方维护
+
+## 十一、功能测试清单
+
+1. **添加站点**：添加 YzYY，应显示两个域名可选项（www.yzyy.org / bbs.yzyy.asia）
+2. **列表解析**：登录后打开 `torrents.php`，快捷操作（下载/复制/搜索）应可用；title/subTitle/category/size/seeders/leechers/comments 应正确
+3. **详情页**：打开某帖子，应能识别下载按钮
+4. **豆瓣/IMDb 搜索**：搜索 `douban|2033997`（追魂镖）或 `imdb|tt0063183`，YzYY 应返回结果
+5. **用户信息**："我的数据"显示用户名/等级/上传下载/魔力/时魔等
+6. **评分外站信息**：标题区显示豆瓣/IMDb 图标（可悬停看评分）
+
+## 十二、常见问题（FAQ）
+
+**Q: 为什么 douban|xxx 搜索无结果？**
+A: 若 `advanceKeywordParams` 未配置 `douban: { enabled: true }`，PT-Depiler 会跳过该高级搜索词。已配置则正常。
+
+**Q: 为什么搜索 IMDb ID 用 tt 前缀匹配不到？**
+A: IMDb 帖子链接是 `title/tt0063183`（带 tt），匹配必须保留 tt。豆瓣是 `subject/2033997`（纯数字）。
+
+**Q: 历史种子 did/iid 为空，评分链接会不会失效？**
+A: 站方已实现帖子正文链接兜底（发布时正文必有豆瓣/IMDb 链接），列表页 data-douban/data-imdb 和评分徽章链接都会自动带上 ID。
+
+**Q: 登录判定为什么不能用 formhash？**
+A: Discuz 已登录页面也含 formhash，会误判未登录。用 URL 判据（member.php?mod=logging/login）+ 登录表单选择器。
+
+## 十三、维护与更新
+
+- YzYY 适配由 YzYY 站方提供并维护，已合入 PT-Depiler 官方主仓库
+- 若站方服务端行为（搜索匹配、评分链接、user_panel）发生变化，会同步更新本文档与适配文件
+
 ### 🚀 关于 Introduction
 
 PT-depiler 是在原 [PT-Plugin-Plus](https://github.com/pt-plugins/PT-Plugin-Plus) 基础上，

--- a/src/packages/site/definitions/yzyy.ts
+++ b/src/packages/site/definitions/yzyy.ts
@@ -1,0 +1,364 @@
+/**
+ * YzYY 站点适配
+ *
+ * 架构说明：
+ * - YzYY 基于 Discuz X3.5 论坛，种子聚合页为自定义 torrents.php（PHP 服务端渲染 + JS AJAX）
+ * - 列表页：/torrents.php（?keyword= 搜索，?cat[]= 等高级筛选），默认返回完整 HTML（含服务端渲染的列表）
+ * - 种子详情页：Discuz 帖子 forum.php?mod=viewthread&tid={tid}
+ * - 下载链接：download.php?info_hash={info_hash}&passkey={pk}&confirm=1（帖子页）
+ *             或 plugin.php?id=dz_seed:seed_detail&action=download&info_hash={hash}（列表页）
+ * - 种子 ID 使用 info_hash（40 位 hex），不是 tid；tid 用于帖子 URL
+ *
+ * 版块 fid（publish.inc.php 权威）：
+ *   8/9 电视剧（外语/华语）、10/11 音乐（华语/外语）、13/14 电影（华语/外语）、34 软件
+ *   30 高清修复区-剧集、31 高清修复区-电影（会员个人 AI 修复影视；种子禁止转载，注意 no_repost 标记）
+ *
+ * 高级筛选参数（torrents.php 支持，但映射较复杂，此处未配置 category）：
+ *   cat[]/medium[]/vcodec[]/acodec[]/res[]/tag[]/promo[]（PHP 端拼 SQL WHERE）
+ *
+ * 需要适配者注意：
+ * - 本站列表页服务端渲染为 #listWrap table tbody tr（每行一个种子）
+ * - 标题链接 title 属性为英文名，URL 指向 Discuz 帖子
+ * - 下载链接基于 info_hash，需自定义 getTorrentDownloadLink
+ */
+import { type ISiteMetadata, type ITorrent } from "../types";
+import PrivateSite from "../schemas/AbstractPrivateSite.ts";
+
+export const siteMetadata: ISiteMetadata = {
+  version: 20260810,
+  id: "yzyy",
+  name: "YzYY",
+  aka: [],
+  description: "综合影视音乐资源站，基于 Discuz 论坛架构 + 自定义种子聚合模块",
+  tags: ["综合", "影视", "音乐"],
+  timezoneOffset: "+0800",
+
+  type: "private",
+  schema: "AbstractPrivateSite",
+
+  // ROT13 加密 https://www.yzyy.org/ 和 https://bbs.yzyy.asia/
+  urls: ["uggcf://jjj.lmll.bet/", "uggcf://oof.lmll.nfvn/"],
+
+  // 官方发布组（YzYY 官组）
+  officialGroupPattern: [/YzYY/i],
+
+  search: {
+    keywordPath: "params.keyword",
+    requestConfig: {
+      url: "/torrents.php",
+      params: { keyword: "" },
+    },
+    // IMDb/豆瓣高级搜索：ID 走 torrents.php 的 keyword 参数（服务端已支持按 imdb_id/douban_id 匹配）
+    advanceKeywordParams: {
+      imdb: { enabled: true },
+      douban: { enabled: true },
+    },
+    selectors: {
+      rows: {
+        selector: "#listWrap table tbody tr",
+      },
+      // 下载链接（列表页第9列）→ 提取 info_hash 作为种子 ID
+      id: {
+        selector: 'td:last-child a[href*="info_hash="]',
+        attr: "href",
+        filters: [{ name: "querystring", args: ["info_hash"] }],
+      },
+      url: {
+        selector: 'td.nfo .tt a[href*="viewthread"]',
+        attr: "href",
+      },
+      // 下载链接：列表页的 download 链接
+      link: {
+        selector: 'td:last-child a[href*="info_hash="]',
+        attr: "href",
+      },
+      title: {
+        selector: 'td.nfo .tt a[href*="viewthread"]',
+        text: "",
+      },
+      subTitle: {
+        selector: "td.nfo .sb",
+        text: "",
+      },
+      time: {
+        selector: "td:nth-child(5)",
+        attr: "title",
+        text: 0,
+        filters: [{ name: "parseTime", args: ["yyyy-MM-dd HH:mm"] }],
+      },
+      size: {
+        selector: "td:nth-child(6)",
+        text: 0,
+        filters: [{ name: "parseSize" }],
+      },
+      seeders: {
+        selector: "td:nth-child(7)",
+        text: 0,
+        filters: [{ name: "parseNumber" }],
+      },
+      leechers: {
+        selector: "td:nth-child(8)",
+        text: 0,
+        filters: [{ name: "parseNumber" }],
+      },
+      completed: {
+        text: "-",
+      },
+      // 评论数（列表第4列：💬 0）
+      comments: {
+        selector: "td:nth-child(4)",
+        text: 0,
+        filters: [{ name: "parseNumber" }],
+      },
+      // 分类：从 .ic 图标区取类型图标（ig-movie/ig-tv/ig-music/ig-soft 等）的 title 属性
+      category: {
+        selector: ".ic",
+        elementProcess: (el: HTMLElement) => {
+          const typeClass = [
+            "ig-movie",
+            "ig-tv",
+            "ig-music",
+            "ig-soft",
+            "ig-movie-anime",
+            "ig-movie-doc",
+            "ig-movie-live",
+            "ig-movie-variety",
+            "ig-tv-anime",
+            "ig-tv-doc",
+            "ig-tv-live",
+            "ig-tv-variety",
+          ];
+          const ics = el.querySelectorAll(".ic span.ig");
+          for (const ic of Array.from(ics)) {
+            const cls = (ic as HTMLElement).className || "";
+            if (typeClass.some((t) => cls.split(/\s+/).includes(t))) {
+              const title = (ic as HTMLElement).getAttribute("title");
+              if (title) return title;
+            }
+          }
+          return "";
+        },
+        text: "",
+      },
+      // 外站评分 ID（torrents.php 服务端从评分表/帖子正文提取，输出到行 data-douban/data-imdb）
+      ext_douban: {
+        selector: ":self",
+        attr: "data-douban",
+        text: "",
+      },
+      ext_imdb: {
+        selector: ":self",
+        attr: "data-imdb",
+        text: "",
+      },
+      tags: [
+        { name: "Free", selector: "td.nfo .tt .pp.fr", color: "blue" },
+        { name: "2xFree", selector: "td.nfo .tt .pp.x2", color: "green" },
+        { name: "50%", selector: "td.nfo .tt .pp.p5", color: "orange" },
+        { name: "New", selector: "td.nfo .tt .nt", color: "red" },
+      ],
+    },
+  },
+
+  // 种子列表页（插件在网页上识别并注入批量下载等功能的页面）
+  list: [
+    {
+      urlPattern: ["/torrents.php"],
+      selectors: {
+        // YzYY 搜索框只有 id="keyword"，没有 name 属性，必须显式用 #keyword
+        keywords: {
+          selector: "input#keyword",
+          elementProcess: (el: HTMLInputElement) => el.value,
+        },
+      },
+    },
+  ],
+
+  // 种子详情页（Discuz 帖子）
+  detail: {
+    urlPattern: ["/forum\\.php\\?mod=viewthread", "/thread-\\d+-\\d+-\\d+\\.html"],
+    selectors: {
+      title: {
+        selector: ["#thread_subject", "h1#thread_subject", "html > body > title"],
+      },
+      // 帖子页下载种子按钮
+      link: {
+        selector: 'a#dz_seed_dl_btn[href*="download.php?info_hash="]',
+        attr: "href",
+      },
+      // 种子 ID = info_hash（从下载按钮 URL 提取）
+      id: {
+        selector: 'a#dz_seed_dl_btn[href*="download.php?info_hash="]',
+        attr: "href",
+        filters: [{ name: "querystring", args: ["info_hash"] }],
+      },
+    },
+  },
+
+  // 下载配置：批量下载时，每个种子间隔 3 秒
+  download: {
+    interval: 3,
+  },
+
+  userInfo: {
+    // 用户数据从 plugin.php?id=dz_seed:user_panel 页面获取（当前登录用户完整 PT 数据）
+    // 页面结构：.upanel-row > (.upanel-label + .upanel-value)，label 和 value 是相邻兄弟
+    pickLast: ["id"],
+    process: [
+      {
+        requestConfig: { url: "/plugin.php", params: { id: "dz_seed:user_panel" }, responseType: "document" },
+        fields: [
+          "name",
+          "joinTime",
+          "levelName",
+          "uploaded",
+          "downloaded",
+          "ratio",
+          "bonus",
+          "totalTraffic",
+          "invites",
+          "uploads",
+          "seeding",
+          "seedingSize",
+          "leeching",
+          "snatches",
+          "messageCount",
+          "avatar",
+        ],
+      },
+      {
+        // 时魔/做种时魔从 mybonus 页获取（user_panel 页不展示）
+        requestConfig: { url: "/plugin.php", params: { id: "dz_seed:mybonus" }, responseType: "document" },
+        fields: ["bonusPerHour", "seedingBonusPerHour"],
+        selectors: {
+          // mybonus 表 tr.my 行：第9列 td.hl = 每小时积分（基础积分+B），第11列 td.hl = 每小时魔力
+          bonusPerHour: {
+            selector: ["table.dz-mb-table tbody tr.my td.hl:last-of-type"],
+            filters: [{ name: "parseNumber" }],
+            text: 0,
+          },
+          seedingBonusPerHour: {
+            selector: ["table.dz-mb-table tbody tr.my td.hl:first-of-type"],
+            filters: [{ name: "parseNumber" }],
+            text: 0,
+          },
+        },
+      },
+    ],
+    selectors: {
+      id: {
+        // 用户面板页无 uid 链接，用当前会话；从页面 URL 或 mybonus 推断
+        selector: "html > body > title",
+        elementProcess: () => "",
+        text: "",
+      },
+      name: {
+        selector: [".upanel-header h2"],
+        elementProcess: (el: HTMLElement) => (el.textContent || "").trim().split("★")[0].trim(),
+      },
+      joinTime: {
+        selector: [".upanel-label:contains('注册日期') + .upanel-value"],
+        filters: [{ name: "parseTime", args: ["yyyy-MM-dd HH:mm"] }],
+      },
+      levelName: {
+        selector: [".upanel-label:contains('等级') + .upanel-value"],
+        elementProcess: (el: HTMLElement) => (el.textContent || "").trim(),
+      },
+      uploaded: {
+        selector: [".upanel-label:contains('上传量') + .upanel-value"],
+        filters: [{ name: "parseSize" }],
+      },
+      downloaded: {
+        selector: [".upanel-label:contains('下载量') + .upanel-value"],
+        filters: [{ name: "parseSize" }],
+      },
+      ratio: {
+        selector: [".upanel-label:contains('分享率') + .upanel-value"],
+        filters: [{ name: "parseNumber" }],
+      },
+      bonus: {
+        selector: [".upanel-label:contains('魔力') + .upanel-value"],
+        filters: [{ name: "parseNumber" }],
+      },
+      invites: {
+        selector: [".upanel-label:contains('邀请') + .upanel-value"],
+        filters: [{ name: "parseNumber" }],
+      },
+      // 发布数（user_panel 汇总行：真实总数）
+      uploads: {
+        selector: [".upanel-label:contains('发布数') + .upanel-value"],
+        filters: [{ name: "parseNumber" }],
+        text: 0,
+      },
+      // 做种数（user_panel 汇总行：真实总数）
+      seeding: {
+        selector: [".upanel-label:contains('做种数') + .upanel-value"],
+        filters: [{ name: "parseNumber" }],
+        text: 0,
+      },
+      // 做种量（user_panel 汇总行：真实总量）
+      seedingSize: {
+        selector: [".upanel-label:contains('做种量') + .upanel-value"],
+        filters: [{ name: "parseSize" }],
+        text: 0,
+      },
+      // 总流量（上传+下载）
+      totalTraffic: {
+        selector: [".upanel-label:contains('总流量') + .upanel-value"],
+        filters: [{ name: "parseSize" }],
+      },
+      // 下载中数
+      leeching: {
+        selector: [".upanel-label:contains('下载中') + .upanel-value"],
+        filters: [{ name: "parseNumber" }],
+        text: 0,
+      },
+      // 完成种子数
+      snatches: {
+        selector: [".upanel-label:contains('完成数') + .upanel-value"],
+        filters: [{ name: "parseNumber" }],
+        text: 0,
+      },
+      // 消息数
+      messageCount: {
+        selector: [".upanel-label:contains('消息数') + .upanel-value"],
+        filters: [{ name: "parseNumber" }],
+        text: 0,
+      },
+      // 头像
+      avatar: {
+        selector: ".upanel-header img",
+        attr: "src",
+      },
+    },
+  },
+
+  noLoginAssert: {
+    // 未登录时 torrents.php 会 302 到 member.php?mod=logging&action=login（URL 含 "login" 已足够判断）
+    // ⚠️ 不能用 formhash 作判据：Discuz 所有已登录页面都含 <input name="formhash">，会导致已登录被误判为未登录
+    urlPatterns: [/member\.php\?mod=logging|action=login|logging/i],
+    matchSelectors: ["form[name='login']", "div#mainbox form[name='login']"],
+  },
+};
+
+export default class YzYY extends PrivateSite {
+  /**
+   * 构造种子下载链接
+   * - 列表页 link 已是 plugin.php?id=dz_seed:seed_detail&action=download&info_hash=... 时直接返回
+   * - 帖子详情页 link 是 download.php?info_hash=...，无需转换
+   * - 兜底：用 info_hash 构造 download.php 下载链接
+   */
+  public override async getTorrentDownloadLink(torrent: ITorrent): Promise<string> {
+    const mockRequestConfig = torrent.url?.startsWith("http")
+      ? { url: torrent.url }
+      : { baseURL: this.url };
+    if (torrent.link) {
+      return this.fixLink(torrent.link, mockRequestConfig);
+    }
+    // 兜底：用 info_hash 构造（torrent.id 是 info_hash）
+    if (torrent.id) {
+      return this.fixLink(`/download.php?info_hash=${torrent.id}`, mockRequestConfig);
+    }
+    return super.getTorrentDownloadLink(torrent);
+  }
+}

--- a/src/packages/site/definitions/yzyy.ts
+++ b/src/packages/site/definitions/yzyy.ts
@@ -25,7 +25,7 @@ import { type ISiteMetadata, type ITorrent } from "../types";
 import PrivateSite from "../schemas/AbstractPrivateSite.ts";
 
 export const siteMetadata: ISiteMetadata = {
-  version: 20260810,
+  version: 20260813,
   id: "yzyy",
   name: "YzYY",
   aka: [],
@@ -81,23 +81,25 @@ export const siteMetadata: ISiteMetadata = {
         text: "",
       },
       time: {
-        selector: "td:nth-child(5)",
-        attr: "title",
+        selector: ":self",
+        attr: "data-time",
         text: 0,
-        filters: [{ name: "parseTime", args: ["yyyy-MM-dd HH:mm"] }],
       },
       size: {
-        selector: "td:nth-child(6)",
+        selector: ":self",
+        attr: "data-size",
         text: 0,
         filters: [{ name: "parseSize" }],
       },
       seeders: {
-        selector: "td:nth-child(7)",
+        selector: ":self",
+        attr: "data-seeders",
         text: 0,
         filters: [{ name: "parseNumber" }],
       },
       leechers: {
-        selector: "td:nth-child(8)",
+        selector: ":self",
+        attr: "data-leechers",
         text: 0,
         filters: [{ name: "parseNumber" }],
       },
@@ -106,7 +108,8 @@ export const siteMetadata: ISiteMetadata = {
       },
       // 评论数（列表第4列：💬 0）
       comments: {
-        selector: "td:nth-child(4)",
+        selector: ":self",
+        attr: "data-replies",
         text: 0,
         filters: [{ name: "parseNumber" }],
       },
@@ -165,6 +168,98 @@ export const siteMetadata: ISiteMetadata = {
     {
       urlPattern: ["/torrents.php"],
       selectors: {
+        rows: {
+          selector: "#listWrap table tbody tr",
+        },
+        id: {
+          selector: 'td:last-child a[href*="info_hash="]',
+          attr: "href",
+          filters: [{ name: "querystring", args: ["info_hash"] }],
+        },
+        url: {
+          selector: 'td.nfo .tt a[href*="viewthread"]',
+          attr: "href",
+        },
+        link: {
+          selector: 'td:last-child a[href*="info_hash="]',
+          attr: "href",
+        },
+        title: {
+          selector: 'td.nfo .tt a[href*="viewthread"]',
+          text: "",
+        },
+        subTitle: {
+          selector: "td.nfo .sb",
+          text: "",
+        },
+        time: {
+          selector: ":self",
+          attr: "data-time",
+          text: 0,
+        },
+        size: {
+          selector: ":self",
+          attr: "data-size",
+          text: 0,
+          filters: [{ name: "parseSize" }],
+        },
+        seeders: {
+          selector: ":self",
+          attr: "data-seeders",
+          text: 0,
+          filters: [{ name: "parseNumber" }],
+        },
+        leechers: {
+          selector: ":self",
+          attr: "data-leechers",
+          text: 0,
+          filters: [{ name: "parseNumber" }],
+        },
+        completed: {
+          text: "-",
+        },
+        comments: {
+          selector: ":self",
+          attr: "data-replies",
+          text: 0,
+          filters: [{ name: "parseNumber" }],
+        },
+        category: {
+          selector: ".ic",
+          elementProcess: (el: HTMLElement) => {
+            const typeClass = [
+              "ig-movie", "ig-tv", "ig-music", "ig-soft",
+              "ig-movie-anime", "ig-movie-doc", "ig-movie-live", "ig-movie-variety",
+              "ig-tv-anime", "ig-tv-doc", "ig-tv-live", "ig-tv-variety",
+            ];
+            const ics = el.querySelectorAll(".ic span.ig");
+            for (const ic of Array.from(ics)) {
+              const cls = (ic as HTMLElement).className || "";
+              if (typeClass.some((t) => cls.split(/\s+/).includes(t))) {
+                const title = (ic as HTMLElement).getAttribute("title");
+                if (title) return title;
+              }
+            }
+            return "";
+          },
+          text: "",
+        },
+        ext_douban: {
+          selector: ":self",
+          attr: "data-douban",
+          text: "",
+        },
+        ext_imdb: {
+          selector: ":self",
+          attr: "data-imdb",
+          text: "",
+        },
+        tags: [
+          { name: "Free", selector: "td.nfo .tt .pp.fr", color: "blue" },
+          { name: "2xFree", selector: "td.nfo .tt .pp.x2", color: "green" },
+          { name: "50%", selector: "td.nfo .tt .pp.p5", color: "orange" },
+          { name: "New", selector: "td.nfo .tt .nt", color: "red" },
+        ],
         // YzYY 搜索框只有 id="keyword"，没有 name 属性，必须显式用 #keyword
         keywords: {
           selector: "input#keyword",

--- a/yzyy-adaptation.md
+++ b/yzyy-adaptation.md
@@ -1,0 +1,225 @@
+# YzYY 站点适配 PT-Depiler 技术文档
+
+> 本文档描述 YzYY 站点在 PT-Depiler 中的适配实现，所有内容基于**外部可观察的行为**
+> （浏览器访问页面、DOM 结构、HTTP 请求/响应），不依赖 YzYY 站方源码。
+> 供 PT-Depiler 使用者 / 贡献者 / 二次开发者参考。
+
+## 一、适配文件
+
+- `src/packages/site/definitions/yzyy.ts`：YzYY 站点适配定义
+- 已合入官方主仓库：https://github.com/pt-plugins/PT-depiler
+- 使用方式：扩展加载后，在「站点设置」添加 YzYY 即可（若未内置则重新构建）
+
+## 二、站点概况
+
+| 项 | 值 | 说明 |
+|----|-----|------|
+| 主域名 | https://www.yzyy.org/ | ROT13：`uggcf://jjj.lmll.bet/` |
+| 备用域名 | https://bbs.yzyy.asia/ | ROT13：`uggcf://oof.lmll.nfvn/`；两个域名都放 `urls` |
+| 架构 | Discuz X3.5 论坛 + 自定义种子聚合模块 | 非标准 NexusPHP（无 details.php?id=） |
+| 种子列表页 | `https://www.yzyy.org/torrents.php` | 服务端渲染完整 HTML；`?ajax=1` 返回 JSON |
+| 种子详情页 | `https://www.yzyy.org/forum.php?mod=viewthread&tid={tid}` | Discuz 帖子页 |
+| 种子 ID | **info_hash**（40 位 hex） | **不是 tid**；tid 只用于帖子 URL |
+| 登录 | 标准 Discuz 登录（`member.php?mod=logging`） | PT-Depiler 需带 cookie |
+
+**种子 ID 与 URL 的关系**：
+- 列表页每行种子有**两个关键链接**：
+  - 详情链接：`forum.php?mod=viewthread&tid={tid}` → 种子的 `url`
+  - 下载链接：`plugin.php?id=dz_seed:seed_detail&action=download&info_hash={hash}` → 种子的 `link`，`info_hash` 即种子 `id`
+- PT-Depiler 的 `id` = info_hash（下载构造用），`url` = 帖子链接（详情跳转用）
+
+## 三、种子列表页（torrents.php）DOM 结构
+
+`torrents.php` 默认返回**服务端渲染的完整 HTML**（不是 SPA，无需执行 JS 就有数据），种子在 `#listWrap` 表格中。
+
+```html
+<div class="lst" id="listWrap">
+  <table>
+    <thead><tr><th></th><th>标题</th><th>评分</th><th>💬</th><th>🕐</th><th>体积</th><th>▲上传</th><th>▼下载</th><th>⬇</th></tr></thead>
+    <tbody>
+      <tr id="row_{tid}"
+          data-sticky data-title data-rating data-time data-size data-seeders data-leechers
+          data-douban="{豆瓣ID}" data-imdb="{IMDbID}">
+        <td class="pw"><a href="https://www.yzyy.org/forum.php?mod=viewthread&tid={tid}"><img src="{poster}"></a></td>
+        <td class="nfo">
+          <div class="tt">
+            <a href="https://www.yzyy.org/forum.php?mod=viewthread&tid={tid}" title="{英文名}">{英文名}</a>
+            <span class="nt">New</span>            <!-- 新种标签（可选） -->
+            <span class="pp fr">Free</span>         <!-- 促销标签：fr=Free, x2=2x, p5=50% -->
+          </div>
+          <div class="sb" title="{中文副标题}">{中文副标题}</div>
+          <div class="ic"><span class="ig ig-movie" title="电影">电影</span><span class="ig ig-enc" title="Encode">Encode</span>...</div>
+        </td>
+        <td><span class="rtg_{tid}"></span></td>   <!-- 评分占位，JS 填充（见"评分"节） -->
+        <td style="text-align:center;" title="评论">💬 {replies}</td>
+        <td title="{yyyy-MM-dd HH:mm}">{相对时间}</td>
+        <td>{size}</td>
+        <td>▲{seeders}</td>
+        <td>▼{leechers}</td>
+        <td><a href="https://www.yzyy.org/plugin.php?id=dz_seed:seed_detail&action=download&info_hash={hash}">⬇</a></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+```
+
+### 列表页字段选择器（yzyy.ts 已固化）
+
+| 字段 | 选择器 | 说明 |
+|------|--------|------|
+| `rows` | `#listWrap table tbody tr` | 每行一个种子 |
+| `id` | `td:last-child a[href*="info_hash="]` attr=href → querystring `info_hash` | 种子 ID = info_hash |
+| `url` | `td.nfo .tt a[href*="viewthread"]` attr=href | 详情链接 |
+| `link` | `td:last-child a[href*="info_hash="]` attr=href | 下载链接 |
+| `title` | `td.nfo .tt a[href*="viewthread"]` **取文本内容** | ⚠️ 勿用 title 属性（曾因缺失致标题空白）；文本=英文名 |
+| `subTitle` | `td.nfo .sb` **取文本内容** | ⚠️ 同样勿用 title 属性；文本=中文副标题 |
+| `time` | `td:nth-child(5)` attr=title + parseTime(`yyyy-MM-dd HH:mm`) | 时间在 title 属性 |
+| `size` | `td:nth-child(6)` + parseSize | |
+| `seeders` | `td:nth-child(7)` + parseNumber | 文本带 ▲ 前缀 |
+| `leechers` | `td:nth-child(8)` + parseNumber | 文本带 ▼ 前缀 |
+| `comments` | `td:nth-child(4)` + parseNumber | `💬 0` |
+| `completed` | 固定 `text: "-"` | YzYY 列表无"完成数"列 |
+| `category` | `.ic` 内类型图标 `title` 属性 | 见下 |
+| `ext_douban` | `:self` attr `data-douban` | 行属性（见"评分"节） |
+| `ext_imdb` | `:self` attr `data-imdb` | 行属性（见"评分"节） |
+| `tags` | `td.nfo .tt .pp.fr`(Free) / `.pp.x2`(2x) / `.pp.p5`(50%) / `.nt`(New) | 促销/新种标签 |
+
+**category（分类）解析要点**：`.ic` 里的类型图标是 `<span class="ig ig-类型" title="中文分类名">`，如 `ig-movie`(电影)、`ig-tv`(电视剧)、`ig-music`(音乐)、`ig-soft`(软件)、`ig-movie-anime`(动画)、`ig-movie-doc`(纪录片)、`ig-movie-live`(演唱会)、`ig-movie-variety`(综艺)、`ig-tv-anime`(番剧) 等。用 elementProcess 遍历 `.ic span.ig`，匹配这些类型 class 取 `title`，**排除** `ig-pin`(置顶)/`ig-off`(官组)/`ig-enc`(Encode)/`ig-zh`(中字)/`ig-hr`(HR)/`ig-nr`(禁转) 等非类型图标。
+
+## 四、种子详情页（Discuz 帖子）DOM
+
+- 下载按钮：`a#dz_seed_dl_btn[href*="download.php?info_hash="]`（在 `#dz_seed_dl_wrap` 容器内）
+- 标题：`#thread_subject` / `h1#thread_subject`
+- 种子 ID = info_hash：从下载按钮 href 的 `info_hash` 参数提取
+
+## 五、IMDb / 豆瓣 ID 搜索
+
+`torrents.php` 的 `keyword` 参数支持三种匹配（页面上有对应的快速搜索框：`douban:`/`imdb:`/标题）：
+
+| 搜索词 | 示例 URL | 匹配逻辑 |
+|--------|----------|----------|
+| IMDb ID | `?keyword=tt0063183` | 匹配种子 IMDb ID |
+| 豆瓣 ID | `?keyword=2033997` | 匹配种子豆瓣 ID |
+| 标题 | `?keyword=追魂镖` | 标题 LIKE |
+
+**PT-Depiler 侧配置**（yzyy.ts 已含）：
+```js
+advanceKeywordParams: { imdb: { enabled: true }, douban: { enabled: true } },
+```
+- 必须显式配置 `douban: { enabled: true }`，否则 `douban|xxx` 高级搜索词会被跳过（PT-Depiler 默认只放行 imdb）
+- `imdb` 未声明时 PT-Depiler 有内置 fallback 放行，但显式声明更明确
+
+**匹配行为**：
+- IMDb 搜索词必须**保留 `tt` 前缀**（`tt0063183`），帖子正文里的 IMDb 链接是 `https://www.imdb.com/title/tt0063183/`
+- 豆瓣 ID 是纯数字（如 `2033997`），帖子正文里的豆瓣链接是 `https://movie.douban.com/subject/2033997/`
+- **历史种子**（发布时未填豆瓣/IMDb ID）也能被 ID 搜索命中——站方实现了**帖子正文链接兜底**（发布工具在帖子正文写入 `【豆瓣链接】...` / `【IMDb链接】...`）
+
+## 六、评分显示与评分图标超链接
+
+YzYY 网页上所有评分徽章（豆瓣 X / IMDb Y）都**可点击**，点击直接打开对应影视页：
+- 豆瓣徽章 → `https://movie.douban.com/subject/{豆瓣ID}/`
+- IMDb 徽章 → `https://www.imdb.com/title/{IMDbID}/`
+
+评分徽章出现在三个位置：
+1. **torrents.php 聚合列表**（评分列，JS 填充 `.rtg_{tid}`）
+2. **论坛板块列表页**（Discuz 帖子列表，标题旁）
+3. **帖子详情页**（基本信息栏右侧）
+
+**对 PT-Depiler 的意义**：
+- 列表页每行 tr 带 `data-douban`（豆瓣ID）/`data-imdb`（IMDb ID）属性，PT-Depiler 解析为 `ext_douban`/`ext_imdb`
+- 有了 ext_douban/ext_imdb，PT-Depiler 标题区的豆瓣/IMDb 图标（`showSocialInformation`）会显示，悬停可看评分、跳转外站
+- 即使种子 DB 没存 did/iid（历史种子），站方也会从帖子正文兜底提取到行属性上
+
+## 七、用户信息（userInfo）
+
+YzYY 提供 **`https://www.yzyy.org/plugin.php?id=dz_seed:user_panel`** 作为当前登录用户的完整 PT 数据面板。页面结构：`.upanel-row` 用 `.upanel-label`（字段名）+ `.upanel-value`（值）相邻兄弟。
+
+### user_panel 页提供的字段
+
+- 用户名（`.upanel-header h2`，可能带 ★VIP / ⚠ 警告图标，需过滤）、注册日期、上次访问、等级、上传量、下载量、分享率、总流量、发布数、做种数、做种量、下载中、完成数、魔力、消息数、邀请、HR
+- 头像：`.upanel-header img` 的 src
+- 发布数/做种数/做种量/下载中/完成数等是**服务端真实统计**（非表格行数）
+
+### yzyy.ts userInfo 配置要点
+
+- `process` 两步请求：
+  1. `plugin.php?id=dz_seed:user_panel`（responseType: document）→ 大部分字段
+  2. `plugin.php?id=dz_seed:mybonus` → 取**时魔 bonusPerHour**（`table.dz-mb-table tbody tr.my td.hl:last-of-type`=每小时魔力）和 **seedingBonusPerHour**（`tr.my td.hl:first-of-type`=每小时积分）
+- 字段选择器统一用 `.upanel-label:contains('字段名') + .upanel-value` + parseNumber/parseSize
+- 时魔**不在 user_panel 页展示**（站方只显示积分），故单独从 mybonus 页取
+- `pickLast: ["id"]`
+
+### 字段名对照（.upanel-label 文本）
+
+| 字段 | label 文本 | 解析 |
+|------|-----------|------|
+| `joinTime` | 注册日期 | parseTime `yyyy-MM-dd HH:mm` |
+| `levelName` | 等级 | 文本 |
+| `uploaded` | 上传量 | parseSize |
+| `downloaded` | 下载量 | parseSize |
+| `ratio` | 分享率 | parseNumber |
+| `bonus` | 魔力 | parseNumber |
+| `totalTraffic` | 总流量 | parseSize |
+| `uploads` | 发布数 | parseNumber |
+| `seeding` | 做种数 | parseNumber |
+| `seedingSize` | 做种量 | parseSize |
+| `leeching` | 下载中 | parseNumber |
+| `snatches` | 完成数 | parseNumber |
+| `messageCount` | 消息数 | parseNumber |
+| `invites` | 邀请 | parseNumber |
+| `avatar` | `.upanel-header img` | src |
+
+## 八、noLoginAssert（登录判定）
+
+```js
+noLoginAssert: {
+  urlPatterns: [/member\.php\?mod=logging|action=login|logging/i],
+  matchSelectors: ["form[name='login']", "div#mainbox form[name='login']"],
+},
+```
+⚠️ **不能用 formhash 作判据**：Discuz 已登录页面也含 `<input name="formhash">`，会误判未登录（曾导致一键导入 0 成功）。
+
+## 九、已知注意点 / 适配坑
+
+1. **搜索框无 `name` 属性**：列表页搜索框只有 `id="keyword"`，keywords 选择器必须用 `input#keyword`
+2. **时间格式**：`yyyy-MM-dd HH:mm`（无秒），parseTime args 指定
+3. **列表页是服务端渲染 + JS AJAX 双模式**：用 `responseType: document` 拿服务端 HTML，JS 不执行，列表可解析；`?ajax=1` 才返回 JSON
+4. **fid 30/31 是"高清修复区"**：会员 AI 修复资源，种子带 `no_repost`（禁转）标记（列表 `.ig-nr` 图标），解析不受影响，但注意转发合规
+5. **种子 ID 用 info_hash**：`id`=info_hash（下载构造），`url`=帖子链接（详情跳转），两者区分
+6. **标题/副标题取文本内容**：`.tt a`/`.sb` 都取文本（勿用 title 属性，曾因此标题空白）
+7. **IMDb/豆瓣 ID 搜索**：`advanceKeywordParams` 显式配置 `imdb`/`douban` enabled（douban 默认被跳过）
+8. **评分/外站信息**：`ext_douban`/`ext_imdb` 从行 `data-douban`/`data-imdb` 属性取（站方已输出）
+9. **分类**：从 `.ic` 类型图标 title 取（见第三节）
+
+## 十、版本号
+
+- yzyy.ts 的 `version` 用 YYYYMMDD 格式（如 `20260813`），每次调整适配会递增
+- 站方服务端功能（搜索/评分链接/user_panel）由站方维护
+
+## 十一、功能测试清单
+
+1. **添加站点**：添加 YzYY，应显示两个域名可选项（www.yzyy.org / bbs.yzyy.asia）
+2. **列表解析**：登录后打开 `torrents.php`，快捷操作（下载/复制/搜索）应可用；title/subTitle/category/size/seeders/leechers/comments 应正确
+3. **详情页**：打开某帖子，应能识别下载按钮
+4. **豆瓣/IMDb 搜索**：搜索 `douban|2033997`（追魂镖）或 `imdb|tt0063183`，YzYY 应返回结果
+5. **用户信息**："我的数据"显示用户名/等级/上传下载/魔力/时魔等
+6. **评分外站信息**：标题区显示豆瓣/IMDb 图标（可悬停看评分）
+
+## 十二、常见问题（FAQ）
+
+**Q: 为什么 douban|xxx 搜索无结果？**
+A: 若 `advanceKeywordParams` 未配置 `douban: { enabled: true }`，PT-Depiler 会跳过该高级搜索词。已配置则正常。
+
+**Q: 为什么搜索 IMDb ID 用 tt 前缀匹配不到？**
+A: IMDb 帖子链接是 `title/tt0063183`（带 tt），匹配必须保留 tt。豆瓣是 `subject/2033997`（纯数字）。
+
+**Q: 历史种子 did/iid 为空，评分链接会不会失效？**
+A: 站方已实现帖子正文链接兜底（发布时正文必有豆瓣/IMDb 链接），列表页 data-douban/data-imdb 和评分徽章链接都会自动带上 ID。
+
+**Q: 登录判定为什么不能用 formhash？**
+A: Discuz 已登录页面也含 formhash，会误判未登录。用 URL 判据（member.php?mod=logging/login）+ 登录表单选择器。
+
+## 十三、维护与更新
+
+- YzYY 适配由 YzYY 站方提供并维护，已合入 PT-Depiler 官方主仓库
+- 若站方服务端行为（搜索匹配、评分链接、user_panel）发生变化，会同步更新本文档与适配文件


### PR DESCRIPTION
修复 torrents.php 页面"推送到默认下载器"报"未解析到当前页面种子"的问题。

YzYY 的种子行 `<tr>` 上有完整的 data-* 属性（data-time/data-size/data-seeders/data-leechers/data-replies），之前选择器用 td:nth-child(N) 无法正确匹配。改为从行属性直接取值。