### PR TITLE
fix(downloader): 补齐 Chrome<140 缺失的 Uint8Array hex/base64 平台方法，修复发送种子失败

### DIFF
--- a/src/packages/downloader/utils.ts
+++ b/src/packages/downloader/utils.ts
@@ -1,3 +1,6 @@
+// 需先于 parse-torrent 的调用链执行：为 Chrome <140 的 Chromium 补齐 uint8-util（2.3+）依赖的平台方法
+import "./utils/uint8ArrayCompat.ts";
+
 import { Buffer } from "buffer";
 import axios, { AxiosRequestConfig } from "axios";
 import parseTorrent, { Instance as TorrentInstance } from "parse-torrent";

--- a/src/packages/downloader/utils/uint8ArrayCompat.ts
+++ b/src/packages/downloader/utils/uint8ArrayCompat.ts
@@ -1,0 +1,70 @@
+/**
+ * Uint8Array 的 hex/base64 便捷方法（prototype.toHex / static fromHex / prototype.toBase64 / static fromBase64）
+ * 自 Chrome 140 起才提供，而运行时依赖链 parse-torrent → bencode → uint8-util（2.3+）已直接调用它们，
+ * 低于 140 的 Chromium 上发送种子到下载器会抛 "toHex is not a function"（#1481）。
+ * manifest 声明的 minimum_chrome_version 为 120，此处对缺失的平台方法做等价兜底。
+ */
+
+const HEX = "0123456789abcdef";
+
+interface Uint8ArrayCompat {
+  toHex?: (this: Uint8Array) => string;
+  fromHex?: (str: string) => Uint8Array;
+  toBase64?: (this: Uint8Array) => string;
+  fromBase64?: (str: string) => Uint8Array;
+}
+
+const proto = Uint8Array.prototype as unknown as Uint8ArrayCompat;
+const statics = Uint8Array as unknown as Uint8ArrayCompat;
+
+if (typeof proto.toHex !== "function") {
+  proto.toHex = function (this: Uint8Array) {
+    let out = "";
+    for (let i = 0; i < this.length; i++) {
+      out += HEX[this[i]! >> 4]! + HEX[this[i]! & 0xf]!;
+    }
+    return out;
+  };
+}
+
+if (typeof statics.fromHex !== "function") {
+  statics.fromHex = (str: string) => {
+    if (str.length % 2 !== 0) {
+      throw new SyntaxError("The string must have an even number of hexadecimal digits.");
+    }
+    const out = new Uint8Array(str.length >> 1);
+    for (let i = 0; i < out.length; i++) {
+      const hi = HEX.indexOf(str[i * 2]!);
+      const lo = HEX.indexOf(str[i * 2 + 1]!);
+      if (hi < 0 || lo < 0) {
+        throw new SyntaxError(`Invalid hexadecimal character at position ${hi < 0 ? i * 2 : i * 2 + 1}.`);
+      }
+      out[i] = (hi << 4) | lo;
+    }
+    return out;
+  };
+}
+
+if (typeof proto.toBase64 !== "function") {
+  proto.toBase64 = function (this: Uint8Array) {
+    let binary = "";
+    const chunk = 0x8000; // String.fromCharCode 参数个数上限
+    for (let i = 0; i < this.length; i += chunk) {
+      binary += String.fromCharCode(...this.subarray(i, i + chunk));
+    }
+    return btoa(binary);
+  };
+}
+
+if (typeof statics.fromBase64 !== "function") {
+  statics.fromBase64 = (str: string) => {
+    const normalized = str.replace(/[\t\n\f\r ]+/g, "");
+    const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
+    const binary = atob(padded);
+    const out = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      out[i] = binary.charCodeAt(i);
+    }
+    return out;
+  };
+}


### PR DESCRIPTION
## 问题
`Uint8Array` 的 hex/base64 便捷方法（`prototype.toHex` / `prototype.toBase64` / `fromHex` / `fromBase64`）自 Chrome 140 起才提供，而运行时依赖链 `parse-torrent → bencode → uint8-util`（2.3+）已直接调用它们：低于 140 的 Chromium（如 #1481 报告者的 Chromium 134）上发送种子到下载器抛 `n.toHex is not a function`，与 manifest 声明的 `minimum_chrome_version: 120` 不符。

注：uint8-util@2.3.2 实际调用了上述全部 4 个方法（`hex2arr` 仅在长度 >64 时走 `fromHex`），`toHex` 只是栈上最先炸的一个。

## 解决方法
在 `downloader/utils.ts`（`parse-torrent` 的唯一引入点）顶部以副作用导入 `uint8ArrayCompat`：四个平台方法**缺失时**安装等价实现（hex 查表、base64 走 `btoa`/`atob` 分块），原生存在时零介入，Chrome 140+ 用户不受任何影响。

## 测试流程及结果
- 复现与修复（CFT 真机 + 本地 qb 5.2.3）：以 CDP `Page.addScriptToEvaluateOnNewDocument` 在 offscreen 上下文预删 4 个平台方法模拟 Chrome <140，经 `downloadTorrent` 消息发送本地 .torrent——master 构建复现 `failed: "n.toHex is not a function"`；本修复 `downloadStatus=completed` 且 qb 收到测试种子；
- polyfill 语义差分：以 Node `Buffer` 为基准，对空/1/255/63/64/65/1000/64KB+ 等 9 组字节做 hex/base64 编解码往返对比全部对齐（63/64 为 uint8-util `fromHex` 快慢路径分界）；
- `pnpm check` 无错误。

Closes #1481
