### PR TITLE
feat(manifest): content_scripts 支持 all_frames, 兼容同源悬浮预览 iframe

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -130,6 +130,9 @@ export default defineConfig({
             matches: ["*://*/*"],
             exclude_matches: ["*://*/*.xml", "*://*/*.xml?*"],
             js: ["src/entries/content-script/index.ts"],
+            // 允许在同源 iframe(如 PT_Masonry_View_Svelte 油猴脚本的悬浮预览 iframe, 加载同源种子详情页)
+            // 内也注入内容脚本, 使详情页的"推送到默认服务器"悬浮按钮在预览窗口内可直接使用
+            all_frames: true,
           },
         ],
 


### PR DESCRIPTION
### 背景
[PT_Masonry_View_Svelte](https://github.com/ 油猴脚本) 的悬浮预览功能, 会在 PT 站点列表页内以**同源 iframe** 加载种子详情页。PT-depiler 的 content_scripts 默认不注入 iframe, 导致预览窗口内无法出现推送到默认服务器悬浮按钮。

### 改动
给 `content_scripts` 增加 `all_frames: true`, 让内容脚本也注入同源 iframe。这样在瀑布流预览窗口内打开种子详情页时, PT-depiler 的悬浮下载按钮可以直接使用, 无需跳转详情页。

### 影响
- 仅新增 `all_frames: true` 一行配置, 不影响主页面行为
- 仅在同源 iframe 内注入, 不扩大注入范围到第三方 iframe