### PR TITLE
fix(pkg/site/keepfrds): 月月从完整列表获取做种与发布数据

### DIFF
--- a/src/packages/site/definitions/keepfrds.ts
+++ b/src/packages/site/definitions/keepfrds.ts
@@ -1,4 +1,6 @@
 import { type ISiteMetadata, type IUserInfo } from "../types";
+import { definedFilters } from "../utils.ts";
+import Sizzle from "sizzle";
 import NexusPHP, {
   CategoryInclbookmarked,
   CategoryIncldead,
@@ -396,16 +398,94 @@ export default class Keepfrds extends NexusPHP {
   }
 
   /**
-   * 新版站点已移除 getusertorrentlistajax.php 接口，且 userdetails 页面不再提供做种体积/发布数。
-   * 覆写基类的回退逻辑，避免请求已失效的接口导致用户信息更新失败。
+   * 新版站点已移除 getusertorrentlistajax.php 接口，改为从完整 torrents.php
+   * 分页列表统计当前做种体积和发布数量。
    */
   protected override async parseUserInfoForSeedingStatus(
     flushUserInfo: Partial<IUserInfo>,
   ): Promise<Partial<IUserInfo>> {
-    return flushUserInfo; // seeding 由 selector 提供，seedingSize 新版页面不提供
+    const userId = flushUserInfo.id as number;
+    const stats = await this.getKeepfrdsUserTorrentStats(userId, 3);
+    flushUserInfo.seeding = stats.count;
+    flushUserInfo.seedingSize = stats.size;
+    return flushUserInfo;
   }
 
   protected override async parseUserInfoForUploads(flushUserInfo: Partial<IUserInfo>): Promise<Partial<IUserInfo>> {
-    return flushUserInfo; // uploads 新版页面不提供，跳过失效接口
+    const userId = flushUserInfo.id as number;
+    const stats = await this.getKeepfrdsUserTorrentStats(userId, 10);
+    flushUserInfo.uploads = stats.count;
+    return flushUserInfo;
+  }
+
+  private async getKeepfrdsUserTorrentStats(
+    userId: number,
+    optionTorrents: 3 | 10,
+  ): Promise<{ count: number; size: number }> {
+    // 月月完整列表每页 50 条，第一页不带 page，后续从 page=1 开始。
+    const maxPages = 50;
+    const seenPages = new Set<string>();
+    let page = 0;
+    let rowCount = 0;
+    let totalSize = 0;
+    let reportedCount = 0;
+
+    while (page < maxPages) {
+      const { data } = await this.request<Document>({
+        url: "/torrents.php",
+        params: {
+          "option-torrents": optionTorrents,
+          userid: userId,
+          ...(page > 0 ? { page } : {}),
+        },
+        responseType: "document",
+      });
+      if (!(data instanceof Document)) break;
+
+      const rows = this.getKeepfrdsTorrentRows(data);
+      if (rows.length === 0) break;
+
+      const pageSignature = rows
+        .map((row) => Sizzle("a[href*='details.php?id=']", row)[0]?.getAttribute("href") || "")
+        .join("|");
+      if (!pageSignature || seenPages.has(pageSignature)) break;
+      seenPages.add(pageSignature);
+
+      rowCount += rows.length;
+      totalSize += this.getKeepfrdsTorrentPageSize(rows);
+      if (page === 0) {
+        reportedCount = this.getKeepfrdsPagerTotal(data);
+      }
+      if (!this.hasKeepfrdsNextPage(data, page + 1)) break;
+      page += 1;
+    }
+
+    return { count: reportedCount >= rowCount ? reportedCount : rowCount, size: totalSize };
+  }
+
+  private getKeepfrdsTorrentRows(doc: Document): Element[] {
+    return Sizzle("table.torrents tr", doc).filter((row) => row.querySelector(":scope > td[data-label='大小']"));
+  }
+
+  private getKeepfrdsTorrentPageSize(rows: Element[]): number {
+    return rows.reduce((total, row) => {
+      const sizeCell = row.querySelector(":scope > td[data-label='大小']") as HTMLElement | null;
+      return total + definedFilters.parseSize(sizeCell?.innerText?.trim() || "0 B");
+    }, 0);
+  }
+
+  private getKeepfrdsPagerTotal(doc: Document): number {
+    let total = 0;
+    Sizzle("p:has(a[href*='page=']) b", doc).forEach((element) => {
+      const match = element.textContent?.replace(/\u00a0/g, " ").match(/(\d+)\s*-\s*(\d+)/);
+      if (!match) return;
+      total = Math.max(total, Number(match[2]) || 0);
+    });
+    return total;
+  }
+
+  private hasKeepfrdsNextPage(doc: Document, nextPage: number): boolean {
+    const pattern = new RegExp(`[?&]page=${nextPage}(?:&|$)`);
+    return Sizzle("a[href*='page=']", doc).some((link) => pattern.test(link.getAttribute("href") || ""));
   }
 }


### PR DESCRIPTION
## 背景

#1410 中已确认月月新版移除了 `getusertorrentlistajax.php`，且 `userdetails.php` 不再提供做种体积和发布数，因此当时将相关回退逻辑直接跳过，避免请求失效接口导致用户信息刷新失败。

但这会留下两个用户可见字段长期缺失：

- 做种体积始终为空
- 发布数量始终为空

**此部分数据对我们PTer很重要，目前无其它更好的解决办法，此方案是目前权衡下来能想到唯一的过渡方案，站点支持后可优化为更轻量级的方案，另外此方案也可以作为降级备用数据源。给站点反馈了意见，暂无回复，我也会持续关注站点动态，虽然方法实现上稍重，实测性能尚可，不能把所有希望寄托于站点支持，时间会非常漫长，当前该站点很多PTer也在强烈呼吁支持此部分数据**

## 实站调研

月月仍保留完整种子列表接口，可以按用户维度分页获取：

- 做种列表：`/torrents.php?option-torrents=3&userid=<uid>`
- 发布列表：`/torrents.php?option-torrents=10&userid=<uid>`

分页行为与 NexusPHP 常规列表一致：

- 每页 50 条
- 第一页不带 `page`
- 后续页从 `page=1` 开始

## 实现方案

- 覆写 `parseUserInfoForSeedingStatus`，分页读取完整做种列表并汇总：
  - 做种数量
  - 做种体积
- 覆写 `parseUserInfoForUploads`，分页读取完整发布列表并统计发布数量。
- 数量优先使用分页器最后一段范围；若小于实际解析行数，则回退为实际行数。
- 体积从每行 `td[data-label='大小']` 汇总。
- 为避免异常页面导致无限请求，增加停止条件：
  - 无数据行
  - 没有下一页
  - 页面内容重复
  - 最多 50 页保护

## 真实数据验证

使用真实月月账号页面验证：

- 分页：14 页，`50 × 13 + 46`
- 做种数量：`696`
- 做种体积：`5.439 TiB`
- 发布数量：`0`（当前账号真实为空）

同时验证了分页器末页范围与逐行统计结果一致，且在最后一页后能正确停止，不会继续请求。

## 检查

- `pnpm check` 通过
- `pnpm build:dist` 通过
- Prettier 格式化通过

## 关联

- 跟进 #1410，恢复当时因旧接口移除而跳过的做种体积和发布数量。
