### PR TITLE
perf(content-script): 拆分轻量引导与按需加载

### DIFF
--- a/src/entries/content-script/app/init.ts
+++ b/src/entries/content-script/app/init.ts
@@ -48,16 +48,14 @@ export function mountApp(document: Document, data: any = {}) {
       shadowRoot.appendChild(mdiCssElement);
     });
 
-  // 将构造过程中产生的样式 pt-depiler.css / pt-depiler-components.css 添加到 shadow DOM 中
-  // （多页构建拆分出的两份样式：vuetify 基础组件样式 + cs-app 入口组件样式，
-  //   动态 import 不会自动加载 css，需按固定地址显式引入）
-  for (const cssFile of ["pt-depiler.css", "pt-depiler-components.css"]) {
-    const buildStyleElement = document.createElement("link");
-    buildStyleElement.id = `ptd-content-script-style-build-${cssFile.replace(".css", "")}`;
-    buildStyleElement.rel = "stylesheet";
-    buildStyleElement.href = chrome.runtime.getURL(cssFile);
-    shadowRoot.appendChild(buildStyleElement);
-  }
+  // 将构造过程中产生的样式 pt-depiler.css 添加到 shadow DOM 中
+  // （cssCodeSplit=false 后全量样式合并为该单一文件——动态 import 不会自动加载
+  //   css 分片，页面上下文需按固定地址显式引入）
+  const buildStyleElement = document.createElement("link");
+  buildStyleElement.id = "ptd-content-script-style-build";
+  buildStyleElement.rel = "stylesheet";
+  buildStyleElement.href = chrome.runtime.getURL("pt-depiler.css");
+  shadowRoot.appendChild(buildStyleElement);
 
   // 在 shadow DOM 中创建一个 html 作为所有元素的容器
   const appMountElement = document.createElement("div");

--- a/src/entries/content-script/app/init.ts
+++ b/src/entries/content-script/app/init.ts
@@ -48,12 +48,16 @@ export function mountApp(document: Document, data: any = {}) {
       shadowRoot.appendChild(mdiCssElement);
     });
 
-  // 将构造过程中产生的样式 pt-depiler.css 添加到 shadow DOM 中
-  const buildStyleElement = document.createElement("link");
-  buildStyleElement.id = "ptd-content-script-style-build";
-  buildStyleElement.rel = "stylesheet";
-  buildStyleElement.href = chrome.runtime.getURL("pt-depiler.css");
-  shadowRoot.appendChild(buildStyleElement);
+  // 将构造过程中产生的样式 pt-depiler.css / pt-depiler-components.css 添加到 shadow DOM 中
+  // （多页构建拆分出的两份样式：vuetify 基础组件样式 + cs-app 入口组件样式，
+  //   动态 import 不会自动加载 css，需按固定地址显式引入）
+  for (const cssFile of ["pt-depiler.css", "pt-depiler-components.css"]) {
+    const buildStyleElement = document.createElement("link");
+    buildStyleElement.id = `ptd-content-script-style-build-${cssFile.replace(".css", "")}`;
+    buildStyleElement.rel = "stylesheet";
+    buildStyleElement.href = chrome.runtime.getURL(cssFile);
+    shadowRoot.appendChild(buildStyleElement);
+  }
 
   // 在 shadow DOM 中创建一个 html 作为所有元素的容器
   const appMountElement = document.createElement("div");

--- a/src/entries/content-script/index.ts
+++ b/src/entries/content-script/index.ts
@@ -1,7 +1,6 @@
 // This file is the entry point for the content script
 
 import { getHostFromUrl } from "@ptd/site";
-import { socialPageParserMatchesMap } from "@ptd/social";
 
 import { sendMessage } from "@/messages.ts";
 import type { IMetadataPiniaStorageSchema } from "@/shared/types/storages/metadata.ts";
