### PR TITLE
feat(ui): 增加控制项，可选是否随窗口大小自动展开/收起侧边栏

### DIFF
--- a/src/entries/options/stores/config.ts
+++ b/src/entries/options/stores/config.ts
@@ -60,6 +60,7 @@ export const useConfigStore = defineStore("config", {
     lang: "zh_CN",
     theme: "light",
     isNavBarOpen: true,
+    autoToggleNavBarOnDisplayChange: true,
 
     ignoreWrongPixelRatio: false,
     showReleaseNoteOnVersionChange: true,

--- a/src/entries/options/views/Layout/Navigation.vue
+++ b/src/entries/options/views/Layout/Navigation.vue
@@ -18,7 +18,9 @@ const configStore = useConfigStore();
 // 当页面窗口大小发生变化时，调整 Navigation 的显示
 const display = useDisplay();
 watch(display.mdAndUp, () => {
-  configStore.isNavBarOpen = display.mdAndUp.value;
+  if (configStore.autoToggleNavBarOnDisplayChange) {
+    configStore.isNavBarOpen = display.mdAndUp.value;
+  }
 });
 
 // 自动从router.ts生成目录

--- a/src/entries/options/views/Settings/SetBase/UiWindow.vue
+++ b/src/entries/options/views/Settings/SetBase/UiWindow.vue
@@ -84,6 +84,22 @@ defineExpose({
         </template>
       </v-switch>
 
+      <v-switch
+        v-model="configStore.autoToggleNavBarOnDisplayChange"
+        color="success"
+        hide-details
+        :label="t('SetBase.ui.autoToggleNavBarOnDisplayChange')"
+      >
+        <template #append>
+          <v-tooltip max-width="400" location="bottom">
+            <template v-slot:activator="{ props }">
+              <v-icon color="info" icon="mdi-help-circle" v-bind="props" />
+            </template>
+            {{ t("SetBase.ui.autoToggleNavBarOnDisplayChangeNote") }}
+          </v-tooltip>
+        </template>
+      </v-switch>
+
       <v-divider />
     </v-col>
   </v-row>

--- a/src/entries/shared/types/storages/config.ts
+++ b/src/entries/shared/types/storages/config.ts
@@ -20,6 +20,8 @@ export interface IConfigPiniaStorageSchema {
   lang: TLangCode;
   theme: supportThemeType;
   isNavBarOpen: boolean;
+  // 窗口大小变化（display 断点变化）时，是否自动展开/收起 Navigation 侧边栏
+  autoToggleNavBarOnDisplayChange: boolean;
 
   ignoreWrongPixelRatio: boolean;
   showReleaseNoteOnVersionChange: boolean; // 是否在版本更新时展示更新日志

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -591,6 +591,8 @@
     "ui": {
       "allowDragLink": "Allow dragging links to the sidebar button",
       "allowExceptionSites": "Allow setting exception sites without sidebar (enable in site settings)",
+      "autoToggleNavBarOnDisplayChange": "Auto expand/collapse the sidebar when the window size changes",
+      "autoToggleNavBarOnDisplayChangeNote": "When disabled, resizing the window will not change the sidebar state automatically; control it manually via the top bar button.",
       "basicSettings": "Basic Settings",
       "changeLanguage": "Switch Language",
       "confirmTwoStep": "Require two-step confirmation for batch copy, local download, etc. on torrent list pages",

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -591,6 +591,8 @@
     "ui": {
       "allowDragLink": "允许拖拽链接到侧边栏按钮",
       "allowExceptionSites": "允许设置不启用侧边栏的例外站点（启用后需在站点设置中对应关闭）",
+      "autoToggleNavBarOnDisplayChange": "窗口大小变化时自动展开/收起侧边栏",
+      "autoToggleNavBarOnDisplayChangeNote": "关闭后，调整窗口大小不会自动改变侧边栏的展开状态，需要手动通过顶栏按钮控制。",
       "basicSettings": "基本设置",
       "changeLanguage": "切换语言",
       "confirmTwoStep": "对种子列表页批量复制、本地下载等操作需要二步确认",


### PR DESCRIPTION
## 变更内容

在「设置 → 界面UI」中新增开关 **`autoToggleNavBarOnDisplayChange`**（默认启用），用于控制 Navigation 侧边栏是否响应窗口尺寸（display 断点）变化：

- **启用（默认）**：与现有行为一致——窗口跨过 md 断点时自动展开/收起侧边栏（`watch(display.mdAndUp)` 改写 `isNavBarOpen`）。
- **禁用**：调整窗口大小不再自动改变侧边栏状态，需通过顶栏按钮手动控制。

## 改动文件

| 文件 | 说明 |
| --- | --- |
| `src/entries/shared/types/storages/config.ts` | schema 新增 `autoToggleNavBarOnDisplayChange: boolean` |
| `src/entries/options/stores/config.ts` | state 默认值 `true`（持久化插件为 `$patch` 合并，老用户升级自动获得默认开启，无需迁移） |
| `src/entries/options/views/Layout/Navigation.vue` | watch 回调加守卫，开关关闭时不自动改写 `isNavBarOpen` |
| `src/entries/options/views/Settings/SetBase/UiWindow.vue` | 「界面UI」区新增开关（带说明 tooltip） |
| `src/locales/zh_CN.json` / `en.json` | 双语词条 |

## 验证

- [x] `pnpm check`（vue-tsc --noEmit）通过
- [x] locale JSON 语法校验通过