### PR TITLE
fix(pkg/site/sewerpt): 对齐站方等级门槛并精简特权文本

### DIFF
--- a/src/packages/site/definitions/sewerpt.ts
+++ b/src/packages/site/definitions/sewerpt.ts
@@ -170,9 +170,7 @@ export const siteMetadata: ISiteMetadata = {
       seedingBonus: 40000,
       ratio: 1.05,
       privilege:
-        "可以直接发布种子；可以查看NFO文档；可以查看用户列表；可以请求续种； " +
-        '可以发送邀请； 可以查看排行榜；可以查看其它用户的种子历史(如果用户隐私等级未设置为"强")； 可以删除自己上传的字幕。' +
-        "当条件符合时将被自动提升。注意，无论何时，如果你的分享率低于0.95，你将自动降级。",
+        '可直接发布种子；查看NFO、用户列表、排行榜；请求续种；发送邀请；查看他人种子历史（对方隐私等级未设为"强"）；删除自己上传的字幕。',
     },
     {
       id: 2,
@@ -182,8 +180,7 @@ export const siteMetadata: ISiteMetadata = {
       downloaded: "120GB",
       seedingBonus: 80000,
       ratio: 1.55,
-      privilege:
-        "Elite User及以上用户封存账号后不会被删除。当条件符合时将被自动提升。注意，无论何时，如果你的分享率低于1.45，你将自动降级。",
+      privilege: "Elite User及以上用户封存账号后不会被删除。",
     },
     {
       id: 3,
@@ -193,8 +190,7 @@ export const siteMetadata: ISiteMetadata = {
       downloaded: "300GB",
       seedingBonus: 150000,
       ratio: 2.05,
-      privilege:
-        "得到两个邀请名额；可以在做种/下载/发布的时候选择匿名模式。当条件符合时将被自动提升。注意，无论何时，如果你的分享率低于1.95，你将自动降级。",
+      privilege: "得到两个邀请名额；做种/下载/发布时可选匿名模式。",
     },
     {
       id: 4,
@@ -204,7 +200,7 @@ export const siteMetadata: ISiteMetadata = {
       downloaded: "500GB",
       seedingBonus: 250000,
       ratio: 2.55,
-      privilege: "可以查看普通日志。当条件符合时将被自动提升。注意，无论何时，如果你的分享率低于2.45，你将自动降级。",
+      privilege: "可以查看普通日志。",
     },
     {
       id: 5,
@@ -215,8 +211,7 @@ export const siteMetadata: ISiteMetadata = {
       seedingBonus: 400000,
       ratio: 3.05,
       isKept: true,
-      privilege:
-        "得到三个邀请名额；可以查看其它用户的评论、帖子历史。Veteran User及以上用户会永远保留账号。当条件符合时将被自动提升。注意，无论何时，如果你的分享率低于2.95，你将自动降级。",
+      privilege: "得到三个邀请名额；可以查看其它用户的评论、帖子历史；Veteran User及以上用户永远保留账号。",
     },
     {
       id: 6,
@@ -227,8 +222,7 @@ export const siteMetadata: ISiteMetadata = {
       seedingBonus: 600000,
       ratio: 3.55,
       isKept: true,
-      privilege:
-        "可以更新过期的外部信息；可以查看Extreme User论坛。当条件符合时将被自动提升。注意，无论何时，如果你的分享率低于3.45，你将自动降级。",
+      privilege: "可以更新过期的外部信息；可以查看Extreme User论坛。",
     },
     {
       id: 7,
@@ -239,7 +233,7 @@ export const siteMetadata: ISiteMetadata = {
       seedingBonus: 900000,
       ratio: 4.05,
       isKept: true,
-      privilege: "得到五个邀请名额。当条件符合时将被自动提升。注意，无论何时，如果你的分享率低于3.95，你将自动降级。",
+      privilege: "得到五个邀请名额。",
     },
     {
       id: 8,
@@ -250,7 +244,7 @@ export const siteMetadata: ISiteMetadata = {
       seedingBonus: 1500000,
       ratio: 4.55,
       isKept: true,
-      privilege: "得到十个邀请名额。当条件符合时将被自动提升。注意，无论何时，如果你的分享率低于4.45，你将自动降级。",
+      privilege: "得到十个邀请名额。",
     },
   ],
 };

--- a/src/packages/site/definitions/sewerpt.ts
+++ b/src/packages/site/definitions/sewerpt.ts
@@ -170,7 +170,7 @@ export const siteMetadata: ISiteMetadata = {
       seedingBonus: 40000,
       ratio: 1.05,
       privilege:
-        "得到一个邀请名额；可以直接发布种子；可以查看NFO文档；可以查看用户列表；可以请求续种； " +
+        "可以直接发布种子；可以查看NFO文档；可以查看用户列表；可以请求续种； " +
         '可以发送邀请； 可以查看排行榜；可以查看其它用户的种子历史(如果用户隐私等级未设置为"强")； 可以删除自己上传的字幕。' +
         "当条件符合时将被自动提升。注意，无论何时，如果你的分享率低于0.95，你将自动降级。",
     },
@@ -189,7 +189,7 @@ export const siteMetadata: ISiteMetadata = {
       id: 3,
       name: "安全员",
       nameAka: ["Crazy User"],
-      interval: "P15W",
+      interval: "P16W",
       downloaded: "300GB",
       seedingBonus: 150000,
       ratio: 2.05,
@@ -200,7 +200,7 @@ export const siteMetadata: ISiteMetadata = {
       id: 4,
       name: "技术员",
       nameAka: ["Insane User"],
-      interval: "P25W",
+      interval: "P28W",
       downloaded: "500GB",
       seedingBonus: 250000,
       ratio: 2.55,


### PR DESCRIPTION
## 主要问题

1. 站方等级页实际配置与定义存在 3 处不一致：
   - Crazy User（安全员）注册时间要求为 **16 周**（NexusPHP 默认 15），定义为 `P15W`
   - Insane User（技术员）注册时间要求为 **28 周**（默认 25），定义为 `P25W`
   - Power User（大工）首次升级邀请名额站方已配置为 **0**（默认 1），特权文本仍含"得到一个邀请名额"
2. 各等级特权文本末尾携带重复的门槛样板尾巴（"当条件符合时将被自动提升。注意，无论何时，如果你的分享率低于X，你将自动降级。"）——门槛（时长/下载量/做种积分/分享率）已由 UserLevelsComponent 结构化展示，文本重复且在单行截断的 UI 场景下不可读。

## 解决方法

- `P15W` → `P16W`、`P25W` → `P28W`；移除大工"得到一个邀请名额"
- 特权文本精简为纯特权描述（邀请名额、功能特权、保号说明等事实项全部保留），风格与 `schemas/NexusPHP.ts` 共享默认等级文本一致

## 测试流程及结果

以站方等级页文本（登录态获取）逐项对照 8 个等级全部阈值：做种积分（40000~1500000）、下载量（50GB~3TB）、升级分享率（1.05~4.55）、降级分享率（0.95~4.45）均一致——包括 #1414 修正过的 Ultimate 900000（默认 800000）与 Master 1500000（默认 1000000）两处非默认值；本次修正上述 3 处不一致项。精简后的特权文本逐级人工核对，特权事实项零丢失。

`pnpm check` 无错误。