### PR TITLE
fix(ci): 固定 Firefox 发布源码到当前 workflow commit

### DIFF
--- a/.github/workflows/action_publish.yml
+++ b/.github/workflows/action_publish.yml
@@ -59,9 +59,8 @@ jobs:
           CHROME_SKIP_SUBMIT_REVIEW: ${{ secrets.CHROME_SKIP_SUBMIT_REVIEW }}
         run: pnpm exec publish-extension --chrome-zip extension-chrome.zip
 
-      ## 下载用于 firefox 商店提交的源代码
-      ## 由于 workflow_dispatch 和 schedule 触发的工作流其 GITHUB_SHA 永远为最新提交的 SHA，此处可以直接固定死下载最新的源代码
-      - run: wget https://github.com/pt-plugins/PT-depiler/archive/refs/heads/master.zip -O source.zip
+      # 下载用于 Firefox 商店提交的源码，并固定到本次工作流提交
+      - run: wget "https://github.com/${{ github.repository }}/archive/${{ github.sha }}.zip" -O source.zip
 
       - name: Publish to Firefox Add-ons
         if: ${{ steps.github_release.outputs.id != '' }}


### PR DESCRIPTION
问题：Firefox 发布源码从上游 master 分支重新下载，可能与本次构建提交不一致。改为从 github.repository 下载 github.sha 对应的源码归档。验证：pnpm check、pnpm build:dist、pnpm build:dist-firefox 均通过。