@@ -14,14 +13,11 @@ sendMessage("getExtStorage", "config").then(async (data) => {
 
   if (configStore?.contentScript?.enabled ?? true) {
     if (configStore?.contentScript?.enabledAtSocialSite ?? true) {
-      for (const [socialSite, patternMatches] of Object.entries(socialPageParserMatchesMap)) {
-        for (const [pattern, _] of patternMatches) {
-          if (new RegExp(pattern, "i").test(window.location.href)) {
-            console.debug(`[PTD] Social site detected: ${socialSite}, loading app...`);
-            mountApp(document, { socialSite });
-            return; // 找到匹配的 social site 后，直接加载应用并退出
-          }
-        }
+      const socialSite = await sendMessage("matchSocialPage", window.location.href);
+      if (socialSite) {
+        console.debug(`[PTD] Social site detected: ${socialSite}, loading app...`);
+        mountApp(document, { socialSite });
+        return; // 找到匹配的 social site 后，直接加载应用并退出
       }
     }
 

--- a/src/entries/content-script/index.ts
+++ b/src/entries/content-script/index.ts
@@ -1,12 +1,25 @@
 // This file is the entry point for the content script
+//
+// 此入口应保持轻量（仅做"当前页面是否需要挂载"的判断），
+// 重资源（Vue/Vuetify/站点包）都在多页构建的 assets/cs-app.js 中按需加载；
+// social 匹配判断经消息由 offscreen 代查，避免把 social 包打进引导（见 issue #1467）。
 
-import { getHostFromUrl } from "@ptd/site";
+import { getHostFromUrl } from "@ptd/site/utils/html.ts";
 
 import { sendMessage } from "@/messages.ts";
 import type { IMetadataPiniaStorageSchema } from "@/shared/types/storages/metadata.ts";
 import type { IConfigPiniaStorageSchema } from "@/shared/types/storages/config.ts";
 
-import { mountApp } from "./app/init.ts";
+async function loadApp(props: Parameters<(typeof import("./app/init.ts"))["mountApp"]>[1]) {
+  // 运行时从扩展包内加载多页构建产出的 ESM 入口（assets/cs-app.js，固定文件名），
+  // @vite-ignore 阻止本入口（IIFE 单文件构建）将 app 静态打进引导
+  const appUrl = chrome.runtime.getURL("assets/cs-app.js");
+  console.debug("[PTD] loading app from", appUrl);
+  const { mountApp } = (await import(/* @vite-ignore */ appUrl)) as typeof import("./app/init.ts");
+  console.debug("[PTD] app module loaded");
+  await mountApp(document, props);
+  console.debug("[PTD] app mounted");
+}
 
 sendMessage("getExtStorage", "config").then(async (data) => {
   const configStore = data as IConfigPiniaStorageSchema;
@@ -16,7 +29,7 @@ sendMessage("getExtStorage", "config").then(async (data) => {
       const socialSite = await sendMessage("matchSocialPage", window.location.href);
       if (socialSite) {
         console.debug(`[PTD] Social site detected: ${socialSite}, loading app...`);
-        mountApp(document, { socialSite });
+        await loadApp({ socialSite });
         return; // 找到匹配的 social site 后，直接加载应用并退出
       }
     }
@@ -39,7 +52,7 @@ sendMessage("getExtStorage", "config").then(async (data) => {
         }
 
         console.debug(`[PTD] host found for site: ${siteId}, loading app...`);
-        mountApp(document, { siteId });
+        await loadApp({ siteId });
       }
     });
   }

--- a/src/entries/messages.ts
+++ b/src/entries/messages.ts
@@ -145,6 +145,8 @@ interface ProtocolMap extends TMessageMap {
 
   // 2.5 社交信息 ( utils/socialInformation )
   getSocialInformation(data: { site: TSupportSocialSite$1; sid: string }): ISocialInformation;
+  // 判断 URL 命中的社交站点（供 content-script 引导做轻量预筛，避免把 social 包打进引导，见 issue #1467）
+  matchSocialPage(url: string): TSupportSocialSite$1 | null;
   getSocialRecommendations(data?: {
     flush?: boolean;
     enrichment?: "all" | "none" | "visible";

--- a/src/entries/offscreen/utils/socialInformation.ts
+++ b/src/entries/offscreen/utils/socialInformation.ts
@@ -1,5 +1,5 @@
 import type { ISocialInformation, TSupportSocialSite$1 } from "@ptd/social";
-import { getSocialSiteInformation } from "@ptd/social";
+import { getSocialSiteInformation, socialPageParserMatchesMap } from "@ptd/social";
 
 import { onMessage, sendMessage } from "@/messages.ts";
 import type { IConfigPiniaStorageSchema } from "@/shared/types.ts";
@@ -55,6 +55,19 @@ export async function getSocialInformation(
 }
 
 onMessage("getSocialInformation", async ({ data: { site, sid } }) => await getSocialInformation(site, sid));
+
+// content-script 引导的轻量预筛：social 包的正则聚合在本上下文已有完整依赖，
+// 由这里判断后回传命中的社交站点名，引导无需携带 social 包（见 issue #1467）
+onMessage("matchSocialPage", async ({ data: url }) => {
+  for (const [socialSite, patternMatches] of Object.entries(socialPageParserMatchesMap)) {
+    for (const [pattern] of patternMatches) {
+      if (new RegExp(pattern, "i").test(url)) {
+        return socialSite as TSupportSocialSite$1;
+      }
+    }
+  }
+  return null;
+});
 
 export async function setSocialInformation(site: TSupportSocialSite$1, sid: string, val: ISocialInformation) {
   const key = `${site}:${sid}`;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -155,6 +155,13 @@ export default defineConfig({
             resources: ["icons/*", "lib/*", "pt-depiler.css"],
             matches: ["*://*/*"],
           },
+          // content script 的按需主逻辑（assets/cs-app.js）及其共享 chunk 依赖链，
+          // 由轻量引导在匹配站点时于页面上下文动态 import 加载（见 issue #1467）。
+          // 使用通配以避免依赖拓扑变化后遗漏新 chunk 导致运行时加载失败。
+          {
+            resources: ["assets/*", "vendor/*"],
+            matches: ["*://*/*"],
+          },
         ],
       }),
       // vite-plugin-web-extension 会在构造中，将js中引入的css文件自动添加到 manifest 中的 content_scripts 中，我们不需要这种默认行为
@@ -170,6 +177,23 @@ export default defineConfig({
       watchFilePaths: ["package.json"],
       htmlViteConfig: {
         plugins: [
+          {
+            name: "cs-app-entry",
+            config(config) {
+              // content script 的重逻辑（Vue/Vuetify/站点包）挂到多页 ESM 构建中作为额外入口，
+              // 产物 assets/cs-app.js 由轻量引导在匹配站点时通过 chrome.runtime.getURL 动态加载，
+              // 并直接复用 options 构建已拆分的 vendor chunk（见 issue #1467）。
+              config.build ??= {};
+              config.build.rollupOptions ??= {};
+              config.build.rollupOptions.input ??= {};
+              (config.build.rollupOptions.input as Record<string, string>)["cs-app"] = base_path(
+                "src/entries/content-script/app/init.ts",
+              );
+              // 该入口仅由 content script 引导在运行时动态 import（构建期无静态消费者），
+              // 必须保留入口导出签名，否则 mountApp 会被 rollup 树摇成纯副作用壳
+              config.build.rollupOptions.preserveEntrySignatures = "strict";
+            },
+          },
           {
             name: "sort-asserts",
             config(config) {
@@ -201,7 +225,13 @@ export default defineConfig({
 
                   return "assets/[name]-[hash].js"; // vite default
                 },
-                entryFileNames: "assets/[name]-[hash].js", // vite default
+                entryFileNames: (chunkInfo) => {
+                  // cs-app 的加载地址写死在 content script 引导里，必须使用稳定文件名（不带 hash）
+                  if (chunkInfo.name === "cs-app") {
+                    return "assets/cs-app.js";
+                  }
+                  return "assets/[name]-[hash].js"; // vite default
+                },
                 assetFileNames: (assetInfo) => {
                   const assetName = assetInfo.names[0] || "";
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -152,7 +152,7 @@ export default defineConfig({
 
         web_accessible_resources: [
           {
-            resources: ["icons/*", "lib/*", "pt-depiler.css"],
+            resources: ["icons/*", "lib/*", "pt-depiler.css", "pt-depiler-components.css"],
             matches: ["*://*/*"],
           },
           // content script 的按需主逻辑（assets/cs-app.js）及其共享 chunk 依赖链，
@@ -235,8 +235,17 @@ export default defineConfig({
                 assetFileNames: (assetInfo) => {
                   const assetName = assetInfo.names[0] || "";
 
-                  // 将 css 文件放到 assets/css 目录下
+                  // 将 css 文件放到 assets/css 目录
                   if (assetName.endsWith(".css")) {
+                    // cs-app（content script 按需主逻辑）依赖的两份样式：vuetify 基础组件样式与
+                    // cs-app 入口组件样式。动态 import 不会自动加载 css 分片，它们由 app/init.ts 在
+                    // shadow DOM 中按固定地址 link，必须输出到根目录且使用稳定文件名
+                    if (assetName === "vuetify.css") {
+                      return "pt-depiler.css";
+                    }
+                    if (assetName === "cs-app.css") {
+                      return "pt-depiler-components.css";
+                    }
                     return "assets/css/[name]-[hash][extname]";
                   }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -152,7 +152,7 @@ export default defineConfig({
 
         web_accessible_resources: [
           {
-            resources: ["icons/*", "lib/*", "pt-depiler.css", "pt-depiler-components.css"],
+            resources: ["icons/*", "lib/*", "pt-depiler.css"],
             matches: ["*://*/*"],
           },
           // content script 的按需主逻辑（assets/cs-app.js）及其共享 chunk 依赖链，
@@ -192,6 +192,10 @@ export default defineConfig({
               // 该入口仅由 content script 引导在运行时动态 import（构建期无静态消费者），
               // 必须保留入口导出签名，否则 mountApp 会被 rollup 树摇成纯副作用壳
               config.build.rollupOptions.preserveEntrySignatures = "strict";
+              // 动态 import 不会自动加载按 chunk 拆分的 css 分片，cs-app 的组件树样式
+              // （vuetify 组件、页面组件等分散在各 chunk 的 css）无法逐份在页面上下文
+              // 引入，故合并为单文件，由 app/init.ts 按固定地址 link
+              config.build.cssCodeSplit = false;
             },
           },
           {
@@ -237,14 +241,11 @@ export default defineConfig({
 
                   // 将 css 文件放到 assets/css 目录
                   if (assetName.endsWith(".css")) {
-                    // cs-app（content script 按需主逻辑）依赖的两份样式：vuetify 基础组件样式与
-                    // cs-app 入口组件样式。动态 import 不会自动加载 css 分片，它们由 app/init.ts 在
-                    // shadow DOM 中按固定地址 link，必须输出到根目录且使用稳定文件名
-                    if (assetName === "vuetify.css") {
+                    // cssCodeSplit=false 后全量样式合并为单一文件；content script 的
+                    // shadow DOM 通过 chrome.runtime.getURL("pt-depiler.css") 固定地址
+                    // 加载（见 app/init.ts），必须输出到根目录且使用稳定文件名
+                    if (assetName === "index.css" || assetName === "style.css") {
                       return "pt-depiler.css";
-                    }
-                    if (assetName === "cs-app.css") {
-                      return "pt-depiler-components.css";
                     }
                     return "assets/css/[name]-[hash][extname]";
                   }


### PR DESCRIPTION
Closes #1467

**主要问题**
content script 以单文件全量注入所有页面（约 2.6MB），绝大多数非 PT/社交站点页面完全不需要，白白消耗内存与脚本解析时间。

**解决方法**
- 入口瘦身为轻量引导（约 4KB）：保留 config/站点/social 判定，匹配后运行时动态 `import(chrome.runtime.getURL("assets/cs-app.js"))` 按需加载主逻辑；
- `app/init.ts` 作为额外入口挂入 options 的多页 ESM 构建（打通此前两个独立入口），直接复用已拆分的 vendor chunk，扩展总包 15.6MB→12.4MB（约 -20%）；
- social 匹配判断改由 offscreen 经 `matchSocialPage` 消息代查（social 包的正则聚合与解析器实现耦合，树摇不掉，此前是引导体积大头）；
- `preserveEntrySignatures: "strict"` 保证该入口导出不被 rollup 树摇（仅运行时动态消费者，构建期不可见）；
- `getHostFromUrl` 改子路径导入避免携带 site 包聚合（SW 的 contextMenus.ts 有同款先例）；
- WAR 暴露 `assets/*`、`vendor/*` 供页面上下文加载动态链（通配防依赖拓扑变化后遗漏）。

**测试流程及结果**
- vue-tsc 零错误；chrome / firefox 双构建通过（Firefox content script 动态 import 已由 bug 1536094 支持，runtime.getURL 解析为 moz-extension://）；
- 产物审计：cs-app 依赖闭包 362 文件零缺失、WAR 模式全覆盖；
- CFT 真机三路径验证：无匹配页引导早退、cs-app 零加载；注入站点映射后动态加载并完成挂载（shadow DOM + 文档字体表痕迹）；真实 douban top250 页 social 匹配加载挂载成功；
- 入口 2,602,840B → 4,399B。