### PR TITLE
fix(options): 媒体服务器编辑对话框表单渲染中断防护与 en.json 键大小写修正

### DIFF
--- a/src/entries/options/views/Settings/SetMediaServer/Editor.vue
+++ b/src/entries/options/views/Settings/SetMediaServer/Editor.vue
@@ -17,7 +17,9 @@ const emits = defineEmits<{
 }>();
 
 const clientMeta = computedAsync<IMediaServerMetadata>(
-  async () => await getMediaServerMetaData(clientConfig.value!.type),
+  // clientConfig 在编辑对话框 after-enter 时才赋值，computedAsync 首次求值可能尚未就绪，需空值短路
+  async () =>
+    clientConfig.value?.type ? await getMediaServerMetaData(clientConfig.value.type) : ({} as IMediaServerMetadata),
   {} as IMediaServerMetadata,
 );
 const formValid = ref<boolean>(false);
@@ -66,7 +68,9 @@ async function checkConnect() {
         </v-row>
 
         <v-row>
-          <v-col class="py-0"><v-label>{{ t("SetMediaServer.Editor.authInfo") }}</v-label></v-col>
+          <v-col class="py-0"
+            ><v-label>{{ t("SetMediaServer.Editor.authInfo") }}</v-label></v-col
+          >
           <v-col v-for="(auth_field, index) in clientMeta!.auth_field" :key="index" cols="12">
             <template v-if="typeof auth_field === 'string'">
               <v-text-field

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -534,7 +534,7 @@
   },
   "SetBase": {
     "download": {
-      "MyClientTitle": "My Downloader",
+      "myClientTitle": "My Downloader",
       "allowDirectSendToClient": "Allow sending links directly (instead of torrent files) to the download server (Do not enable unless necessary)",
       "enableSiteFilter": "Enable site filter (configure per-downloader site filtering in downloader settings)",
       "initDownloaderTorrentOnEnter": "Automatically load torrents from the downloader when entering the My Downloader page",


### PR DESCRIPTION
发布前巡检发现的两处小问题。

**主要问题**
1. `SetMediaServer/Editor.vue` 的 `clientMeta` computedAsync 首次求值时 `clientConfig` 尚未赋值（EditDialog 需等 v-dialog 的 after-enter 才填充），`clientConfig.value!.type` 读取 undefined 的 `.type` 抛出 TypeError 会打断组件渲染，表现为编辑媒体服务器对话框表单空白。与 #1461 中 SetDownloader/Editor.vue 同源问题（SetBackup 的对应实现本就有空值防护，三处写法不一致）。
2. `src/locales/en.json` 中 `SetBase.download.MyClientTitle` 键大小写与模板引用（`t("SetBase.download.myClientTitle")`）不一致，英文界面该条目回退；zh_CN.json 键名本就正确。

**解决方法**
1. clientConfig 未就绪时短路返回初始空对象，待 after-enter 赋值后自动重新求值（与 #1461 的修法一致）。
2. en.json 键名改为 `myClientTitle`。

**测试流程及结果**
- vue-tsc 零错误、vite build 通过；
- CFT 真机验证：注入 emby 媒体服务器配置后连续开合编辑对话框 5 次，表单均正常渲染（5/5）；
- 构建产物静态断言：无 MyClientTitle 大写残留，myClientTitle 小写键随 DownloadWindow chunk 正常打包。