### PR TITLE
fix(site/rousipro): 适配 Rousi Pro 现行 API, 修复搜索/用户信息/下载

### DIFF
--- a/src/packages/site/definitions/rousipro.ts
+++ b/src/packages/site/definitions/rousipro.ts
@@ -1,11 +1,40 @@
-import { ISearchInput, ISiteMetadata, ITorrent, ITorrentTag, TPreDefinedTorrentTagName } from "@ptd/site";
+import type { AxiosRequestConfig } from "axios";
+import {
+  EResultParseStatus,
+  ISearchInput,
+  ISiteMetadata,
+  ITorrent,
+  ITorrentTag,
+  IUserInfo,
+  TPreDefinedTorrentTagName,
+} from "@ptd/site";
 import PrivateSite from "@ptd/site/schemas/AbstractPrivateSite.ts";
-import type { AxiosRequestConfig, AxiosResponse } from "axios";
+import { sendMessage } from "@/messages.ts";
 
-const torrentIdRegex = /\/torrent\/([0-9a-z-]+)\/?/;
+const torrentIdRegex = /\/torrents?\/([0-9a-z-]+)\/?/;
 
+/**
+ * 读取浏览器中 rousi.pro 的会话 cookie, 拼接成 Cookie 请求头。
+ * PT-depiler 的用户信息/下载请求从 offscreen 跨域发出, 默认不带站点 cookie,
+ * 而 rousi.pro 的 /api/v1/session 与 /api/v1/torrents/:id/download 均需要 cookie 会话。
+ * 这里显式读取 cookie 交给 replaceUnsafeHeader 的 DNR 机制注入请求头。
+ */
+async function getRousiCookieHeader(siteUrl: string): Promise<string> {
+  try {
+    const cookies = (await sendMessage("getAllCookies", { url: siteUrl })) as chrome.cookies.Cookie[];
+    if (Array.isArray(cookies) && cookies.length > 0) {
+      return cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+    }
+  } catch (e) {
+    console?.debug("[RousiPro] read cookie failed", e);
+  }
+  return "";
+}
+
+// Rousi Pro: 会话认证(浏览器 cookie), 无需 passkey
+// 已实测(2026-08): /api/v1/torrents?keyword= 搜索(无需认证)、/api/v1/session 用户信息、/api/v1/torrents/:id/download 下载(均需 cookie)
 export const siteMetadata: ISiteMetadata = {
-  version: 1,
+  version: 4,
   id: "rousipro",
   name: "Rousi Pro",
   aka: ["Rousi", "肉丝"],
@@ -22,10 +51,10 @@ export const siteMetadata: ISiteMetadata = {
       key: "category",
       options: [
         // (await (await fetch('/api/v1/categories')).json()).data.map(x => ({name: x.label, value: x.name}))
-        { name: "电影", value: "movie" },
+        { name: "电影", value: "movies" },
         { name: "电视剧", value: "tv" },
         { name: "纪录片", value: "documentary" },
-        { name: "动漫", value: "animation" },
+        { name: "动漫", value: "anime" },
         { name: "音乐", value: "music" },
         { name: "综艺", value: "variety" },
         { name: "9KG", value: "9kg" },
@@ -38,55 +67,47 @@ export const siteMetadata: ISiteMetadata = {
   ],
 
   search: {
-    requestConfig: { url: "/api/v1/search", params: { page_size: 100 } },
+    requestConfig: { url: "/api/v1/torrents", params: { limit: 100, offset: 0 }, responseType: "json" },
     keywordPath: "params.keyword",
     advanceKeywordParams: { imdb: false, douban: false },
     selectors: {
-      rows: { selector: "data.torrents" },
-      id: { selector: "uuid" }, // 使用 uuid 而不是 id
-      title: { selector: "title" },
+      rows: { selector: "data.items" },
+      id: { selector: "id" }, // 数字 id
+      title: { selector: "name" },
       subTitle: { selector: "subtitle" },
-      url: { selector: "uuid", filters: [{ name: "prepend", args: ["/torrent/"] }] }, // 直接构造 uuid
-      // link: { selector: "uuid" }, // 下载链接中有 passkey 参数，此处不构造，由 class 生成
-      time: { selector: "created_at", filters: [{ name: "parseTime" }] },
-      size: { selector: "size" },
-      author: { selector: "uploader" },
+      url: { selector: "id", filters: [{ name: "prepend", args: ["/torrents/"] }] }, // 构造详情链接
+      time: { selector: "uploaded_at" }, // ISO 时间串, 原样展示
+      size: { selector: "size_bytes", filters: [{ name: "parseNumber" }] }, // 原始字节数
       seeders: { selector: "seeders" },
       leechers: { selector: "leechers" },
-      completed: { selector: "downloads" },
-      // comments: { text: "N/A" }, // 不显示该站点的种子评论数
-      category: { selector: "category_name" },
+      completed: { selector: "completed" },
+      category: { selector: "category.name" },
     },
   },
 
   list: [
     {
-      urlPattern: ["/categories", "/search"],
+      urlPattern: ["/torrents"],
+      // 关键: content-script 先判断 list 再判断 detail, /torrents 会误匹配详情页 /torrents/8448,
+      // 必须排除详情页路径, 否则详情页被当作列表页解析 → "未解析到当前页面种子"
+      excludeUrlPattern: ["/torrents/[0-9a-z-]+", "/torrents/\\d+"],
       mergeSearchSelectors: false,
       selectors: {
-        keywords: { selector: "input[placeholder*='搜索种子']" },
-        rows: { selector: 'div.border > a[href^="/torrent/"]' },
-        id: { selector: ":self", attr: "href", filters: [{ name: "replace", args: ["/torrent/", ""] }] },
-        title: { selector: "span.truncate[title]", attr: "title" },
-        subTitle: { selector: "span.text-muted-foreground.truncate" },
+        keywords: { selector: "input[placeholder*='搜索']" },
+        rows: { selector: 'a[href^="/torrents/"]' },
+        id: { selector: ":self", attr: "href", filters: [{ name: "replace", args: ["/torrents/", ""] }] },
+        title: { selector: "h3" },
         url: { selector: ":self", attr: "href" },
-        // link 由 getTorrentDownloadLink 方法构造
-        time: {
-          selector: "div:nth-child(6)[title]",
-          attr: "title",
-          filters: [{ name: "parseTime", args: ["yyyy/MM/dd HH:mm:ss"] }],
-        },
-        size: { selector: "div:nth-child(4)", filters: [{ name: "parseSize" }] },
-        seeders: { selector: "div:nth-child(5)", filters: [{ name: "split", args: ["/", 0] }] },
-        leechers: { selector: "div:nth-child(5)", filters: [{ name: "split", args: ["/", 1] }] },
-        completed: { selector: "div:nth-child(5)", filters: [{ name: "split", args: ["/", 2] }] },
-        category: { selector: "div:nth-child(3)" },
+        size: { selector: "span.font-medium.tabular-nums" },
+        seeders: { selector: "span.text-success-foreground" },
+        leechers: { selector: "span.text-destructive" },
+        time: { selector: "time.ml-auto" },
       },
     },
   ],
 
   detail: {
-    urlPattern: ["/torrent/"],
+    urlPattern: ["/torrents/"],
     selectors: {
       id: {
         selector: ":self",
@@ -104,93 +125,221 @@ export const siteMetadata: ISiteMetadata = {
   userInfo: {
     process: [
       {
-        requestConfig: { url: "/api/v1/profile", params: { "include_fields[user]": "seeding_leeching_data" } },
-        selectors: {
-          id: { selector: "data.id" },
-          name: { selector: "data.username" },
-          levelId: { selector: "data.level" },
-          levelName: { selector: "data.level_text" },
-          joinTime: { selector: "data.registered_at", filters: [{ name: "parseTime" }] },
-          lastAccessAt: { selector: "data.last_active_at", filters: [{ name: "parseTime" }] },
-          messageCount: { text: 0 },
-          downloaded: { selector: "data.downloaded" },
-          uploaded: { selector: "data.uploaded" },
-          ratio: { selector: "data.ratio" },
-
-          seeding: { selector: "data.seeding_leeching_data.seeding_count" },
-          seedingSize: { selector: "data.seeding_leeching_data.seeding_size" },
-          seedingTime: { selector: "data.seeding_time" },
-
-          bonus: { selector: "data.karma" },
+        // 会话认证用户信息: /api/v1/session 需携带 cookie 才返回数据
+        requestConfig: { url: "/api/v1/session", responseType: "json" },
+        requestConfigTransformer: (config, _userInfo, siteInstance) => {
+          const cookieStr = (siteInstance as RousiPro).rousiproCookie;
+          if (cookieStr) {
+            config.headers = { ...(config.headers ?? {}), Cookie: cookieStr };
+          }
+          return config;
         },
-      },
-      {
-        requestConfig: { url: "/api/v1/seeding-reward" },
         selectors: {
-          bonusPerHour: { selector: "data.total_reward" },
+          id: { selector: ["data.user.id", "data.id"] },
+          name: { selector: ["data.user.username", "data.username"] },
+          uploaded: {
+            selector: ["data.user.uploaded", "data.uploaded"],
+            filters: [{ name: "parseNumber" }],
+          },
+          downloaded: {
+            selector: ["data.user.downloaded", "data.downloaded"],
+            filters: [{ name: "parseNumber" }],
+          },
+          ratio: { selector: ["data.user.ratio", "data.ratio"] },
+          bonus: { selector: ["data.user.karma", "data.karma"] },
+          seeding: {
+            selector: ["data.user.seeding_leeching_data.seeding_count", "data.seeding_leeching_data.seeding_count"],
+            filters: [{ name: "parseNumber" }],
+          },
+          seedingSize: {
+            selector: ["data.user.seeding_leeching_data.seeding_size", "data.seeding_leeching_data.seeding_size"],
+            filters: [{ name: "parseNumber" }],
+          },
+          leeching: {
+            selector: ["data.user.seeding_leeching_data.leeching_count", "data.seeding_leeching_data.leeching_count"],
+            filters: [{ name: "parseNumber" }],
+          },
+          leechingSize: {
+            selector: ["data.user.seeding_leeching_data.leeching_size", "data.seeding_leeching_data.leeching_size"],
+            filters: [{ name: "parseNumber" }],
+          },
+          levelName: { selector: ["data.user.level_text", "data.level_text"] },
+          joinTime: {
+            selector: ["data.user.registered_at", "data.registered_at"],
+            elementProcess: (value: string) => (value ? new Date(value).getTime() : value),
+          },
         },
       },
     ],
   },
-
-  userInputSettingMeta: [
-    { name: "passkey", label: "Passkey", hint: "用户的Passkey，可以在 账户设置-Passkey 中复制", required: true },
-  ],
 };
 
-interface IRawSearchDatium {
-  id: number;
-  promotion?: {
-    type: 1 | 2 | 3 | 4 | 5 | 6 | 7; // 促销类型（1=普通, 2=免费, 3=2X, 4=2X免费, 5=50%, 6=2X50%, 7=30%）
-    is_active: boolean; // 是否激活
-  };
-}
-
-const promotionTypeMap: Record<Required<IRawSearchDatium>["promotion"]["type"], TPreDefinedTorrentTagName> = {
-  1: "",
-  2: "Free",
-  3: "2xUp",
-  4: "2xFree",
-  5: "50%",
-  6: "2x50%",
-  7: "30%",
+const promotionTagMap: Record<string, TPreDefinedTorrentTagName> = {
+  free: "Free",
+  double_up: "2xUp",
+  double_upload_free: "2xFree",
+  half_download: "50%",
+  double_up_half_download: "2x50%",
 };
 
 export default class RousiPro extends PrivateSite {
-  get userPasskey(): string {
-    return this.userConfig.inputSetting!.passkey ?? "";
-  }
+  /** 最近一次预读取的 rousi.pro 会话 cookie (供 getTorrentDownloadRequestConfig 复用) */
+  rousiproCookie = "";
 
-  public override async request<T>(
-    axiosConfig: AxiosRequestConfig,
-    checkLogin: boolean = true,
-  ): Promise<AxiosResponse<T>> {
-    // 设置默认的 method 和 responseType ， 这样其他配置不需要显式声明
-    axiosConfig.responseType = "json";
+  /**
+   * 用户信息: 直接实现多端点获取, 不再走 userInfo.process。
+   * rousi.pro 的 /api/v1/session 只返回 id/username, 统计字段(上传/下载/分享率/积分/等级)
+   * 分散在 /api/v1/me/traffic、/api/v1/me/economy、/api/v1/me/tracker-activity。
+   * 所有端点都需要会话 cookie, 请求从 offscreen 跨域发出默认不带 cookie,
+   * 故统一通过 getAllCookies 预读并注入 Cookie header (由 replaceUnsafeHeader 的 DNR 机制生效)。
+   */
+  public override async getUserInfoResult(lastUserInfo: Partial<IUserInfo> = {}): Promise<IUserInfo> {
+    if (!this.allowQueryUserInfo) {
+      return {
+        status: EResultParseStatus.passParse,
+        updateAt: +new Date(),
+        site: this.metadata.id,
+      };
+    }
 
-    // 在请求的 headers 中添加 Bearer Token
-    axiosConfig.headers = {
-      ...(axiosConfig.headers ?? {}),
-      Authorization: `Bearer ${this.userPasskey}`,
+    const cookieStr = await getRousiCookieHeader(this.url as string);
+    this.rousiproCookie = cookieStr;
+    const headers: Record<string, string> = cookieStr ? { Cookie: cookieStr } : {};
+
+    const flushUserInfo: IUserInfo = {
+      ...(lastUserInfo ?? {}),
+      status: EResultParseStatus.unknownError,
+      updateAt: +new Date(),
+      site: this.metadata.id,
     };
 
-    return super.request<T>(axiosConfig, checkLogin);
+    try {
+      // 1. session → id / name
+      const session = await this.request<any>({ url: "/api/v1/session", responseType: "json", headers });
+      const user = session.data?.user;
+      if (user?.id) {
+        flushUserInfo.id = user.id;
+        flushUserInfo.name = user.username ?? user.display_name;
+      }
+      if (!flushUserInfo.id) {
+        throw new Error("RousiPro session has no user (need login)");
+      }
+
+      // 2. me/traffic → 上传/下载/分享率
+      const traffic = await this.request<any>({
+        url: "/api/v1/me/traffic",
+        params: { limit: 20 },
+        responseType: "json",
+        headers,
+      });
+      const totals = traffic.data?.totals;
+      if (totals) {
+        const up = parseInt(totals.raw_uploaded_bytes ?? totals.credited_uploaded_bytes ?? "0", 10);
+        const down = parseInt(totals.raw_downloaded_bytes ?? totals.charged_downloaded_bytes ?? "0", 10);
+        if (up > 0 || down > 0) {
+          flushUserInfo.uploaded = up;
+          flushUserInfo.downloaded = down;
+          if (down > 0) {
+            flushUserInfo.ratio = +(up / down).toFixed(3);
+          }
+        }
+      }
+
+      // 3. me/economy → 积分(magic) 与 等级
+      const economy = await this.request<any>({
+        url: "/api/v1/me/economy",
+        params: { limit: 1 },
+        responseType: "json",
+        headers,
+      });
+      const eco = economy.data;
+      if (eco) {
+        const magic = parseFloat(eco.magic_balance ?? "0");
+        if (magic > 0 || eco.magic_balance) {
+          flushUserInfo.bonus = magic;
+        }
+        const level = eco.progress?.level;
+        if (typeof level === "number") {
+          flushUserInfo.levelId = level;
+          flushUserInfo.levelName = `Lv.${level}`;
+        }
+      }
+
+      // 4. me/tracker-activity → 做种/下载中/做种量
+      try {
+        const tracker = await this.request<any>({
+          url: "/api/v1/me/tracker-activity",
+          responseType: "json",
+          headers,
+        });
+        const items = tracker.data?.items;
+        if (Array.isArray(items)) {
+          let seeding = 0;
+          let seedingSize = 0;
+          let leeching = 0;
+          for (const it of items) {
+            const act = String(it?.action ?? it?.state ?? it?.status ?? "").toLowerCase();
+            const size = parseInt(it?.size_bytes ?? it?.size ?? it?.payload_size_bytes ?? "0", 10) || 0;
+            if (act.includes("seed")) {
+              seeding += 1;
+              seedingSize += size;
+            } else if (act.includes("leech") || act.includes("down")) {
+              leeching += 1;
+            } else if (size > 0) {
+              seeding += 1; // 未知状态但有大小, 按做种计入
+              seedingSize += size;
+            }
+          }
+          flushUserInfo.seeding = seeding;
+          flushUserInfo.seedingSize = seedingSize;
+          flushUserInfo.leeching = leeching;
+        }
+      } catch (e) {
+        // tracker-activity 获取失败不致命
+        console?.debug("[RousiPro] tracker-activity failed", e);
+      }
+
+      // 5. users/:username → 注册时间/发种数
+      try {
+        const profile = await this.request<any>({
+          url: `/api/v1/users/${flushUserInfo.name}`,
+          responseType: "json",
+          headers,
+        });
+        const p = profile.data;
+        if (p?.joined_at) {
+          flushUserInfo.joinTime = new Date(p.joined_at).getTime();
+        }
+        if (typeof p?.published_torrent_count === "number") {
+          flushUserInfo.uploads = p.published_torrent_count;
+        }
+      } catch (e) {
+        console?.debug("[RousiPro] users profile failed", e);
+      }
+
+      flushUserInfo.status = EResultParseStatus.success;
+    } catch (error) {
+      if (import.meta.env.DEV) {
+        console.error("[RousiPro] getUserInfoResult", error);
+      }
+      flushUserInfo.status = EResultParseStatus.parseError;
+    }
+
+    return flushUserInfo;
   }
 
   protected override parseTorrentRowForTags(
     torrent: Partial<ITorrent>,
-    row: IRawSearchDatium,
+    row: Record<string, any>,
     searchConfig: ISearchInput,
   ): Partial<ITorrent> {
     torrent = super.parseTorrentRowForTags(torrent, row, searchConfig);
 
-    // 将种子优惠标签加入 tags 中
-    if (row.promotion?.is_active) {
-      let tagName = promotionTypeMap[row.promotion.type] ?? "";
-      if (tagName) {
-        torrent.tags = torrent.tags || [];
-        torrent.tags.push({ name: tagName } as ITorrentTag);
-      }
+    // 将种子的促销标签加入 tags 中 (promotion 为字符串, 如 double_upload_free)
+    const promotion = row && (row as any).promotion;
+    if (promotion && promotionTagMap[promotion]) {
+      torrent.tags = torrent.tags || [];
+      torrent.tags.push({ name: promotionTagMap[promotion] } as ITorrentTag);
     }
 
     return torrent;
@@ -200,9 +349,9 @@ export default class RousiPro extends PrivateSite {
     // fix: 如果 torrent 对象没有 id ，则依次尝试从 url, link 中提取
     if (!torrent.id && (torrent.url || torrent.link)) {
       let match;
-      if (torrent.url?.includes("/torrent/")) {
+      if (torrent.url?.includes("/torrent")) {
         match = torrent.url.match(torrentIdRegex);
-      } else if (torrent.link?.includes("/torrent/")) {
+      } else if (torrent.link?.includes("/torrent")) {
         match = torrent.link.match(torrentIdRegex);
       }
 
@@ -211,7 +360,21 @@ export default class RousiPro extends PrivateSite {
       }
     }
 
-    // /api/torrent/:uuid/download/:passkey
-    return `${this.url}api/torrent/${torrent.id}/download/${this.userPasskey}`;
+    // 会话认证下载端点(已实测返回 .torrent)
+    return `${this.url}api/v1/torrents/${torrent.id}/download`;
+  }
+
+  /**
+   * 下载种子需携带 rousi.pro 会话 cookie:
+   * - 本地 extension 下载 / qBittorrent 中转(localDownloadOption) 都会使用这里的配置,
+   *   显式注入 Cookie header 后即可通过 DNR 机制带上登录态。
+   */
+  public override async getTorrentDownloadRequestConfig(torrent: ITorrent): Promise<AxiosRequestConfig> {
+    const config = await super.getTorrentDownloadRequestConfig(torrent);
+    const cookieStr = await getRousiCookieHeader(this.url as string);
+    if (cookieStr) {
+      config.headers = { ...(config.headers ?? {}), Cookie: cookieStr };
+    }
+    return config;
   }
 }


### PR DESCRIPTION
Rousi Pro 已升级站点, 旧适配(基于 passkey Bearer 认证 + 旧接口 `/api/v1/search`、`data.torrents`、`uuid`)已全部失效:
- 搜索 `/api/v1/search` → 401
- 下载端点 `/torrent/:uuid/download/:passkey` 错误
- 用户信息 `/api/v1/profile` 需要 Bearer API Key, 扩展无法提供

本 PR 重写 rousipro 适配(version 1 → 4), 改为**会话认证(浏览器 cookie)** + 现行 API:

### 修复内容
1. **搜索**: `/api/v1/torrents`(无需认证, 返回 `data.items`), 映射 id/name/subtitle/size_bytes/seeders/leechers/completed/category.name/promotion
2. **下载**: `/api/v1/torrents/:id/download`, 通过 `getAllCookies` 预读站点 cookie 注入 Cookie header。PT-depiler 的用户信息/下载请求从 offscreen 跨域发出默认不带 cookie, 无 cookie 时下载返回 401 `web_session_required`
3. **用户信息**: `/api/v1/session` 只返回 id/username, 统计字段分散在多端点, override `getUserInfoResult` 多端点获取:
   - `/api/v1/me/traffic` → 上传/下载/分享率
   - `/api/v1/me/economy` → 积分(magic_balance)/等级
   - `/api/v1/me/tracker-activity` → 做种/下载中
   - `/api/v1/users/:username` → 注册时间/发种数
4. **详情页/列表页**: `list.urlPattern: [/torrents]` 正则误匹配详情页 `/torrents/:id`(content-script 先判断 list 再判断 detail), 导致详情页被当列表页解析(点下载报未解析到当前页面种子), 加 `excludeUrlPattern` 排除; 列表页选择器按现行 SPA DOM 调整(h3 / span.font-medium.tabular-nums 等)