### PR TITLE
fix(ci): 固定 publish-browser-extension 版本

### DIFF
--- a/.github/workflows/action_publish.yml
+++ b/.github/workflows/action_publish.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: ">=23.7.0"
 
       - run: pnpm init
-      - run: pnpm i -D publish-browser-extension
+      - run: pnpm i -D publish-browser-extension@6.1.1
 
       # 下载 action_build.yml 构造出来的 extension-chrome.zip, extension-firefox.zip 两个文件
       - name: Download Chrome Built Artifact


### PR DESCRIPTION
## Summary

- Pin the workflow dependency to `publish-browser-extension@6.1.1` for reproducible publishing behavior.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm check`
- `pnpm build:dist`
- `pnpm build:dist-firefox`
- Installed `publish-browser-extension@6.1.1` in an isolated scratch project.
- Verified the CLI reports `6.1.1` and parses the existing `--chrome-zip`, `--firefox-zip`, `--firefox-sources-zip`, and `--edge-zip` flags in help-only mode.
- No real store publish was triggered.
