### PR TITLE
fix(pkg/site/hdarea): 兜底解析悬浮提示模式下的种子标题

### DIFF
--- a/src/packages/site/definitions/hdarea.ts
+++ b/src/packages/site/definitions/hdarea.ts
@@ -151,6 +151,19 @@ export const siteMetadata: ISiteMetadata = {
       rows: {
         selector: "table.torrents > tbody > tr:has(table.torrentname)",
       },
+      title: {
+        ...SchemaMetadata.search!.selectors!.title!,
+        // 站点设置「种子标题上悬浮提示类型」选为简单/中型 IMDb 信息时，标题锚点渲染为
+        // onmouseover="get_ext_info_ajax(...)"（悬停浮窗），无 title 属性、href 不带 hit，
+        // 模板默认选择器全部落空导致标题丢失（#1417），此处追加该形态的兜底
+        selector: [
+          "a[href^='details.php?id='][title]:has(b)",
+          "a[href*='details.php?id='][href*='hit']",
+          "a[href*='hit'][title]",
+          "a[href*='hit']:has(b)",
+          "a[onmouseover*='get_ext_info_ajax']",
+        ],
+      },
       subTitle: {
         text: "",
         selector: [
@@ -158,6 +171,7 @@ export const siteMetadata: ISiteMetadata = {
           "a[href*='details.php?id='][href*='hit']",
           "a[href*='hit'][title]",
           "a[href*='hit']:has(b)",
+          "a[onmouseover*='get_ext_info_ajax']",
         ],
         // HDArea places the subtitle in a sibling div of the title div,
         // rather than after a <br> tag, so we look at the next sibling element.


### PR DESCRIPTION
## 问题
HDArea 站点设置「种子标题上悬浮提示类型」（`usercp.php?action=tracker`）选择「简单/中型 IMDb 信息」时，站方为实现悬停浮窗，将标题锚点渲染为 `onmouseover="get_ext_info_ajax(...)"` 形式——无 `title` 属性、`href` 不带 `hit` 参数，模板 `baseTitleQuery` 的 4 个选择器全部落空，搜索结果中这类种子的标题/副标题为空（Closes #1417）。选择「关闭悬浮提示」时锚点带 `title` 属性，不受影响（这也是此前无法复现的原因）。

## 解决方法
在 hdarea 站点定义的 `title`/`subTitle` 选择器数组**末尾**追加 `a[onmouseover*='get_ext_info_ajax']` 兜底（纯增量，不动既有选择器）；取值沿用模板既有的 `title || textContent` 逻辑，副标题沿用既有的 sibling `div` 定位。

该设置是 NexusPHP 核心功能，其他 NexusPHP 站点理论上同样可能触发；如倾向在 `baseTitleQuery` 层统一兜底可另行调整，本 PR 按最小影响面只动 hdarea。

## 测试流程及结果
实站登录态验证（悬浮提示=中型IMDb信息）：
- 种子列表 100 行中 56 行为 onmouseover 形态，修复前选择器 0/56 命中（标题全丢），追加兜底后 100/100 行标题与副标题正常解析；
- 普通 title 形态（44 行）修复前后均正常命中；
- `pnpm check` 无错误。
