### PR TITLE
fix(ci): 修复 PR 中 vue-tsc 失败未阻断工作流

### DIFF
--- a/.github/workflows/action_build.yml
+++ b/.github/workflows/action_build.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: vue-tsc check
         run: pnpm check
-        continue-on-error: ${{ github.event_name == 'pull_request' && false || true }}
+        continue-on-error: ${{ github.event_name == 'push' }}
 
       - name: Build Output
         run: |


### PR DESCRIPTION
问题：现有 continue-on-error 表达式会让 pull_request 下的 pnpm check 失败继续执行。改为仅 push 容忍失败，使 pull_request 和 workflow_call 保持严格。验证：clean upstream/master 与本分支均通过 pnpm check、pnpm build:dist、pnpm build:dist-firefox。