### PR TITLE
fix(core): Firefox 下 DNR initiatorDomains 改用扩展 UUID host 匹配自身请求 (#1486)

### DIFF
--- a/src/entries/background/utils/webRequest.ts
+++ b/src/entries/background/utils/webRequest.ts
@@ -1,14 +1,18 @@
 import { onMessage, sendMessage } from "@/messages.ts";
 
 onMessage("updateDNRSessionRules", async ({ data: { rule, extOnly = true } }) => {
-  // 不影响其他非本扩展的网络请求：将规则正向圈定到本扩展页面发起的请求
-  // （offscreen/options 等扩展上下文发起的请求，其 initiator 为 chrome-extension://<id>，可用扩展 ID 表示）。
+  // 将规则正向圈定到本扩展发起的请求，避免误改普通网页的请求头（见 #1465）。
   //
-  // 此前采用 excludedTabIds 快照方案（排除安装规则时已存在的非扩展标签页），存在两个缺陷（见 #1465）：
-  // 1. 快照过期：之后新开的标签页不在豁免名单内，其中命中 urlFilter 的请求会被误改请求头；
-  // 2. urlFilter 为无锚点子串匹配：规则中的 URL 片段可能命中完全无关的请求，放大误伤面。
+  // DNR 的 initiatorDomains 按「请求 initiator 的 host」匹配。两浏览器下扩展自身上下文
+  // （background/offscreen/options 等）发起的请求，其 initiator host 均等于扩展自身 origin 的 host：
+  // - Chrome：chrome-extension://<id>，host 即 chrome.runtime.id；
+  // - Firefox：moz-extension://<uuid>，host 是扩展的 moz-extension UUID。而 chrome.runtime.id 返回
+  //   manifest 声明的 gecko.id（本扩展为 ptdepiler.ptplugins@gmail.com），与 UUID 并不相同（也非合法
+  //   domain），规则将永不命中，导致扩展发起的 unsafe header 请求（如 M-Team 校验所需的 Origin 头）
+  //   在 Firefox 中全部失效（见 #1486）。因此 Firefox 侧取 new URL(chrome.runtime.getURL("")).host
+  //   作为匹配值（在任何扩展上下文均可计算，不依赖 location）。
   if (extOnly) {
-    rule.condition.initiatorDomains = [chrome.runtime.id];
+    rule.condition.initiatorDomains = [__BROWSER__ === "firefox" ? new URL(chrome.runtime.getURL("")).host : chrome.runtime.id];
     delete rule.condition.excludedTabIds;
   }
 


### PR DESCRIPTION
## 背景 / 问题

Closes #1486(Firefox 无法访问 M-Team 数据,浏览器 Windows Firefox 155.0,版本 v0.0.6.1868):

- 站点数据无法刷新、无法搜索站点种子;
- M-Team 种子页推送种子到下载器报错 `TypeError: can't access property "data", e is undefined`。

该回归在 v0.0.6.1820 未出现,由 #1461 中的 DNR 改动(commit 3909525b,含 #1465 修复)引入:background 侧 `updateDNRSessionRules` 改为 `condition.initiatorDomains = [chrome.runtime.id]` 正向圈定规则只命中本扩展发起的请求。

## 根因调研结论

`initiatorDomains` 在 Firefox 中受支持(见 [Bugzilla 1908959](https://bugzilla.mozilla.org/show_bug.cgi?id=1908959),Rob Wu 确认),匹配语义是「请求 initiator 的 host」。两浏览器下扩展自身上下文发起请求的 initiator host:

| | initiator host(扩展页面) | `chrome.runtime.id` | 可匹配? |
|---|---|---|---|
| Chrome | `chrome-extension://<id>` 的 host = 扩展 ID | 扩展 ID(如 `hgmjcniliicnomekjcdbefmhfljkgdeh`) | ✅(二者相等) |
| Firefox | `moz-extension://<uuid>` 的 host = 扩展 UUID | manifest `gecko.id`(如 `ptdepiler.ptplugins@gmail.com`) | ❌(不等,且非合法 domain) |

Firefox 官方 xpcshell 测试([test_ext_dnr_testMatchOutcome.js](https://searchfox.org/mozilla-central/source/toolkit/components/extensions/test/xpcshell/test_ext_dnr_testMatchOutcome.js) `match_initiator_moz_extension`)即用扩展 UUID(`location.host`)命中本扩展页面发起的请求,佐证上述语义。

因此 `[chrome.runtime.id]` 的规则在 Firefox 永不命中,扩展携带 unsafe header 的请求(如 M-Team 校验所需的 `Origin` 头,见 [mteam.ts](src/packages/site/definitions/mteam.ts))全部失效。

## 修复

`src/entries/background/utils/webRequest.ts`:`initiatorDomains` 匹配值按浏览器取:

- **Chrome**:维持 `chrome.runtime.id`;
- **Firefox**:取 `new URL(chrome.runtime.getURL("")).host`(= moz-extension UUID)。该值在任何扩展上下文(background 页/options 等)均可计算、不依赖 `location`,并在运行时动态反映当前安装的 UUID。

两个浏览器都保留 #1465 的正向圈定语义(规则只命中本扩展请求,不误伤普通网页标签页)。

## 验证

- `pnpm run check`(vue-tsc)通过;
- `TARGET=firefox vite build` 构建通过;
- Chrome 侧逻辑未改动(原有行为,见 #1461 E2E);Firefox 侧依据 Firefox 官方 DNR 测试语义与用户实机数据(FF 155:`runtime.getURL('')` → `moz-extension://<uuid>/`,`runtime.id` → gecko.id)确认修复方向。